### PR TITLE
Add ExternalMessages.properties to the com/ibm/oti/util package

### DIFF
--- a/closed/make/CopyFiles.gmk
+++ b/closed/make/CopyFiles.gmk
@@ -1,0 +1,23 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2017 All Rights Reserved
+# ===========================================================================
+# 
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# 
+# ===========================================================================
+
+$(JDK_OUTPUTDIR)/classes/com/ibm/oti/util/ExternalMessages.properties: $(JDK_OUTPUTDIR)/j9jcl_sources/jdk/src/share/classes/com/ibm/oti/util/ExternalMessages.properties
+	$(call install-file)
+
+COPY_FILES += $(JDK_OUTPUTDIR)/classes/com/ibm/oti/util/ExternalMessages.properties


### PR DESCRIPTION
Copy ExternalMessages.properties to the jdk classes directory.
Include ExternalMessages.properties into resources.jar.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>