### PR TITLE
Rename runtimes/tr.source to runtimes/compiler

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -199,6 +199,10 @@ stage-j9 : \
 	$(call openj9_copy_tree,$(OUTPUT_ROOT)/vm/omr,$(OPENJ9OMR_TOPDIR))
 
 # Only update version files when the SHAs change.
+$(OUTPUT_ROOT)/vm/compiler/jit.version : $(call DependOnVariable, OPENJ9_SHA)
+        @$(MKDIR) -p $(@D)
+        $(ECHO) '#define TR_LEVEL_NAME "$(OPENJ9_SHA)"' > $@
+
 $(OUTPUT_ROOT)/vm/tr.source/jit.version : $(call DependOnVariable, OPENJ9_SHA)
 	@$(MKDIR) -p $(@D)
 	$(ECHO) '#define TR_LEVEL_NAME "$(OPENJ9_SHA)"' > $@
@@ -207,7 +211,7 @@ $(OUTPUT_ROOT)/vm/omr/OMR_VERSION_STRING : $(call DependOnVariable, OPENJ9OMR_SH
 	@$(MKDIR) -p $(@D)
 	$(ECHO) '#define OMR_VERSION_STRING "$(OPENJ9OMR_SHA)"' > $@
 
-run-preprocessors-j9 : stage-j9 $(OUTPUT_ROOT)/vm/tr.source/jit.version $(OUTPUT_ROOT)/vm/omr/OMR_VERSION_STRING
+run-preprocessors-j9 : stage-j9 $(OUTPUT_ROOT)/vm/tr.source/jit.version $(OUTPUT_ROOT)/vm/compiler/jit.version $(OUTPUT_ROOT)/vm/omr/OMR_VERSION_STRING
 	@$(ECHO) Running OpenJ9 preprocessors with OPENJ9_BUILDSPEC: $(OPENJ9_BUILDSPEC)
 	(export BOOT_JDK=$(BOOT_JDK) \
 		&& cd $(OUTPUT_ROOT)/vm \


### PR DESCRIPTION
We will temporarily generate both version files in tr.source and
compiler directories to avoid build breaks. A subsequent change will
remove the tr.source file generation once the dependent builds pickup
this change.

Signed-off-by: Filip Jeremic <fjeremic@ca.ibm.com>