### PR TITLE
Changes to allow diagnostic jars to be created

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -291,6 +291,18 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 			-dest $(JDK_OUTPUTDIR)/j9jcl_sources/jdk/src/share/classes \
 			-macro:define "com.ibm.oti.vm.library.version=29" \
 			-tag:define "PLATFORM-$(OPENJ9_PLATFORM_CODE)"
+	@$(BOOT_JDK)/bin/java \
+		-cp $(OUTPUT_ROOT)/vm/sourcetools/lib/jpp.jar \
+		-Dfile.encoding=US-ASCII \
+		com.ibm.jpp.commandline.CommandlineBuilder \
+			-verdict \
+			-baseDir $(OPENJ9_TOPDIR)/ \
+			-config SIDECAR18-TOOLS-OPENJ9 \
+			-srcRoot jcl/ \
+			-xml jpp_configuration.xml \
+			-dest $(JDK_OUTPUTDIR)/j9jcl_sources/jdk/src/share/classes \
+			-macro:define "com.ibm.oti.vm.library.version=29" \
+			-tag:define "PLATFORM-$(OPENJ9_PLATFORM_CODE)"
 	@$(MKDIR) -p $(@D)
 	@$(TOUCH) $@
 

--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -418,7 +418,7 @@ $(eval $(call SetupLauncher,jdmpview, \
 
 $(eval $(call SetupLauncher,traceformat, \
     -DEXPAND_CLASSPATH_WILDCARDS \
-    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.ibm.jvm.traceformat.TraceFormat"$(COMMA) }'))
+    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.ibm.jvm.format.TraceFormat"$(COMMA) }'))
 
 ifneq ($(findstring $(OPENJDK_TARGET_OS),linux aix),)
   $(eval $(call SetupLauncher,jextract, \

--- a/jdk/make/CreateJars.gmk
+++ b/jdk/make/CreateJars.gmk
@@ -56,6 +56,47 @@ $(eval $(call MakeDir, $(IMAGES_OUTPUTDIR)/lib))
 
 ##########################################################################################
 
+$(eval $(call SetupArchive,BUILD_DTFJ_JAR, , \
+    SRCS := $(JDK_OUTPUTDIR)/classes, \
+    INCLUDES := com/ibm/dtfj com/ibm/jvm/j9/dump com/ibm/java/diagnostics/utils, \
+    JAR := $(IMAGES_OUTPUTDIR)/lib/ext/dtfj.jar, \
+    SKIP_METAINF := true))
+
+
+##########################################################################################
+
+$(eval $(call SetupArchive,BUILD_DTFJVIEW_JAR, , \
+    SRCS := $(JDK_OUTPUTDIR)/classes, \
+    INCLUDES := com/ibm/jvm/dtfjview, \
+    JAR := $(IMAGES_OUTPUTDIR)/lib/ext/dtfjview.jar, \
+    SKIP_METAINF := true))
+
+
+##########################################################################################
+
+$(eval $(call SetupArchive,BUILD_TRACEFORMAT_JAR, , \
+    SRCS := $(JDK_OUTPUTDIR)/classes, \
+    INCLUDES := com/ibm/jvm/traceformat \
+                com/ibm/jvm/format \
+                com/ibm/jvm/trace, \
+    EXTRA_FILES := com/ibm/jvm/Debug.class \
+		           com/ibm/jvm/FormatTimestamp.class \
+		           com/ibm/jvm/Indent.class \
+		           com/ibm/jvm/InputFile.class \
+		           com/ibm/jvm/MessageFile.class \
+		           com/ibm/jvm/OutputFile.class \
+		           com/ibm/jvm/ProgramOption.class \
+		           com/ibm/jvm/Statistics.class \
+		           com/ibm/jvm/Summary.class \
+		           com/ibm/jvm/Threads.class \
+		           com/ibm/jvm/Timezone.class \
+		           com/ibm/jvm/TraceFormat.class \
+		           com/ibm/jvm/Verbose.class, \
+    JAR := $(IMAGES_OUTPUTDIR)/lib/ext/traceformat.jar, \
+    SKIP_METAINF := true))
+
+##########################################################################################
+
 $(eval $(call SetupArchive,BUILD_JCONSOLE_JAR, , \
     SRCS := $(JDK_OUTPUTDIR)/classes, \
     SUFFIXES := .class .gif .png .properties, \
@@ -218,7 +259,28 @@ RT_JAR_EXCLUDES += \
     com/oracle/jrockit/jfr \
     oracle/jrockit/jfr \
     jdk/jfr \
-    com/ibm/tools/attach/attacher
+    com/ibm/tools/attach/attacher \
+    com/ibm/dtfj \
+    com/ibm/java/diagnostics \
+    	com/ibm/jvm/Debug.class \
+	com/ibm/jvm/FormatTimestamp.class \
+	com/ibm/jvm/Indent.class \
+	com/ibm/jvm/InputFile.class \
+	com/ibm/jvm/MessageFile.class \
+	com/ibm/jvm/OutputFile.class \
+	com/ibm/jvm/ProgramOption.class \
+	com/ibm/jvm/Statistics.class \
+	com/ibm/jvm/Summary.class \
+	com/ibm/jvm/Threads.class \
+	com/ibm/jvm/Timezone.class \
+	com/ibm/jvm/TraceFormat.class \
+	com/ibm/jvm/Verbose.class \
+    com/ibm/jvm/j9 \
+    com/ibm/jvm/dtfjview \
+    com/ibm/jvm/TraceFormat.class  \
+    com/ibm/jvm/format  \
+    com/ibm/jvm/trace  \
+    com/ibm/jvm/traceformat
 
 # Find all files in the classes dir to use as dependencies. This could be more fine granular.
 ALL_FILES_IN_CLASSES := $(call not-containing, _the., $(filter-out %javac_state, \

--- a/jdk/make/Profiles.gmk
+++ b/jdk/make/Profiles.gmk
@@ -89,6 +89,9 @@ ALL_JARS := $(FULL_JRE_JARS) \
     $(IMAGES_OUTPUTDIR)/lib/rt.jar \
     $(IMAGES_OUTPUTDIR)/lib/resources.jar \
     $(IMAGES_OUTPUTDIR)/lib/jconsole.jar \
+    $(IMAGES_OUTPUTDIR)/lib/ext/dtfj.jar \
+    $(IMAGES_OUTPUTDIR)/lib/ext/dtfjview.jar \
+    $(IMAGES_OUTPUTDIR)/lib/ext/traceformat.jar \
     $(IMAGES_OUTPUTDIR)/lib/dt.jar \
     $(IMAGES_OUTPUTDIR)/lib/tools.jar \
     $(IMAGES_OUTPUTDIR)/lib/ct.sym \


### PR DESCRIPTION
The jars that are created are:
dtfj.jar, dtfjview.jar and traceformat.jar

Signed-off-by: Steve Groeger <GROEGES@uk.ibm.com>