### PR TITLE
fix OPENJDK_TAG in java version output

### DIFF
--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -137,6 +137,12 @@ AC_DEFUN_ONCE([OPENJDK_VERSION_DETAILS],
 [
   OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
   OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags`
+
+  if test "x$OPENJDK_TAG" = x; then
+    LAST_TAGGED_REVISION=`git -C $SRC_ROOT rev-list --tags --max-count=1`
+    OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk8*" "${LAST_TAGGED_REVISION}"`
+  fi
+
   AC_SUBST(OPENJDK_SHA)
   AC_SUBST(OPENJDK_TAG)
   

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -8276,6 +8276,12 @@ $as_echo "$DEBUG_LEVEL" >&6; }
   OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
   OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags`
 
+  if test "x$OPENJDK_TAG" = x; then
+    LAST_TAGGED_REVISION=`git -C $SRC_ROOT rev-list --tags --max-count=1`
+    OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk8*" "${LAST_TAGGED_REVISION}"`
+  fi
+
+
 
 
   # Outer [ ] to quote m4.


### PR DESCRIPTION
Signed-off-by: Bhaktavatsal Reddy <bhamaram@in.ibm.com>

Fixes #27 

Java version output of openJ9 builds doesn't contain proper OPENJDK_TAG.

> openjdk version "1.8.0-internal"
> OpenJDK Runtime Environment (build 1.8.0-internal-jenkins_2018_01_09_13_02-b00)
> Eclipse OpenJ9 VM (build 2.9, JRE 1.8.0 Linux amd64-64 Compressed References 20180109_42 (JIT enabled, AOT enabled)
> OpenJ9   - b116fb3
> OMR      - 7a770d6
> OpenJDK  - 00e69f9 based on )

Output with this fix

> openjdk version "1.8.0-internal"
> OpenJDK Runtime Environment (build 1.8.0-internal-bhamaram_2018_01_10_00_29-b00)
> Eclipse OpenJ9 VM (build 2.9, JRE 1.8.0 Linux amd64-64 Compressed References 20180110_000000 (JIT enabled, AOT enabled)
> OpenJ9   - b116fb3
> OMR      - 7a770d6
> OpenJDK  - 00e69f9 based on jdk8u152-b16)