### PR TITLE
Fix to pick up the correct libjvm.so on s390x OpenJ9 builds

### DIFF
--- a/jdk/src/solaris/bin/zero/jvm.cfg
+++ b/jdk/src/solaris/bin/zero/jvm.cfg
@@ -1,4 +1,7 @@
-# Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+#
+# (c) Copyright IBM Corp. 2003, 2018 All Rights Reserved
+#
+# Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,5 +34,5 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
--server KNOWN
--client IGNORE
+-j9vm KNOWN
+-server IGNORE


### PR DESCRIPTION
Fixes https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/23

It may also be sensible to remove the `s390x/jvm.cfg`if it's not being picked up, but I understand it does work on some people's machines.