### PR TITLE
Fix -Xinternalversion output

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -218,12 +218,12 @@ stage-j9 : \
 
 OPENJ9_VERSION_VARS := \
 	COMPILER_VERSION_STRING \
-	HOTSPOT_TARGET_OS \
+	OPENJDK_TARGET_OS \
 	OPENJDK_TARGET_CPU_BITS \
 	OPENJDK_TARGET_CPU_OSARCH \
 	PRODUCT_NAME \
 	USERNAME \
-	VERSION_STRING \
+	JRE_RELEASE_VERSION \
 	#
 
 OPENJ9_VERSION_SCRIPT := \

--- a/closed/openj9_version_info.h.in
+++ b/closed/openj9_version_info.h.in
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2017 All Rights Reserved
+ * (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
 #define J9PRODUCT_NAME            "@PRODUCT_NAME@"
 #define J9TARGET_CPU_BITS         "@OPENJDK_TARGET_CPU_BITS@"
 #define J9TARGET_CPU_OSARCH       "@OPENJDK_TARGET_CPU_OSARCH@"
-#define J9TARGET_OS               "@HOTSPOT_TARGET_OS@"
+#define J9TARGET_OS               "@OPENJDK_TARGET_OS@"
 #define J9USERNAME                "@USERNAME@"
-#define J9VERSION_STRING          "@VERSION_STRING@"
+#define J9VERSION_STRING          "@JRE_RELEASE_VERSION@"
 
 #endif /* OPENJ9_VERSION_INFO_H */

--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
 # 
 # This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ endif
 
 # for constructing version output
 COMPILER_VERSION_STRING := @COMPILER_VERSION_STRING@
+USERNAME                := @USERNAME@
 OPENJDK_SHA             := @OPENJDK_SHA@
 OPENJDK_TAG             := @OPENJDK_TAG@
 


### PR DESCRIPTION
Define USERNAME and COMPILER_VERSION_STRING. Use OPENJDK_TARGET_OS
instead of HOTSPOT_TARGET_OS, and JRE_RELEASE_VERSION instead of
VERSION_STRING.

Fixes https://github.com/eclipse/openj9/issues/923

`java -Xinternalversion`

before: `Eclipse OpenJ9 OpenJDK 64-bit Server VM () from -amd64 JRE (), built on Jan 11 2018 21:41:51 by with`

after: `Eclipse OpenJ9 OpenJDK 64-bit Server VM (1.8.0-internal-peter_2018_01_12_20_32-b00) from linux-amd64 JRE (1.8.0-internal-peter_2018_01_12_20_32-b00), built on Jan 12 2018 20:36:06 by peter with g++-4.8 (Ubuntu 4.8.5-4ubuntu2) 4.8.5`

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>