### PR TITLE
Fix issue with SED when generating openj9_version_info.h on AIX

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -227,7 +227,7 @@ OPENJ9_VERSION_VARS := \
 	#
 
 OPENJ9_VERSION_SCRIPT := \
-	$(foreach var,$(OPENJ9_VERSION_VARS),-e 's:@${var}@:$(value $(var)):g')
+	$(foreach var,$(OPENJ9_VERSION_VARS),-e 's|@${var}@|$(value $(var))|g')
 
 $(OUTPUT_ROOT)/vm/util/openj9_version_info.h : $(SRC_ROOT)/closed/openj9_version_info.h.in
 	@$(MKDIR) -p $(@D)


### PR DESCRIPTION
Signed-off-by: Joe deKoning <joe_dekoning@ca.ibm.com>