### PR TITLE
Build libjaas as part of OpenJ9

### DIFF
--- a/jdk/make/lib/SecurityLibraries.gmk
+++ b/jdk/make/lib/SecurityLibraries.gmk
@@ -1,6 +1,6 @@
 #
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
 #
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
@@ -62,9 +62,9 @@ $(eval $(call SetupNativeCompilation,BUILD_LIBJAAS, \
     OBJECT_DIR := $(JDK_OUTPUTDIR)/objs/libjaas, \
     DEBUG_SYMBOLS := $(DEBUG_ALL_BINARIES)))
 
-#$(BUILD_LIBJAAS): $(BUILD_LIBJAVA)
+$(BUILD_LIBJAAS): $(BUILD_LIBJAVA)
 
-#BUILD_LIBRARIES += $(BUILD_LIBJAAS)
+BUILD_LIBRARIES += $(BUILD_LIBJAAS)
 
 ##########################################################################################
 


### PR DESCRIPTION
This patch enables building libjaas as part of OpenJ9.

A JAAS implementation is required to run certain software (like
Apache Spark) and not building this library as part of OpenJ9
results in an UnsatisfiedLinkError when the platform-specific
class in com/sun/security/auth/module/ attempts to load the
missing JAAS library.

Fixes: eclipse/openj9#1000

Signed-off-by: Younes Manton <ymanton@ca.ibm.com>