### PR TITLE
Revert SecurityLibraries.gmk to the original OpenJDK version

### DIFF
--- a/jdk/make/lib/SecurityLibraries.gmk
+++ b/jdk/make/lib/SecurityLibraries.gmk
@@ -1,8 +1,4 @@
 #
-# ===========================================================================
-# (c) Copyright IBM Corp. 2017 All Rights Reserved
-# ===========================================================================
-#
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -62,9 +58,9 @@ $(eval $(call SetupNativeCompilation,BUILD_LIBJAAS, \
     OBJECT_DIR := $(JDK_OUTPUTDIR)/objs/libjaas, \
     DEBUG_SYMBOLS := $(DEBUG_ALL_BINARIES)))
 
-#$(BUILD_LIBJAAS): $(BUILD_LIBJAVA)
+$(BUILD_LIBJAAS): $(BUILD_LIBJAVA)
 
-#BUILD_LIBRARIES += $(BUILD_LIBJAAS)
+BUILD_LIBRARIES += $(BUILD_LIBJAAS)
 
 ##########################################################################################
 
@@ -94,7 +90,7 @@ $(eval $(call SetupNativeCompilation,BUILD_LIBJ2PCSC, \
     OBJECT_DIR := $(JDK_OUTPUTDIR)/objs/libj2pcsc, \
     DEBUG_SYMBOLS := $(DEBUG_ALL_BINARIES)))
 
-#BUILD_LIBRARIES += $(BUILD_LIBJ2PCSC)
+BUILD_LIBRARIES += $(BUILD_LIBJ2PCSC)
 
 ##########################################################################################
 
@@ -117,7 +113,7 @@ ifneq ($(OPENJDK_TARGET_OS), windows)
       OBJECT_DIR := $(JDK_OUTPUTDIR)/objs/libj2gss, \
       DEBUG_SYMBOLS := $(DEBUG_ALL_BINARIES)))
 
-  #BUILD_LIBRARIES += $(BUILD_LIBJ2GSS)
+  BUILD_LIBRARIES += $(BUILD_LIBJ2GSS)
 endif
 
 ##########################################################################################
@@ -216,7 +212,7 @@ $(eval $(call SetupNativeCompilation,BUILD_LIBJ2PKCS11, \
     OBJECT_DIR := $(JDK_OUTPUTDIR)/objs/libj2pkcs11, \
     DEBUG_SYMBOLS := $(DEBUG_ALL_BINARIES)))
 
-#BUILD_LIBRARIES += $(BUILD_LIBJ2PKCS11)
+BUILD_LIBRARIES += $(BUILD_LIBJ2PKCS11)
 
 ##########################################################################################
 


### PR DESCRIPTION
Builds all security libraries

Obsoletes #29 

Fixes: eclipse/openj9#1000

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>