### PR TITLE
Remove OpenJDK SHA add-on code for extensions

### DIFF
--- a/jdk/make/gensrc/GensrcMisc.gmk
+++ b/jdk/make/gensrc/GensrcMisc.gmk
@@ -38,8 +38,6 @@ $(PROFILE_VERSION_JAVA_TARGETS): \
 	$(ECHO) Generating sun/misc/Version.java $(call profile_version_name, $@)
 	$(SED) -e 's/@@launcher_name@@/$(LAUNCHER_NAME)/g' \
 	    -e 's/@@java_version@@/$(RELEASE)/g' \
-	    -e 's/@@OPENJDK_SHA@@/$(OPENJDK_SHA)/g' \
-	    -e 's/@@OPENJDK_TAG@@/$(OPENJDK_TAG)/g' \
 	    -e 's/@@java_runtime_version@@/$(FULL_VERSION)/g' \
 	    -e 's/@@java_runtime_name@@/$(RUNTIME_NAME)/g' \
 	    -e 's/@@java_profile_name@@/$(call profile_version_name, $@)/g' \

--- a/jdk/src/share/classes/sun/misc/Version.java.template
+++ b/jdk/src/share/classes/sun/misc/Version.java.template
@@ -1,9 +1,4 @@
 /*
- *
- * ===========================================================================
- * (c) Copyright IBM Corp. 2017 All Rights Reserved
- * ===========================================================================
- *
  * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -39,12 +34,6 @@ public class Version {
 
     private static final String java_version =
         "@@java_version@@";
-
-    private static final String openjdk_sha =
-        "@@OPENJDK_SHA@@";
-
-    private static final String openjdk_tag =
-        "@@OPENJDK_TAG@@";
 
     private static final String java_runtime_name =
         "@@java_runtime_name@@";
@@ -132,7 +121,7 @@ public class Version {
         String java_vm_version = System.getProperty("java.vm.version");
         String java_vm_info    = System.getProperty("java.vm.info");
         ps.println(java_vm_name + " (build " + java_vm_version + ", " +
-                   java_vm_info + "\nOpenJDK  - " + openjdk_sha + " based on " + openjdk_tag + ")");
+                   java_vm_info + ")");
     }
 
 


### PR DESCRIPTION
Extensions used to add the OpenJDK SHA to the java -version
output.

Now OpenJ9 does it in eclipse/openj9#1010, so this code isn't needed anymore.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>