### PR TITLE
Find OpenJ9 tag associated with current commit

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -27,13 +27,13 @@ ifeq (,$(BUILD_ID))
   BUILD_ID := 000000
 endif
 
-# find the closest tag name
-OPENJ9_TAG    := $(shell git -C $(OPENJ9_TOPDIR)    describe --abbrev=0)
 OPENJ9_SHA    := $(shell git -C $(OPENJ9_TOPDIR)    rev-parse --short HEAD)
 OPENJ9OMR_SHA := $(shell git -C $(OPENJ9OMR_TOPDIR) rev-parse --short HEAD)
 ifeq (,$(OPENJ9_SHA))
   $(error Could not determine OpenJ9 SHA)
 endif
+# Find OpenJ9 tag associated with current commit specified by OPENJ9_SHA and remove stderr output in case there is no such tag found
+OPENJ9_TAG := $(shell git -C $(OPENJ9_TOPDIR) describe --exact-match $(OPENJ9_SHA) 2>/dev/null)
 ifeq (,$(OPENJ9_TAG))
   OPENJ9_BRANCH := $(shell git -C $(OPENJ9_TOPDIR)    rev-parse --abbrev-ref HEAD)
   ifeq (,$(OPENJ9_BRANCH))


### PR DESCRIPTION
Find `OpenJ9` tag associated with current commit

Find `OpenJ9` tag associated with current commit specified by `OPENJ9_SHA` and remove `stderr` output in case there is no such `tag` found.

Tested the script manually in a personal repo.

Closes: eclipse/openj9#1140

Related to PR: https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/123

Reviewer @Peter-Shipton 
FYI: @daniel-heidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>