### PR TITLE
Fix git queries for OPENJDK_TAG

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -69,7 +69,7 @@ override MAKEFLAGS := -j $(JOBS)
 ifeq ($(OPENJDK_TARGET_OS),windows)
   # set Visual Studio environment
   EXPORT_MSVS_ENV_VARS := PATH="$(PATH)" INCLUDE="$(INCLUDE)" LIB="$(LIB)"
-  # On Windows, the mingw compiler is used for certain files such as 
+  # On Windows, the mingw compiler is used for certain files such as
   # the bytecode interpreter.
   # Uncomment the following line to use the default compiler throughout.
   # EXPORT_NO_USE_MINGW := NO_USE_MINGW=true
@@ -250,11 +250,11 @@ OPENJ9_VERSION_SCRIPT := \
 $(OUTPUT_ROOT)/vm/include/openj9_version_info.h : $(SRC_ROOT)/closed/openj9_version_info.h.in
 	@$(MKDIR) -p $(@D)
 	@$(SED) $(OPENJ9_VERSION_SCRIPT) > $@ < $(SRC_ROOT)/closed/openj9_version_info.h.in
- 
- # update if values change
- $(OUTPUT_ROOT)/vm/include/openj9_version_info.h : \
+
+# update if values change
+$(OUTPUT_ROOT)/vm/include/openj9_version_info.h : \
  	$(foreach var,$(OPENJ9_VERSION_VARS),$(call DependOnVariable, $(var)))
- 
+
 # Only update version files when the SHAs change.
 $(OUTPUT_ROOT)/vm/compiler/jit.version : $(call DependOnVariable, OPENJ9_SHA)
 	@$(MKDIR) -p $(@D)
@@ -311,7 +311,7 @@ recur_wildcard = $(foreach dir,$(wildcard $1/*),$(call recur_wildcard,$(dir),$2)
 AllJclSource   = $(call recur_wildcard,$(OPENJ9_TOPDIR)/jcl/src,*.java)
 
 # FixPath
-# On Windows, convert unix path to windows path, 
+# On Windows, convert unix path to windows path,
 # on other platforms leave it unchanged
 # ----------------------
 # param 1 = The path to convert

--- a/common/autoconf/configure
+++ b/common/autoconf/configure
@@ -122,16 +122,17 @@ fi
 ### Process command-line arguments
 ###
 # Add default OpenJ9 closed extensions
-full_script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-OPENJDK_TAG=`git -C $full_script_dir/../.. describe --abbrev=0 --tags`
+full_src_root_dir="$( cd "${conf_script_dir}/../.." && pwd )"
+OPENJDK_SHA=`git -C $full_src_root_dir rev-parse --short HEAD`
+OPENJDK_TAG=`git -C $full_src_root_dir describe --abbrev=0 --tags --match "jdk8u*" "${OPENJDK_SHA}"`
 if test "x$OPENJDK_TAG" = x; then
-  LAST_TAGGED_REVISION=`git -C $full_script_dir/../.. rev-list --tags --max-count=1`
-  OPENJDK_TAG=`git -C $full_script_dir/../.. describe --abbrev=0 --tags --match "jdk8*" "${LAST_TAGGED_REVISION}"`
+  LAST_TAGGED_REVISION=`git -C $full_src_root_dir rev-list --tags --max-count=1`
+  OPENJDK_TAG=`git -C $full_src_root_dir describe --abbrev=0 --tags --match "jdk8u*" "${LAST_TAGGED_REVISION}"`
 fi
 build_update_version=`echo $OPENJDK_TAG | sed 's/jdk8u//' | awk -F'-' '{print $1}'`
 jdk_build_number=`echo $OPENJDK_TAG | awk -F'-' '{print $2}'`
 conf_milestone=
-conf_processed_arguments=("--with-custom-make-dir=$full_script_dir/../../closed/make" "--with-add-source-root=$full_script_dir/../../closed/adds" "--with-update-version=$build_update_version")
+conf_processed_arguments=("--with-custom-make-dir=$full_src_root_dir/closed/make" "--with-add-source-root=$full_src_root_dir/closed/adds" "--with-update-version=$build_update_version")
 conf_openjdk_target=
 
 for conf_option

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -3912,7 +3912,7 @@ fi
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1518173054
+DATE_WHEN_GENERATED=1518465981
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -1,10 +1,10 @@
 # ===========================================================================
 # (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
-# 
+#
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
-# published by the Free Software Foundation.  
+# published by the Free Software Foundation.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License version
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
-# 
+#
 # ===========================================================================
 
 AC_DEFUN_ONCE([CUSTOM_EARLY_HOOK],
@@ -142,16 +142,16 @@ AC_DEFUN_ONCE([OPENJDK_VERSION_DETAILS],
   AC_SUBST(JDK_FIX_VERSION)
 
   OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
-  OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags`
+  OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk8u*" "${OPENJDK_SHA}"`
 
   if test "x$OPENJDK_TAG" = x; then
     LAST_TAGGED_REVISION=`git -C $SRC_ROOT rev-list --tags --max-count=1`
-    OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk8*" "${LAST_TAGGED_REVISION}"`
+    OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk8u*" "${LAST_TAGGED_REVISION}"`
   fi
 
   AC_SUBST(OPENJDK_SHA)
   AC_SUBST(OPENJDK_TAG)
-  
+
   # Outer [ ] to quote m4.
   [ USERNAME=`$ECHO "$USER" | $TR -d -c '[a-z][A-Z][0-9]'` ]
   AC_SUBST(USERNAME)

--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -1,10 +1,10 @@
 # ===========================================================================
 # (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
-# 
+#
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
-# published by the Free Software Foundation.  
+# published by the Free Software Foundation.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License version
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
-# 
+#
 # ===========================================================================
 
 # This macro is called to allow inclusion of closed source counterparts.
@@ -56,10 +56,10 @@ USERNAME                := @USERNAME@
 OPENJDK_SHA             := @OPENJDK_SHA@
 OPENJDK_TAG             := @OPENJDK_TAG@
 
-JDK_MOD_VERSION:=@JDK_MOD_VERSION@
-JDK_FIX_VERSION:=@JDK_FIX_VERSION@
-J9JDK_EXT_VERSION:=${JDK_MINOR_VERSION}.${JDK_MICRO_VERSION}.${JDK_MOD_VERSION}.${JDK_FIX_VERSION}
-J9JDK_EXT_NAME:=Extensions for OpenJDK for Eclipse OpenJ9
+JDK_MOD_VERSION         := @JDK_MOD_VERSION@
+JDK_FIX_VERSION         := @JDK_FIX_VERSION@
+J9JDK_EXT_VERSION       := ${JDK_MINOR_VERSION}.${JDK_MICRO_VERSION}.${JDK_MOD_VERSION}.${JDK_FIX_VERSION}
+J9JDK_EXT_NAME          := Extensions for OpenJDK for Eclipse OpenJ9
 
 # required by UMA
 FREEMARKER_JAR          := @FREEMARKER_JAR@
@@ -67,4 +67,3 @@ OPENJ9_BUILDSPEC        := @OPENJ9_BUILDSPEC@
 
 # required by JPP
 OPENJ9_PLATFORM_CODE    := @OPENJ9_PLATFORM_CODE@
-

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -3967,7 +3967,7 @@ fi
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1518173054
+DATE_WHEN_GENERATED=1518465981
 
 ###############################################################################
 #
@@ -8270,11 +8270,11 @@ $as_echo "$DEBUG_LEVEL" >&6; }
 
 
   OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
-  OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags`
+  OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk8u*" "${OPENJDK_SHA}"`
 
   if test "x$OPENJDK_TAG" = x; then
     LAST_TAGGED_REVISION=`git -C $SRC_ROOT rev-list --tags --max-count=1`
-    OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk8*" "${LAST_TAGGED_REVISION}"`
+    OPENJDK_TAG=`git -C $SRC_ROOT describe --abbrev=0 --tags --match "jdk8u*" "${LAST_TAGGED_REVISION}"`
   fi
 
 


### PR DESCRIPTION
Only match openjdk tags whose names start with 'jdk8u'.

Adjust whitespace as requested for #35.