### PR TITLE
Checkout branch/sha to keep branch info

### DIFF
--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
 # 
 # This code is free software; you can redistribute it and/or modify it
@@ -189,7 +189,7 @@ for i in "${!default_j9repos[@]}" ; do
 		echo
 
 		cd ${i}
-		git checkout ${shas[$i]} || exit $?
+		git checkout -B ${branches[$i]} ${shas[$i]} || exit $?
 		cd -
 	fi
 done


### PR DESCRIPTION
Checkout `branch/sha` to keep `branch` info

Closes: https://github.com/eclipse/openj9/issues/1149

Reviewer @Peter-Shipton 
FYI: @daniel-heidinga 