### PR TITLE
Backport from Java 9 support for $ in file names

### DIFF
--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -1,4 +1,8 @@
 #
+# ===========================================================================
+# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# ===========================================================================
+#
 # Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -33,31 +37,35 @@
 ifndef _MAKEBASE_GMK
 _MAKEBASE_GMK := 1
 
+################################################################################
+# This macro translates $ into \$ to protect the $ from expansion in the shell.
+# To make this macro resilient against already escaped strings, first remove
+# any present escapes before escaping so that no double escapes are added.
+EscapeDollar = $(subst $$,\$$,$(subst \$$,$$,$(strip $1)))
+
 # If the variable that you want to send to stdout for piping into a file or otherwise,
 # is potentially long, for example the a list of file paths, eg a list of all package directories.
 # Then you need to use ListPathsSafely, which optimistically splits the output into several shell
 # calls as well as use compression on recurrent file paths segments, to get around the potential
 # command line length problem that exists in cygwin and other shells.
-compress_pre:=$(strip $(shell $(CAT) $(SRC_ROOT)/make/common/support/ListPathsSafely-pre-compress.incl))
-compress_post:=$(strip $(shell $(CAT) $(SRC_ROOT)/make/common/support/ListPathsSafely-post-compress.incl))
-compress_paths=$(compress_pre)\
-$(subst $(SRC_ROOT),X97,\
-$(subst $(OUTPUT_ROOT),X98,\
-$(subst X,X00,\
-$(subst $(SPACE),\n,$(strip $1)))))\
-$(compress_post)
+$(eval compress_paths = \
+    $(strip $(shell $(CAT) $(SRC_ROOT)/make/common/support/ListPathsSafely-pre-compress.incl)))
+compress_paths += \
+    $(subst $(SRC_ROOT),X97, \
+    $(subst $(OUTPUT_ROOT),X98, \
+    $(subst X,X00, \
+    $(subst $(SPACE),\n,$(strip $1)))))
+$(eval compress_paths += \
+    $(strip $(shell $(CAT) $(SRC_ROOT)/make/common/support/ListPathsSafely-post-compress.incl)))
 
 decompress_paths=$(SED) -f $(SRC_ROOT)/make/common/support/ListPathsSafely-uncompress.sed -e 's|X99|\\n|g' \
     -e 's|X98|$(OUTPUT_ROOT)|g' -e 's|X97|$(SRC_ROOT)|g' \
     -e 's|X00|X|g' | tr '\n' '$2'
 
-define ListPathsSafely_If
-	$(if $(word $3,$($1)),$(eval $1_LPS$3:=$(call compress_paths,$(wordlist $3,$4,$($1)))))
-endef
-
-define ListPathsSafely_Printf
-	$(if $(strip $($1_LPS$4)),$(if $(findstring $(LOG_LEVEL),trace),,@)printf \
-	    -- "$(strip $($1_LPS$4))\n" | $(decompress_paths) $3)
+define ListPathsSafely_IfPrintf
+	$(if $(word $4,$($1)), \
+		@printf -- "$(strip $(call EscapeDollar, \
+			$(call compress_paths,$(wordlist $4,$5,$($1)))))\\n" | $(decompress_paths) $3)
 endef
 
 # Receipt example:
@@ -67,166 +75,86 @@ endef
 # if instead , , (a space) is supplied, then spaces remain spaces.
 define ListPathsSafely
 	$(if $(word 16001,$($1)),$(error Cannot list safely more than 16000 paths. $1 has $(words $($1)) paths!))
-	$(ECHO) $(LOG_DEBUG) Writing $(words $($1)) paths to '$3'
-	$(call ListPathsSafely_If,$1,$2,1,250)
-	$(call ListPathsSafely_If,$1,$2,251,500)
-	$(call ListPathsSafely_If,$1,$2,501,750)
-	$(call ListPathsSafely_If,$1,$2,751,1000)
+	@$(ECHO) $(LOG_DEBUG) Writing $(words $($1)) paths to '$3'
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,1,250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,251,500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,501,750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,751,1000)
 
-	$(call ListPathsSafely_If,$1,$2,1001,1250)
-	$(call ListPathsSafely_If,$1,$2,1251,1500)
-	$(call ListPathsSafely_If,$1,$2,1501,1750)
-	$(call ListPathsSafely_If,$1,$2,1751,2000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,1001,1250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,1251,1500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,1501,1750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,1751,2000)
 
-	$(call ListPathsSafely_If,$1,$2,2001,2250)
-	$(call ListPathsSafely_If,$1,$2,2251,2500)
-	$(call ListPathsSafely_If,$1,$2,2501,2750)
-	$(call ListPathsSafely_If,$1,$2,2751,3000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,2001,2250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,2251,2500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,2501,2750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,2751,3000)
 
-	$(call ListPathsSafely_If,$1,$2,3001,3250)
-	$(call ListPathsSafely_If,$1,$2,3251,3500)
-	$(call ListPathsSafely_If,$1,$2,3501,3750)
-	$(call ListPathsSafely_If,$1,$2,3751,4000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,3001,3250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,3251,3500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,3501,3750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,3751,4000)
 
-	$(call ListPathsSafely_If,$1,$2,4001,4250)
-	$(call ListPathsSafely_If,$1,$2,4251,4500)
-	$(call ListPathsSafely_If,$1,$2,4501,4750)
-	$(call ListPathsSafely_If,$1,$2,4751,5000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,4001,4250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,4251,4500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,4501,4750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,4751,5000)
 
-	$(call ListPathsSafely_If,$1,$2,5001,5250)
-	$(call ListPathsSafely_If,$1,$2,5251,5500)
-	$(call ListPathsSafely_If,$1,$2,5501,5750)
-	$(call ListPathsSafely_If,$1,$2,5751,6000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,5001,5250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,5251,5500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,5501,5750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,5751,6000)
 
-	$(call ListPathsSafely_If,$1,$2,6001,6250)
-	$(call ListPathsSafely_If,$1,$2,6251,6500)
-	$(call ListPathsSafely_If,$1,$2,6501,6750)
-	$(call ListPathsSafely_If,$1,$2,6751,7000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,6001,6250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,6251,6500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,6501,6750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,6751,7000)
 
-	$(call ListPathsSafely_If,$1,$2,7001,7250)
-	$(call ListPathsSafely_If,$1,$2,7251,7500)
-	$(call ListPathsSafely_If,$1,$2,7501,7750)
-	$(call ListPathsSafely_If,$1,$2,7751,8000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,7001,7250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,7251,7500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,7501,7750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,7751,8000)
 
-	$(call ListPathsSafely_If,$1,$2,8001,8250)
-	$(call ListPathsSafely_If,$1,$2,8251,8500)
-	$(call ListPathsSafely_If,$1,$2,8501,8750)
-	$(call ListPathsSafely_If,$1,$2,8751,9000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,8001,8250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,8251,8500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,8501,8750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,8751,9000)
 
-	$(call ListPathsSafely_If,$1,$2,9001,9250)
-	$(call ListPathsSafely_If,$1,$2,9251,9500)
-	$(call ListPathsSafely_If,$1,$2,9501,9750)
-	$(call ListPathsSafely_If,$1,$2,9751,10000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,9001,9250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,9251,9500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,9501,9750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,9751,10000)
 
-	$(call ListPathsSafely_If,$1,$2,10001,10250)
-	$(call ListPathsSafely_If,$1,$2,10251,10500)
-	$(call ListPathsSafely_If,$1,$2,10501,10750)
-	$(call ListPathsSafely_If,$1,$2,10751,11000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,10001,10250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,10251,10500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,10501,10750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,10751,11000)
 
-	$(call ListPathsSafely_If,$1,$2,11001,11250)
-	$(call ListPathsSafely_If,$1,$2,11251,11500)
-	$(call ListPathsSafely_If,$1,$2,11501,11750)
-	$(call ListPathsSafely_If,$1,$2,11751,12000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,11001,11250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,11251,11500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,11501,11750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,11751,12000)
 
-	$(call ListPathsSafely_If,$1,$2,12001,12250)
-	$(call ListPathsSafely_If,$1,$2,12251,12500)
-	$(call ListPathsSafely_If,$1,$2,12501,12750)
-	$(call ListPathsSafely_If,$1,$2,12751,13000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,12001,12250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,12251,12500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,12501,12750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,12751,13000)
 
-	$(call ListPathsSafely_If,$1,$2,13001,13250)
-	$(call ListPathsSafely_If,$1,$2,13251,13500)
-	$(call ListPathsSafely_If,$1,$2,13501,13750)
-	$(call ListPathsSafely_If,$1,$2,13751,14000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,13001,13250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,13251,13500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,13501,13750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,13751,14000)
 
-	$(call ListPathsSafely_If,$1,$2,14001,14250)
-	$(call ListPathsSafely_If,$1,$2,14251,14500)
-	$(call ListPathsSafely_If,$1,$2,14501,14750)
-	$(call ListPathsSafely_If,$1,$2,14751,15000)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,14001,14250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,14251,14500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,14501,14750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,14751,15000)
 
-	$(call ListPathsSafely_If,$1,$2,15001,15250)
-	$(call ListPathsSafely_If,$1,$2,15251,15500)
-	$(call ListPathsSafely_If,$1,$2,15501,15750)
-	$(call ListPathsSafely_If,$1,$2,15751,16000)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,1)
-	$(call ListPathsSafely_Printf,$1,$2,$3,251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,1001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,1251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,1501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,1751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,2001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,2251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,2501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,2751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,3001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,3251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,3501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,3751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,4001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,4251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,4501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,4751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,5001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,5251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,5501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,5751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,6001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,6251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,6501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,6751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,7001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,7251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,7501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,7751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,8001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,8251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,8501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,8751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,9001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,9251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,9501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,9751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,10001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,10251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,10501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,10751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,11001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,11251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,11501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,11751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,12001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,12251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,12501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,12751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,13001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,13251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,13501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,13751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,14001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,14251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,14501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,14751)
-
-	$(call ListPathsSafely_Printf,$1,$2,$3,15001)
-	$(call ListPathsSafely_Printf,$1,$2,$3,15251)
-	$(call ListPathsSafely_Printf,$1,$2,$3,15501)
-	$(call ListPathsSafely_Printf,$1,$2,$3,15751)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,15001,15250)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,15251,15500)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,15501,15750)
+	$(call ListPathsSafely_IfPrintf,$1,$2,$3,15751,16000)
 endef
 
 define ListPathsSafelyNow_IfPrintf


### PR DESCRIPTION
Many of the Java source files generated for DDR have such names.

Issue: eclipse/openj9#378
Signed-off-by: Keith W. Campbell <keithc@ca.ibm.com>