### PR TITLE
WIP: Deprecate shape=sun for Java 8

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -141,7 +141,7 @@ define openj9_set_classlib_props
 $1 : $2/classlib.properties
 $2/classlib.properties : $3/classlib.properties
 	$(ECHO) Setting $1/classlib.properties
-	$(SED) -e 's/shape=vm.shape/shape=sun\nbootpath=rt.jar:resources.jar:jsse.jar:charsets.jar:jce.jar:tools.jar/g' -e 's/version=1.9/version=1.8/g' < $$< > $$@
+	$(SED) -e 's/shape=vm.shape/shape=sun_openjdk\nbootpath=rt.jar:resources.jar:jsse.jar:charsets.jar:jce.jar:tools.jar/g' -e 's/version=1.9/version=1.8/g' < $$< > $$@
 endef
 
 # openj9_copy_prereq


### PR DESCRIPTION
Deprecate `shape=sun` for `Java 8`

Replace it with `shape=sun_openjdk`.

PR company: https://github.com/eclipse/openj9/pull/1296

Reviewer @pshipton
FYI: @DanHeidinga 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>