### PR TITLE
Enable DDR support for Linux x86-64

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -69,6 +69,10 @@ OPENJ9_VM_FILES := \
 	options.default \
 	#
 
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+  OPENJ9_VM_FILES += j9ddr.dat
+endif
+
 OPENJ9_NOTICE_FILES := openj9-notices.html
 OPENJ9_REDIRECTOR := redirector/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
 
@@ -200,7 +204,13 @@ endif
 SPEC_SED_SCRIPT := -e 's/gcc-4.6/gcc/g'
 
 # Adjust DDR enablement flags.
-SPEC_SED_SCRIPT += $(call SedDisable,module_ddr)
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+  FEATURE_SED_SCRIPT += $(call SedEnable,opt_useOmrDdr)
+  SPEC_SED_SCRIPT    += $(call SedEnable,module_ddr)
+else
+  FEATURE_SED_SCRIPT += $(call SedDisable,opt_useOmrDdr)
+  SPEC_SED_SCRIPT    += $(call SedDisable,module_ddr)
+endif
 
 # openj9_stage_buildspec_file
 # ---------------------------

--- a/closed/make/DDR-gensrc.gmk
+++ b/closed/make/DDR-gensrc.gmk
@@ -1,0 +1,90 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+# The main target.
+all :
+
+ifeq (,$(wildcard $(SPEC)))
+  $(error BuildDDR.gmk needs SPEC set to a proper spec.gmk)
+endif
+
+include $(SPEC)
+include $(SRC_ROOT)/make/common/MakeBase.gmk
+include $(SRC_ROOT)/make/common/JavaCompilation.gmk
+include $(SRC_ROOT)/jdk/make/Setup.gmk
+
+# Supporting definitions.
+DDR_SUPPORT_DIR := $(JDK_OUTPUTDIR)/ddr
+DDR_VM_SRC_ROOT := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src
+
+#############################################################################
+
+# Build a jar containing the code generators.
+$(eval $(call SetupJavaCompilation,BUILD_DDR_TOOLS, \
+	SETUP := GENERATE_OLDBYTECODE, \
+	BIN := $(DDR_SUPPORT_DIR)/tools, \
+	ADD_JAVAC_FLAGS := -classpath $(JDK_OUTPUTDIR)/classes, \
+	SRC := $(DDR_VM_SRC_ROOT), \
+	INCLUDE_FILES := $(addsuffix .java,$(subst .,/, \
+		com.ibm.j9ddr.BytecodeGenerator \
+		com.ibm.j9ddr.CTypeParser \
+		com.ibm.j9ddr.StructureHeader \
+		com.ibm.j9ddr.StructureReader \
+		com.ibm.j9ddr.StructureTypeManager \
+		com.ibm.j9ddr.logging.LoggerNames \
+		com.ibm.j9ddr.tools.FlagStructureList \
+		com.ibm.j9ddr.tools.PointerGenerator \
+		com.ibm.j9ddr.tools.StructureStubGenerator \
+		com.ibm.j9ddr.tools.store.J9DDRStructureStore \
+		com.ibm.j9ddr.tools.store.StructureKey \
+		com.ibm.j9ddr.tools.store.StructureMismatchError \
+		)) \
+	))
+
+#############################################################################
+
+# The superset file is built with the VM.
+DDR_SUPERSET_FILE := $(OUTPUT_ROOT)/vm/superset.dat
+
+# Generate Java pointer classes.
+DDR_POINTERS_MARKER := $(DDR_SUPPORT_DIR)/pointers.done
+
+$(DDR_POINTERS_MARKER) : $(DDR_SUPERSET_FILE) $(BUILD_DDR_TOOLS)
+	@$(ECHO) Generating DDR pointer classes
+	@$(RM) -rf $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/vm29/pointer/generated/
+	@$(JAVA) -cp $(BUILD_DDR_TOOLS_BIN) com.ibm.j9ddr.tools.PointerGenerator \
+		-f $(dir $(DDR_SUPERSET_FILE)) \
+		-s $(notdir $(DDR_SUPERSET_FILE)) \
+		-p com.ibm.j9ddr.vm29.pointer.generated \
+		-v 29 \
+		-o $(DDR_VM_SRC_ROOT)
+	@$(TOUCH) $@
+
+# Generate Java structure stub classes.
+DDR_STRUCTURES_MARKER := $(DDR_SUPPORT_DIR)/structures.done
+
+$(DDR_STRUCTURES_MARKER) : $(DDR_SUPERSET_FILE) $(BUILD_DDR_TOOLS)
+	@$(ECHO) Generating DDR structure stubs
+	@$(RM) -rf $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/vm29/structure/
+	@$(JAVA) -cp $(BUILD_DDR_TOOLS_BIN) com.ibm.j9ddr.tools.StructureStubGenerator \
+		-f $(dir $(DDR_SUPERSET_FILE)) \
+		-s $(notdir $(DDR_SUPERSET_FILE)) \
+		-p com.ibm.j9ddr.vm29.structure \
+		-o $(DDR_VM_SRC_ROOT)
+	@$(TOUCH) $@
+
+all : $(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER)

--- a/closed/make/DDR-jar.gmk
+++ b/closed/make/DDR-jar.gmk
@@ -1,0 +1,59 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+# The main target.
+all :
+	@$(ECHO) Finished building j9ddr.jar
+
+ifeq (,$(wildcard $(SPEC)))
+  $(error BuildDDR.gmk needs SPEC set to a proper spec.gmk)
+endif
+
+include $(SPEC)
+include $(SRC_ROOT)/make/common/MakeBase.gmk
+include $(SRC_ROOT)/make/common/JavaCompilation.gmk
+include $(SRC_ROOT)/jdk/make/Setup.gmk
+
+# Supporting definitions.
+DDR_CLASSES_BIN := $(JDK_OUTPUTDIR)/ddr/classes
+
+# We depend upon class files from these modules.
+DDR_CLASSPATH := $(JDK_OUTPUTDIR)/classes
+
+DDR_SRC_EXCLUDES := com/ibm/j9ddr/tools/ant
+
+ifeq (,$(filter mz31 mz64,$(OPENJ9_PLATFORM_CODE)))
+DDR_SRC_EXCLUDES += com/ibm/j9ddr/corereaders/tdump
+endif
+
+$(eval $(call SetupJavaCompilation,BUILD_DDR_CLASSES, \
+	SETUP := GENERATE_USINGJDKBYTECODE, \
+	BIN := $(DDR_CLASSES_BIN), \
+	CLASSPATH := $(DDR_CLASSPATH), \
+	SRC := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src, \
+	EXCLUDES := $(DDR_SRC_EXCLUDES), \
+	COPY := com/ibm/j9ddr/StructureAliases29.dat \
+	))
+
+$(eval $(call SetupArchive,BUILD_DDR_MAIN, $(BUILD_DDR_CLASSES), \
+	SRCS := $(DDR_CLASSES_BIN), \
+	SUFFIXES := .class .dat .properties, \
+	EXCLUDES := com/ibm/j9ddr/vm29/structure, \
+	JAR := $(JDK_IMAGE_DIR)/lib/ddr/j9ddr.jar \
+	))
+
+all : $(BUILD_DDR_MAIN_JAR)

--- a/closed/make/Images.gmk
+++ b/closed/make/Images.gmk
@@ -1,0 +1,30 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+
+.PHONY : openj9.ddr-gensrc openj9.ddr-jar
+
+openj9.ddr-gensrc :
+	+$(MAKE) -f $(SRC_ROOT)/closed/make/DDR-gensrc.gmk SPEC=$(SPEC)
+
+openj9.ddr-jar : openj9.ddr-gensrc
+	+$(MAKE) -f $(SRC_ROOT)/closed/make/DDR-jar.gmk SPEC=$(SPEC)
+
+jdk-image : openj9.ddr-jar
+
+endif # OPENJ9_ENABLE_DDR

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -3912,7 +3912,7 @@ fi
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1518465981
+DATE_WHEN_GENERATED=1518536315
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -37,6 +37,7 @@ AC_DEFUN_ONCE([CUSTOM_EARLY_HOOK],
   OPENJ9_PLATFORM_SETUP
   OPENJDK_VERSION_DETAILS
   OPENJ9_CONFIGURE_CUDA
+  OPENJ9_CONFIGURE_DDR
   OPENJ9_THIRD_PARTY_REQUIREMENTS
 ])
 
@@ -80,6 +81,31 @@ AC_DEFUN([OPENJ9_CONFIGURE_CUDA],
   AC_SUBST(OPENJ9_ENABLE_CUDA)
   AC_SUBST(OPENJ9_CUDA_HOME)
   AC_SUBST(OPENJ9_GDK_HOME)
+])
+
+AC_DEFUN([OPENJ9_CONFIGURE_DDR],
+[
+  AC_MSG_CHECKING([for ddr])
+  AC_ARG_ENABLE([ddr], [AS_HELP_STRING([--enable-ddr], [enable DDR support @<:@disabled@:>@])])
+  if test "x$enable_ddr" = xyes ; then
+    AC_MSG_RESULT([yes (explicitly enabled)])
+    OPENJ9_ENABLE_DDR=true
+  elif test "x$enable_ddr" = xno ; then
+    AC_MSG_RESULT([no (explicitly disabled)])
+    OPENJ9_ENABLE_DDR=false
+  elif test "x$enable_ddr" = x ; then
+    if test "x$OPENJ9_PLATFORM_CODE" = xxa64 ; then
+      AC_MSG_RESULT([yes (default for xa64)])
+      OPENJ9_ENABLE_DDR=true
+    else
+      AC_MSG_RESULT([no (default)])
+      OPENJ9_ENABLE_DDR=false
+    fi
+  else
+    AC_MSG_ERROR([--enable-ddr accepts no argument])
+  fi
+
+  AC_SUBST(OPENJ9_ENABLE_DDR)
 ])
 
 AC_DEFUN([OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU],

--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -46,6 +46,9 @@ ifneq (,@OPENJ9_GDK_HOME@)
 export GDK_HOME         := @OPENJ9_GDK_HOME@
 endif
 
+## DDR
+OPENJ9_ENABLE_DDR       := @OPENJ9_ENABLE_DDR@
+
 # for constructing version output
 COMPILER_VERSION_STRING := @COMPILER_VERSION_STRING@
 USERNAME                := @USERNAME@

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -859,6 +859,7 @@ OUTPUT_ROOT
 CONF_NAME
 SPEC
 FREEMARKER_JAR
+OPENJ9_ENABLE_DDR
 OPENJ9_GDK_HOME
 OPENJ9_CUDA_HOME
 OPENJ9_ENABLE_CUDA
@@ -1040,6 +1041,7 @@ with_debug_level
 with_cuda
 with_gdk
 enable_cuda
+enable_ddr
 with_freemarker_jar
 with_conf_name
 with_builddeps_conf
@@ -1747,6 +1749,7 @@ Optional Features:
   --enable-debug          set the debug level to fastdebug (shorthand for
                           --with-debug-level=fastdebug) [disabled]
   --enable-cuda           enable CUDA support [disabled]
+  --enable-ddr            enable DDR support [disabled]
   --disable-headful       disable building headful support (graphical UI
                           support) [enabled]
   --enable-hotspot-test-in-build
@@ -3967,7 +3970,7 @@ fi
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1518465981
+DATE_WHEN_GENERATED=1518536315
 
 ###############################################################################
 #
@@ -8391,6 +8394,38 @@ $as_echo "no (default)" >&6; }
   fi
 
 
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ddr" >&5
+$as_echo_n "checking for ddr... " >&6; }
+  # Check whether --enable-ddr was given.
+if test "${enable_ddr+set}" = set; then :
+  enableval=$enable_ddr;
+fi
+
+  if test "x$enable_ddr" = xyes ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes (explicitly enabled)" >&5
+$as_echo "yes (explicitly enabled)" >&6; }
+    OPENJ9_ENABLE_DDR=true
+  elif test "x$enable_ddr" = xno ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no (explicitly disabled)" >&5
+$as_echo "no (explicitly disabled)" >&6; }
+    OPENJ9_ENABLE_DDR=false
+  elif test "x$enable_ddr" = x ; then
+    if test "x$OPENJ9_PLATFORM_CODE" = xxa64 ; then
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes (default for xa64)" >&5
+$as_echo "yes (default for xa64)" >&6; }
+      OPENJ9_ENABLE_DDR=true
+    else
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no (default)" >&5
+$as_echo "no (default)" >&6; }
+      OPENJ9_ENABLE_DDR=false
+    fi
+  else
+    as_fn_error $? "--enable-ddr accepts no argument" "$LINENO" 5
+  fi
 
 
 


### PR DESCRIPTION
* add configure option '--enable-ddr' (enabled by default for xa64)
* enable opt_useOmrDdr accordingly
* build j9ddr.jar for inclusion in JDK

Depends on https://github.com/eclipse/openj9/pull/1399.