### PR TITLE
Fix race condition in jdwp

### DIFF
--- a/jdk/src/share/back/debugInit.c
+++ b/jdk/src/share/back/debugInit.c
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
 /*
  * Copyright (c) 1998, 2012, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -58,6 +79,7 @@
 static jboolean vmInitialized;
 static jrawMonitorID initMonitor;
 static jboolean initComplete;
+static jboolean VMInitComplete;
 static jbyte currentSessionID;
 
 /*
@@ -454,8 +476,9 @@ cbEarlyVMInit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread)
     if ( gdata->vmDead ) {
         EXIT_ERROR(AGENT_ERROR_INTERNAL,"VM dead at VM_INIT time");
     }
-    if (initOnStartup)
+    if (initOnStartup) {
         initialize(env, thread, EI_VM_INIT);
+	}
     vmInitialized = JNI_TRUE;
     LOG_MISC(("END cbEarlyVMInit"));
 }
@@ -635,6 +658,41 @@ debugInit_waitInitComplete(void)
     debugMonitorExit(initMonitor);
 }
 
+void
+signalVMInitComplete(void)
+{
+    /*
+     * VM Initialization is complete
+     */
+    LOG_MISC(("signal VM initialization complete"));
+    debugMonitorEnter(initMonitor);
+    VMInitComplete = JNI_TRUE;
+    debugMonitorNotifyAll(initMonitor);
+    debugMonitorExit(initMonitor);
+}
+
+/*
+ * Determine if VM initialization is complete.
+ */
+jboolean
+debugInit_isVMInitComplete(void)
+{
+    return VMInitComplete;
+}
+
+/*
+ * Wait for VM initialization to complete.
+ */
+void
+debugInit_waitVMInitComplete(void)
+{
+    debugMonitorEnter(initMonitor);
+    while (!VMInitComplete) {
+        debugMonitorWait(initMonitor);
+    }
+    debugMonitorExit(initMonitor);
+}
+
 /* All process exit() calls come from here */
 void
 forceExit(int exit_code)
@@ -690,6 +748,7 @@ initialize(JNIEnv *env, jthread thread, EventIndex triggering_ei)
     LOG_MISC(("Begin initialize()"));
     currentSessionID = 0;
     initComplete = JNI_FALSE;
+	VMInitComplete = JNI_FALSE;
 
     if ( gdata->vmDead ) {
         EXIT_ERROR(AGENT_ERROR_INTERNAL,"VM dead at initialize() time");
@@ -799,6 +858,7 @@ debugInit_reset(JNIEnv *env)
 
     currentSessionID++;
     initComplete = JNI_FALSE;
+	VMInitComplete = JNI_TRUE; /* The VM Is already initialized */
 
     eventHandler_reset(currentSessionID);
     transport_reset();

--- a/jdk/src/share/back/debugInit.h
+++ b/jdk/src/share/back/debugInit.h
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
 /*
  * Copyright (c) 1998, 2005, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -38,6 +59,9 @@ jboolean debugInit_suspendOnInit(void);
 void debugInit_reset(JNIEnv *env);
 void debugInit_exit(jvmtiError, const char *);
 void forceExit(int);
+
+void debugInit_waitVMInitComplete(void);
+void signalVMInitComplete(void);
 
 JNIEXPORT jint JNICALL Agent_OnLoad(JavaVM *, char *, void *);
 JNIEXPORT void JNICALL Agent_OnUnload(JavaVM *);

--- a/jdk/src/share/back/debugLoop.c
+++ b/jdk/src/share/back/debugLoop.c
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
 /*
  * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -98,6 +119,7 @@ debugLoop_run(void)
     standardHandlers_onConnect();
     threadControl_onConnect();
 
+	debugInit_waitVMInitComplete();
     /* Okay, start reading cmds! */
     while (shouldListen) {
         if (!dequeue(&p)) {

--- a/jdk/src/share/back/eventHelper.c
+++ b/jdk/src/share/back/eventHelper.c
@@ -1,3 +1,24 @@
+/*******************************************************************************
+ * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] http://openjdk.java.net/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 OR LicenseRef-GPL-2.0 WITH Assembly-exception
+ *******************************************************************************/
 /*
  * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -574,6 +595,7 @@ handleReportVMInitCommand(JNIEnv* env, ReportVMInitCommand *command)
         (void)threadControl_suspendThread(command->thread, JNI_FALSE);
     }
 
+	signalVMInitComplete();
     outStream_initCommand(&out, uniqueID(), 0x0,
                           JDWP_COMMAND_SET(Event),
                           JDWP_COMMAND(Event, Composite));


### PR DESCRIPTION
Normally, the event helper thread suspends all threads, then the debug loop in
the listener thread receives a command to resume.  The debugger may deadlock if
the debug loop in the listener thread starts processing commands (e.g. resume
threads) before the event helper completes the initialization (and suspends
threads).

This patch adds synchronization to ensure the event helper completes the
initialization sequence before debugger commands are processed.

@andrew-m-leonard FYI.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>