### PR TITLE
Get sources from final openj9-0.8.0 tag for OpenJ9 and OMR

### DIFF
--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -46,7 +46,7 @@ fi
 declare -A j9repos
 declare -A branches
 declare -A default_j9repos=( [openj9]=eclipse/openj9 [omr]=eclipse/openj9-omr )
-declare -A default_branches=( [openj9]=openj9-0.8.0-rc2 [omr]=openj9-0.8.0-rc2 )
+declare -A default_branches=( [openj9]=openj9-0.8.0 [omr]=openj9-0.8.0 )
 declare -A commands
 declare -A shas
 


### PR DESCRIPTION
This is the pull request to update get_sources.sh to the final tag for the 0.8.0 OpenJ9 release.

This can't be merged until the OpenJ9 / OMR repos have been tagged and OpenJ9 has given the OK.