### PR TITLE
Restore creation of dtfj, dtfjview & traceformat jars

### DIFF
--- a/closed/make/CreateJars.gmk
+++ b/closed/make/CreateJars.gmk
@@ -1,0 +1,107 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+$(eval $(call SetupArchive,BUILD_DTFJ_JAR, , \
+	SRCS := $(JDK_OUTPUTDIR)/classes, \
+	INCLUDES := \
+		com/ibm/dtfj \
+		com/ibm/java/diagnostics/utils \
+		com/ibm/jvm/j9/dump, \
+	JAR := $(IMAGES_OUTPUTDIR)/lib/ext/dtfj.jar, \
+	SKIP_METAINF := true))
+
+$(eval $(call SetupArchive,BUILD_DTFJVIEW_JAR, , \
+	SRCS := $(JDK_OUTPUTDIR)/classes, \
+	INCLUDES := com/ibm/jvm/dtfjview, \
+	JAR := $(IMAGES_OUTPUTDIR)/lib/ext/dtfjview.jar, \
+	SKIP_METAINF := true))
+
+$(eval $(call SetupArchive,BUILD_TRACEFORMAT_JAR, , \
+	SRCS := $(JDK_OUTPUTDIR)/classes, \
+	INCLUDES := \
+		com/ibm/jvm/format \
+		com/ibm/jvm/trace \
+		com/ibm/jvm/traceformat, \
+	EXTRA_FILES := \
+		com/ibm/jvm/Debug.class \
+		com/ibm/jvm/FormatTimestamp.class \
+		com/ibm/jvm/Indent.class \
+		com/ibm/jvm/InputFile.class \
+		com/ibm/jvm/MessageFile.class \
+		com/ibm/jvm/OutputFile.class \
+		com/ibm/jvm/ProgramOption.class \
+		com/ibm/jvm/Statistics.class \
+		com/ibm/jvm/Summary.class \
+		com/ibm/jvm/Threads.class \
+		com/ibm/jvm/Timezone.class \
+		com/ibm/jvm/TraceFormat.class \
+		com/ibm/jvm/Verbose.class, \
+	JAR := $(IMAGES_OUTPUTDIR)/lib/ext/traceformat.jar, \
+	SKIP_METAINF := true))
+
+JARS += $(patsubst %,$(IMAGES_OUTPUTDIR)/lib/ext/%.jar, dtfj dtfjview traceformat)
+
+EXPORTED_PRIVATE_PKGS += \
+	com.ibm.cuda \
+	com.ibm.cuda.internal \
+	com.ibm.dataaccess \
+	com.ibm.gpu \
+	com.ibm.java.lang.management.internal \
+	com.ibm.jit \
+	com.ibm.jvm \
+	com.ibm.lang.management \
+	com.ibm.lang.management.internal \
+	com.ibm.le.conditionhandling \
+	com.ibm.oti.lang \
+	com.ibm.oti.reflect \
+	com.ibm.oti.shared \
+	com.ibm.oti.util \
+	com.ibm.oti.vm \
+	com.ibm.tools.attach.target \
+	com.ibm.virtualization.management \
+	com.ibm.virtualization.management.internal \
+	jdk.internal.org.objectweb.asm \
+	jdk.internal.org.objectweb.asm.commons \
+	jdk.internal.org.objectweb.asm.tree \
+	jdk.internal.org.objectweb.asm.util \
+	openj9.lang.management \
+	openj9.lang.management.internal \
+	#
+
+RT_JAR_EXCLUDES += \
+	com/ibm/dtfj \
+	com/ibm/java/diagnostics \
+	com/ibm/jvm/Debug.class \
+	com/ibm/jvm/dtfjview \
+	com/ibm/jvm/format \
+	com/ibm/jvm/FormatTimestamp.class \
+	com/ibm/jvm/Indent.class \
+	com/ibm/jvm/InputFile.class \
+	com/ibm/jvm/j9 \
+	com/ibm/jvm/MessageFile.class \
+	com/ibm/jvm/OutputFile.class \
+	com/ibm/jvm/ProgramOption.class \
+	com/ibm/jvm/Statistics.class \
+	com/ibm/jvm/Summary.class \
+	com/ibm/jvm/Threads.class \
+	com/ibm/jvm/Timezone.class \
+	com/ibm/jvm/trace \
+	com/ibm/jvm/traceformat \
+	com/ibm/jvm/TraceFormat.class \
+	com/ibm/jvm/Verbose.class \
+	com/ibm/tools/attach/attacher \
+	#

--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -1,4 +1,8 @@
 #
+# ===========================================================================
+# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# ===========================================================================
+#
 # Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -411,22 +415,19 @@ $(eval $(call SetupLauncher,rmiregistry, \
 $(eval $(call SetupLauncher,jcmd, \
     -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "sun.tools.jcmd.JCmd"$(COMMA) }'))
 
-# Include executables for OpenJ9 (jdmpview, traceformat and jextract)
+# Include executables for OpenJ9 (jdmpview, traceformat and jextract).
 $(eval $(call SetupLauncher,jdmpview, \
     -DEXPAND_CLASSPATH_WILDCARDS \
-    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.ibm.jvm.dtfjview.DTFJView"$(COMMA) }' \
-    -DAPP_CLASSPATH='{ "/lib/tools.jar"$(COMMA) "/classes" }'))
+    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.ibm.jvm.dtfjview.DTFJView" }'))
 
 $(eval $(call SetupLauncher,traceformat, \
     -DEXPAND_CLASSPATH_WILDCARDS \
-    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.ibm.jvm.format.TraceFormat"$(COMMA) }' \
-    -DAPP_CLASSPATH='{ "/lib/tools.jar"$(COMMA) "/classes" }'))
+    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.ibm.jvm.format.TraceFormat" }'))
 
-ifneq ($(findstring $(OPENJDK_TARGET_OS),linux aix),)
+ifneq ($(findstring $(OPENJDK_TARGET_OS),aix linux),)
   $(eval $(call SetupLauncher,jextract, \
     -DEXPAND_CLASSPATH_WILDCARDS \
-    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.ibm.jvm.j9.dump.extract.Main"$(COMMA) }' \
-    -DAPP_CLASSPATH='{ "/lib/tools.jar"$(COMMA) "/classes" }'))
+    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.ibm.jvm.j9.dump.extract.Main" }'))
 endif
 
 ifeq ($(OPENJDK_TARGET_OS), windows)

--- a/jdk/make/CreateJars.gmk
+++ b/jdk/make/CreateJars.gmk
@@ -217,29 +217,7 @@ RT_JAR_EXCLUDES += \
     $(LOCALEDATA_INCLUDES) \
     com/oracle/jrockit/jfr \
     oracle/jrockit/jfr \
-    jdk/jfr \
-    com/ibm/tools/attach/attacher \
-    com/ibm/dtfj \
-    com/ibm/java/diagnostics \
-    	com/ibm/jvm/Debug.class \
-	com/ibm/jvm/FormatTimestamp.class \
-	com/ibm/jvm/Indent.class \
-	com/ibm/jvm/InputFile.class \
-	com/ibm/jvm/MessageFile.class \
-	com/ibm/jvm/OutputFile.class \
-	com/ibm/jvm/ProgramOption.class \
-	com/ibm/jvm/Statistics.class \
-	com/ibm/jvm/Summary.class \
-	com/ibm/jvm/Threads.class \
-	com/ibm/jvm/Timezone.class \
-	com/ibm/jvm/TraceFormat.class \
-	com/ibm/jvm/Verbose.class \
-    com/ibm/jvm/j9 \
-    com/ibm/jvm/dtfjview \
-    com/ibm/jvm/TraceFormat.class  \
-    com/ibm/jvm/format  \
-    com/ibm/jvm/trace  \
-    com/ibm/jvm/traceformat
+    jdk/jfr
 
 # Find all files in the classes dir to use as dependencies. This could be more fine granular.
 ALL_FILES_IN_CLASSES := $(call not-containing, _the., $(filter-out %javac_state, \
@@ -287,6 +265,7 @@ $(IMAGES_OUTPUTDIR)/lib$(PROFILE)/_the.jars.contents: $(BUILD_TOOLS) $(IMAGES_OU
 	$(TOOL_JARREORDER) \
 	    -o $@.tmp $(IMAGES_OUTPUTDIR)/lib/classlist $(IMAGES_OUTPUTDIR)/lib$(PROFILE)/_the.jars.exclude . )
 	$(SED) 's/\r//g' $@.tmp > $@
+	$(RM) $@.tmp
 
 $(IMAGES_OUTPUTDIR)/lib$(PROFILE)/_the.rt.jar.contents: $(IMAGES_OUTPUTDIR)/lib$(PROFILE)/_the.jars.contents
 	$(MKDIR) -p $(@D)
@@ -532,15 +511,10 @@ TOOLS_JAR_INCLUDES := \
     sun/tools/native2ascii \
     sun/tools/serialver \
     sun/tools/tree \
-    sun/tools/util \
-    com/ibm/tools/attach/attacher \
-    com/ibm/jvm/traceformat \
-    com/ibm/jvm/format \
-    com/ibm/jvm/trace \
-    com/ibm/jvm/dtfjview \
-    com/ibm/dtfj \
-    com/ibm/jvm/j9/dump \
-    com/ibm/java/diagnostics/utils
+    sun/tools/util
+
+# Contributions from OpenJ9:
+TOOLS_JAR_INCLUDES += com/ibm/tools/attach/attacher 
 
 # The sjavac tools is not ready for public consumption.
 TOOLS_JAR_EXCLUDES = com/sun/tools/sjavac
@@ -555,20 +529,7 @@ $(eval $(call SetupArchive,BUILD_TOOLS_JAR, , \
         META-INF/services/com.sun.jdi.connect.spi.TransportService \
         META-INF/services/com.sun.tools.attach.spi.AttachProvider \
         META-INF/services/com.sun.tools.internal.ws.wscompile.Plugin \
-        META-INF/services/com.sun.tools.internal.xjc.Plugin \
-        com/ibm/jvm/Debug.class \
-		com/ibm/jvm/FormatTimestamp.class \
-		com/ibm/jvm/Indent.class \
-		com/ibm/jvm/InputFile.class \
-		com/ibm/jvm/MessageFile.class \
-		com/ibm/jvm/OutputFile.class \
-		com/ibm/jvm/ProgramOption.class \
-		com/ibm/jvm/Statistics.class \
-		com/ibm/jvm/Summary.class \
-		com/ibm/jvm/Threads.class \
-		com/ibm/jvm/Timezone.class \
-		com/ibm/jvm/TraceFormat.class \
-		com/ibm/jvm/Verbose.class, \
+        META-INF/services/com.sun.tools.internal.xjc.Plugin, \
     JAR := $(IMAGES_OUTPUTDIR)/lib/tools.jar, \
     SKIP_METAINF := true, \
     CHECK_COMPRESS_JAR := true))
@@ -601,31 +562,7 @@ EXCLUDE_PROPWARN_PKGS = com.sun.java.swing.plaf.windows \
 # with a new module system (being discussed for JDK 8).
 #
 EXPORTED_PRIVATE_PKGS = com.oracle.net \
-    com.oracle.nio \
-    com.ibm.cuda \
-    com.ibm.cuda.internal \
-    com.ibm.dataaccess \
-    com.ibm.gpu \
-    com.ibm.java.lang.management.internal \
-    com.ibm.jit \
-    com.ibm.jvm \
-    com.ibm.lang.management \
-    com.ibm.lang.management.internal \
-    openj9.lang.management \
-    openj9.lang.management.internal \
-    com.ibm.le.conditionhandling \
-    com.ibm.oti.lang \
-    com.ibm.oti.reflect \
-    com.ibm.oti.shared \
-    com.ibm.oti.util \
-    com.ibm.oti.vm \
-    com.ibm.virtualization.management \
-    com.ibm.virtualization.management.internal \
-    com.ibm.tools.attach.target \
-    jdk.internal.org.objectweb.asm \
-    jdk.internal.org.objectweb.asm.commons \
-    jdk.internal.org.objectweb.asm.tree \
-    jdk.internal.org.objectweb.asm.util
+    com.oracle.nio
 
 $(IMAGES_OUTPUTDIR)/symbols/_the.symbols: $(IMAGES_OUTPUTDIR)/lib/rt.jar
 	$(RM) -r $(IMAGES_OUTPUTDIR)/symbols/META-INF/sym
@@ -777,7 +714,7 @@ $(IMAGES_OUTPUTDIR)/lib/ext/zipfs.jar: $(JDK_OUTPUTDIR)/demo/nio/zipfs/zipfs.jar
 # This file is imported from hotspot in Import.gmk. Copying it into images/lib so that
 # all jars can be found in one place when creating images in Images.gmk. It needs to be
 # done here so that clean targets can be simple and accurate.
-# Not required for J9VM
+# Not required for OpenJ9
 #$(IMAGES_OUTPUTDIR)/lib/sa-jdi.jar: $(JDK_OUTPUTDIR)/lib/sa-jdi.jar
 #	$(install-file)
 


### PR DESCRIPTION
* Enables basic commands in jdmpview.
* Content in those jars forms part of the API to an SDK. Used, for example, by HealthCenter.
* Include only necessary OpenJ9 classes in tools.jar.
* Revert many changes to jdk/make/CreateJars.gmk by moving as much as possible to closed/make/CreateJars.gmk.
* Use default APP_CLASSPATH for jdmpview, jextract and traceformat.
* Add missing IBM copyright notice.