### PR TITLE
Clean up libjdwp per reviewers' comments

### DIFF
--- a/jdk/src/share/back/debugInit.c
+++ b/jdk/src/share/back/debugInit.c
@@ -653,15 +653,6 @@ signalVMInitComplete(void)
 }
 
 /*
- * Determine if VM initialization is complete.
- */
-jboolean
-debugInit_isVMInitComplete(void)
-{
-    return VMInitComplete;
-}
-
-/*
  * Wait for VM initialization to complete.
  */
 void
@@ -839,7 +830,6 @@ debugInit_reset(JNIEnv *env)
 
     currentSessionID++;
     initComplete = JNI_FALSE;
-	VMInitComplete = JNI_TRUE; /* The VM Is already initialized */
 
     eventHandler_reset(currentSessionID);
     transport_reset();


### PR DESCRIPTION
Remove unused function and redundant variable settings.

Same as changes for Java 9.

For review by @andrew-m-leonard and @pshipton .

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>