### PR TITLE
Update mk/config scripts to support 32-bit on Windows

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -3912,7 +3912,7 @@ fi
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1525362336
+DATE_WHEN_GENERATED=1526493779
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -146,12 +146,12 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
     [build non-compressedrefs vm (large heap)])])
 
   OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU($build_cpu)
-  if test "x$with_noncompressedrefs" = x; then
-    OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}_cmprssptrs"
-    OPENJ9_LIBS_SUBDIR=compressedrefs
-  else
+  if test "x$with_noncompressedrefs" != x  -o "x$OPENJDK_TARGET_CPU_BITS" = x32; then
     OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}"
     OPENJ9_LIBS_SUBDIR=default
+  else
+    OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}_cmprssptrs"
+    OPENJ9_LIBS_SUBDIR=compressedrefs
   fi
 
   if test "x$OPENJ9_CPU" = xx86-64; then
@@ -160,7 +160,12 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
     elif test "x$OPENJDK_BUILD_OS" = xwindows; then
       OPENJ9_PLATFORM_CODE=wa64
       if test "x$OPENJ9_LIBS_SUBDIR" = xdefault; then
-        OPENJ9_BUILDSPEC="win_x86-64"
+        if test "x$OPENJDK_TARGET_CPU_BITS" = x32; then
+          OPENJ9_PLATFORM_CODE=wi32
+          OPENJ9_BUILDSPEC="win_x86"
+        else
+          OPENJ9_BUILDSPEC="win_x86-64"
+        fi
       else
         OPENJ9_BUILDSPEC="win_x86-64_cmprssptrs"
       fi

--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -72,3 +72,5 @@ OPENJ9_LIBS_SUBDIR      := @OPENJ9_LIBS_SUBDIR@
 
 # Windows
 MSVCP_DLL               := @MSVCP_DLL@
+
+COPY_JVM_CFG_FILE       := true

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -3982,7 +3982,7 @@ fi
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1525362336
+DATE_WHEN_GENERATED=1526493779
 
 ###############################################################################
 #
@@ -8259,12 +8259,12 @@ fi
       ;;
   esac
 
-  if test "x$with_noncompressedrefs" = x; then
-    OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}_cmprssptrs"
-    OPENJ9_LIBS_SUBDIR=compressedrefs
-  else
+  if test "x$with_noncompressedrefs" != x  -o "x$OPENJDK_TARGET_CPU_BITS" = x32; then
     OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}"
     OPENJ9_LIBS_SUBDIR=default
+  else
+    OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}_cmprssptrs"
+    OPENJ9_LIBS_SUBDIR=compressedrefs
   fi
 
   if test "x$OPENJ9_CPU" = xx86-64; then
@@ -8273,7 +8273,12 @@ fi
     elif test "x$OPENJDK_BUILD_OS" = xwindows; then
       OPENJ9_PLATFORM_CODE=wa64
       if test "x$OPENJ9_LIBS_SUBDIR" = xdefault; then
-        OPENJ9_BUILDSPEC="win_x86-64"
+        if test "x$OPENJDK_TARGET_CPU_BITS" = x32; then
+          OPENJ9_PLATFORM_CODE=wi32
+          OPENJ9_BUILDSPEC="win_x86"
+        else
+          OPENJ9_BUILDSPEC="win_x86-64"
+        fi
       else
         OPENJ9_BUILDSPEC="win_x86-64_cmprssptrs"
       fi

--- a/jdk/src/windows/bin/i586/jvm.cfg
+++ b/jdk/src/windows/bin/i586/jvm.cfg
@@ -1,3 +1,7 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+#
 # Copyright (c) 2001, 2013, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -30,5 +34,6 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
--client KNOWN
--server KNOWN
+-j9vm KNOWN
+-server IGNORE
+-client IGNORE


### PR DESCRIPTION
The change is to modify the makefile and config
script so as to compile a 32-bit build on Windows.

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>