### PR TITLE
Fix handling of path list in dbgsysBuildLibName

### DIFF
--- a/jdk/src/windows/back/linker_md.c
+++ b/jdk/src/windows/back/linker_md.c
@@ -1,4 +1,10 @@
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -51,8 +57,10 @@ static void dll_build_name(char* buffer, size_t buflen,
     path = strtok_s(paths_copy, PATH_SEPARATOR, &next_token);
 
     while (path != NULL) {
-        _snprintf(buffer, buflen, "%s\\%s.dll", path, fname);
-        if (_access(buffer, 0) == 0) {
+        size_t result_len = (size_t)_snprintf(buffer, buflen, "%s\\%s.dll", path, fname);
+        if (result_len >= buflen) {
+            /* Ignore this path that doesn't fit in the supplied buffer. */
+        } else if (_access(buffer, 0) == 0) {
             break;
         }
         *buffer = '\0';
@@ -107,13 +115,13 @@ dbgsysBuildLibName(char *holder, int holderlen, const char *pname, const char *f
     const int pnamelen = pname ? (int)strlen(pname) : 0;
 
     *holder = '\0';
-    /* Quietly truncates on buffer overflow. Should be an error. */
-    if (pnamelen + (int)strlen(fname) + 10 > holderlen) {
-        return;
-    }
 
     if (pnamelen == 0) {
-        sprintf(holder, "%s.dll", fname);
+        size_t result_len = (size_t)_snprintf(holder, holderlen, "%s.dll", fname);
+        if (result_len >= holderlen) {
+            /* Ignore this path that doesn't fit in the supplied buffer. */
+            *holder = '\0';
+        }
     } else {
       dll_build_name(holder, holderlen, pname, fname);
     }


### PR DESCRIPTION
Silently ignore paths that don't fit in the supplied buffer.

This should address https://github.com/eclipse/openj9/issues/2129.