### PR TITLE
Use '--topo-order' in git tag query

### DIFF
--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -225,7 +225,7 @@ AC_DEFUN_ONCE([OPENJDK_VERSION_DETAILS],
   AC_SUBST(JDK_FIX_VERSION)
 
   OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
-  LAST_TAGGED_SHA=`git -C $SRC_ROOT rev-list --tags="jdk8u*" --max-count=1 2>/dev/null`
+  LAST_TAGGED_SHA=`git -C $SRC_ROOT rev-list --tags="jdk8u*" --topo-order --max-count=1 2>/dev/null`
   if test "x$LAST_TAGGED_SHA" != x; then
     OPENJDK_TAG=`git -C $SRC_ROOT describe --tags "$LAST_TAGGED_SHA"`
   else


### PR DESCRIPTION
For consistency with newer versions.