### PR TITLE
Move ddrgen step after building VM

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -70,6 +70,16 @@ OPENJ9_VM_FILES := \
 	#
 
 ifeq (true,$(OPENJ9_ENABLE_DDR))
+  .PHONY : run-ddrgen
+  $(OUTPUT_ROOT)/vm/j9ddr.dat : run-ddrgen
+  run-ddrgen :
+	export OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS) \
+		VERSION_MAJOR=8 \
+		$(EXPORT_MSVS_ENV_VARS) \
+	&& $(MAKE) -C $(OUTPUT_ROOT)/vm/ddr -f run_omrddrgen.mk \
+		CC="$(CC)" \
+		CXX="$(CXX)"
+
   OPENJ9_VM_FILES += j9ddr.dat
 endif
 


### PR DESCRIPTION
Move the run ddrgen step outside of the building VM step in order to
resolve DDR dependencies better.

This PR moves the run ddrgen step to after the VM is built, and needs to be delivered together with https://github.com/eclipse/openj9/pull/2588.

Signed-off-by: mikezhang <mike.h.zhang@ibm.com>