### PR TITLE
Enable building a 'test-image'

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -186,8 +186,6 @@ define openj9_copy_tree_impl
 endef
 
 $(eval $(call generated_target_rules,build_jdk,$(JDK_OUTPUTDIR)))
-$(eval $(call generated_target_rules,jdk_image,$(JDK_IMAGE_DIR)))
-$(eval $(call generated_target_rules,jre_image,$(JRE_IMAGE_DIR)))
 
 # Comments for stage-j9
 # Currently there is a staged location where j9 is built.  This is due to a number of reasons:
@@ -340,7 +338,7 @@ build-j9 : run-preprocessors-j9
 	@$(ECHO) Compiling OpenJ9 in $(OUTPUT_ROOT)/vm
 ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 	(export OPENJ9_BUILD=true $(EXPORT_MSVS_ENV_VARS) \
-		&& $(MAKE) -C  $(OUTPUT_ROOT)/vm/build $(MAKEFLAGS) install \
+		&& $(MAKE) -C $(OUTPUT_ROOT)/vm/build $(MAKEFLAGS) install \
 	)
 else
 	(export OPENJ9_BUILD=true $(EXPORT_NO_USE_MINGW) $(EXPORT_MSVS_ENV_VARS) \

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -20,6 +20,7 @@ ifeq (,$(wildcard $(SPEC)))
   $(error OpenJ9.gmk needs SPEC set to a proper spec.gmk)
 endif
 include $(SPEC)
+include $(SRC_ROOT)/make/common/MakeBase.gmk
 
 ifeq (,$(BUILD_ID))
   BUILD_ID := 000000
@@ -186,6 +187,67 @@ define openj9_copy_tree_impl
 endef
 
 $(eval $(call generated_target_rules,build_jdk,$(JDK_OUTPUTDIR)))
+
+OPENJ9_TEST_IMAGE_DIR := $(IMAGES_OUTPUTDIR)/test/openj9
+
+# openj9_test_image_rules
+# -----------------------
+# $1 = absolute library path
+define openj9_test_image_rules
+openj9_test_image : $(OPENJ9_TEST_IMAGE_DIR)/$(notdir $(strip $1))
+$(OPENJ9_TEST_IMAGE_DIR)/$(notdir $(strip $1)) : $(strip $1)
+	$$(call install-file)
+endef
+
+$(foreach file, \
+	$(patsubst %, $(OUTPUT_ROOT)/vm/%$(EXE_SUFFIX), \
+		algotest \
+		bcvunit \
+		cfdump \
+		ctest \
+		dyntest \
+		gc_rwlocktest \
+		glaunch \
+		invtest \
+		jsigjnitest \
+		pltest \
+		propstest \
+		shrtest \
+		testjep178_dynamic \
+		testjep178_static \
+		thrstatetest \
+		vmLifecyleTests \
+		vmtest \
+		) \
+	$(patsubst %, $(OUTPUT_ROOT)/vm/$(call SHARED_LIBRARY,%), \
+		balloon29 \
+		bcuwhite \
+		bcvwhite \
+		gptest \
+		hooktests \
+		j9ben \
+		j9lazyClassLoad \
+		j9thrnumanatives29 \
+		j9thrtestnatives29 \
+		j9unresolved \
+		j9vmtest \
+		jcoregen29 \
+		jlmagent29 \
+		jniargtests \
+		jvmtitest \
+		memorywatcher29 \
+		migration \
+		osmemory29 \
+		SharedClassesNativeAgent \
+		softmxtest \
+		testjvmtiA \
+		testjvmtiB \
+		testlibA \
+		testlibB \
+		vmruntimestateagent29 \
+		), \
+	$(if $(wildcard $(file)), \
+		$(eval $(call openj9_test_image_rules, $(file)))))
 
 # Comments for stage-j9
 # Currently there is a staged location where j9 is built.  This is due to a number of reasons:

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -21,25 +21,15 @@ clean-j9vm :
 .PHONY : \
 	j9vm-build \
 	j9vm-compose-buildjvm \
-	openj9-jdk-image \
-	openj9-jre-image \
 	#
 
+OPENJ9_MAKE := $(MAKE) -f $(SRC_ROOT)/closed/OpenJ9.gmk SPEC=$(SPEC)
+
 j9vm-build :
-	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS) build-j9)
+	+$(OPENJ9_MAKE) OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS) build-j9
 
 j9vm-compose-buildjvm : j9vm-build
-	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_build_jdk)
-
-product-images : openj9-jdk-image openj9-jre-image
-
-openj9-jdk-image : jdk-image j9vm-build
-	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_jdk_image)
-
-openj9-jre-image : jre-image j9vm-build
-	+($(CD) $(SRC_ROOT)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_jre_image)
-
-ALL_TARGETS += openj9-jdk-image openj9-jre-image
+	+$(OPENJ9_MAKE) stage_openj9_build_jdk
 
 # Shortly after this makefile fragment is included, Main.gmk computes the list
 # of Java source files. Unless a goal is for 'help' or to 'clean' something, we

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -21,6 +21,8 @@ clean-j9vm :
 .PHONY : \
 	j9vm-build \
 	j9vm-compose-buildjvm \
+	openj9-test-image \
+	test-image \
 	#
 
 OPENJ9_MAKE := $(MAKE) -f $(SRC_ROOT)/closed/OpenJ9.gmk SPEC=$(SPEC)
@@ -30,6 +32,13 @@ j9vm-build :
 
 j9vm-compose-buildjvm : j9vm-build
 	+$(OPENJ9_MAKE) stage_openj9_build_jdk
+
+images :: test-image
+
+test-image : openj9-test-image
+
+openj9-test-image : j9vm-build
+	+$(OPENJ9_MAKE) openj9_test_image
 
 # Shortly after this makefile fragment is included, Main.gmk computes the list
 # of Java source files. Unless a goal is for 'help' or to 'clean' something, we


### PR DESCRIPTION
Java 11 and newer build frameworks allow building a 'test-image' which include test artifacts (executables and shared libraries). This does the same for Java 8.

Add make target 'test-image'
* add 'test-image' as a prerequisite for 'images'.

Remove unused rules
* neither 'product-images' nor 'ALL_TARGETS' is mentioned in other makefiles, so they can safely be removed along with their prerequisites.

See https://github.com/eclipse/openj9/issues/2100.