### PR TITLE
Build with OpenSSL v1.1.1 on AIX

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4336,7 +4336,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1538754016
+DATE_WHEN_GENERATED=1539007666
 
 ###############################################################################
 #

--- a/jdk/make/CopyFiles.gmk
+++ b/jdk/make/CopyFiles.gmk
@@ -259,6 +259,16 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
       OPENSSL_LIB_NAME = libcrypto-1_1.dll
     endif
     OPENSSL_TARGET_LIB = $(JDK_OUTPUTDIR)/bin/$(OPENSSL_LIB_NAME)
+  else ifeq ($(OPENJDK_TARGET_OS), aix)
+    #OpenSSL 1.1.1 on AIX has switched to use archive library files (natural way) instead of '.so' files.
+    #  For reference, corresponding OpenSSL PR is https://github.com/openssl/openssl/pull/6487
+    #OpenSSL v1.1.0 crypto library to bundle with JDK
+    OPENSSL_LIB_NAME = libcrypto.so.1.1
+    ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
+      #OpenSSL v1.1.1 crypto library to bundle with JDK
+      OPENSSL_LIB_NAME = libcrypto.a
+    endif
+    OPENSSL_TARGET_LIB = $(JDK_OUTPUTDIR)/lib$(OPENJDK_TARGET_CPU_LIBDIR)/$(OPENSSL_LIB_NAME)
   else
     OPENSSL_LIB_NAME = libcrypto.so.1.1
     OPENSSL_TARGET_LIB = $(JDK_OUTPUTDIR)/lib$(OPENJDK_TARGET_CPU_LIBDIR)/$(OPENSSL_LIB_NAME)

--- a/jdk/make/CopyFiles.gmk
+++ b/jdk/make/CopyFiles.gmk
@@ -263,7 +263,7 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
     #OpenSSL 1.1.1 on AIX has switched to use archive library files (natural way) instead of '.so' files.
     #  For reference, corresponding OpenSSL PR is https://github.com/openssl/openssl/pull/6487
     #OpenSSL v1.1.0 crypto library to bundle with JDK
-    OPENSSL_LIB_NAME = libcrypto.so.1.1
+    OPENSSL_LIB_NAME = libcrypto.so
     ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
       #OpenSSL v1.1.1 crypto library to bundle with JDK
       OPENSSL_LIB_NAME = libcrypto.a

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -472,7 +472,7 @@ AC_DEFUN([CONFIGURE_OPENSSL],
         OPENSSL_DIR=$SRC_ROOT/openssl
         FOUND_OPENSSL=yes
         OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
-        OPENSSL_LIBS="-L${OPENSSL_DIR} -lssl -lcrypto"
+        OPENSSL_LIBS="-L${OPENSSL_DIR} -lcrypto"
         if test -s $OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1; then
           BUILD_OPENSSL=no
         else
@@ -516,13 +516,13 @@ AC_DEFUN([CONFIGURE_OPENSSL],
           if test -s "$OPENSSL_DIR/lib/libcrypto.lib"; then
             FOUND_OPENSSL=yes
             OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
-            OPENSSL_LIBS="-libpath:${OPENSSL_DIR}/lib libssl.lib libcrypto.lib"
+            OPENSSL_LIBS="-libpath:${OPENSSL_DIR}/lib libcrypto.lib"
           fi
         else
           if test -s "$OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1"; then
             FOUND_OPENSSL=yes
             OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
-            OPENSSL_LIBS="-L${OPENSSL_DIR} -lssl -lcrypto"
+            OPENSSL_LIBS="-L${OPENSSL_DIR} -lcrypto"
           fi
         fi
       fi

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -4432,7 +4432,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1538754016
+DATE_WHEN_GENERATED=1539007666
 
 ###############################################################################
 #
@@ -15481,7 +15481,7 @@ $as_echo "no" >&6; }
         OPENSSL_DIR=$SRC_ROOT/openssl
         FOUND_OPENSSL=yes
         OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
-        OPENSSL_LIBS="-L${OPENSSL_DIR} -lssl -lcrypto"
+        OPENSSL_LIBS="-L${OPENSSL_DIR} -lcrypto"
         if test -s $OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1; then
           BUILD_OPENSSL=no
         else
@@ -15715,13 +15715,13 @@ $as_echo "$as_me: The path of OPENSSL_DIR, which resolves as \"$path\", is inval
           if test -s "$OPENSSL_DIR/lib/libcrypto.lib"; then
             FOUND_OPENSSL=yes
             OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
-            OPENSSL_LIBS="-libpath:${OPENSSL_DIR}/lib libssl.lib libcrypto.lib"
+            OPENSSL_LIBS="-libpath:${OPENSSL_DIR}/lib libcrypto.lib"
           fi
         else
           if test -s "$OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1"; then
             FOUND_OPENSSL=yes
             OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
-            OPENSSL_LIBS="-L${OPENSSL_DIR} -lssl -lcrypto"
+            OPENSSL_LIBS="-L${OPENSSL_DIR} -lcrypto"
           fi
         fi
       fi


### PR DESCRIPTION
This PR is for issue #123 

#112  enabled OpenSSL support in openJ9-openjdk builds which also allow bundling of OpenSSL crypto library with JDK build. However build fails with `--enable-openssl-bundling` option as OpenSSL 1.1.1 changed the library name to align with the natural way of handling shared library on AIX. Corresponding openssl PR for reference - https://github.com/openssl/openssl/pull/6487

As a result, we now have to link and bundle libcrypto.a instead of libcrypto.so.1.1.

In this fix, 
- we copy libcrypto.a to jre/lib/ppc64 directory if built with OpenSSL v1.1.1 and libcrypto.so to jre/lib/ppc64 if built with OpenSSL 1.1.0x
- remove linking against `ssl` on all platforms as our implementation use only `crypto` library

Signed-off-by: Bhaktavatsal Reddy <bhamaram@in.ibm.com>