### PR TITLE
Add rpath $ORIGIN to linker options that generate libjncrypto.so

### DIFF
--- a/jdk/make/lib/SecurityLibraries.gmk
+++ b/jdk/make/lib/SecurityLibraries.gmk
@@ -302,7 +302,7 @@ ifeq ($(WITH_OPENSSL), yes)
         OPTIMIZATION := LOW, \
         CFLAGS := $(CFLAGS_JDKLIB) -c $(OPENSSL_CFLAGS), \
         MAPFILE := $(SRC_ROOT)/closed/make/mapfiles/libjncrypto/mapfile-vers, \
-        LDFLAGS := $(SHARED_LIBRARY_FLAGS) $(LDFLAGS_JDKLIB), \
+        LDFLAGS := $(SHARED_LIBRARY_FLAGS) $(LDFLAGS_JDKLIB) $(call SET_SHARED_LIBRARY_ORIGIN), \
         LDFLAGS_SUFFIX := $(OPENSSL_LIBS), \
         VERSIONINFO_RESOURCE := $(JDK_TOPDIR)/src/windows/resource/version.rc, \
         RC_FLAGS := $(RC_FLAGS) \


### PR DESCRIPTION
fixes #128 

This fix adds linker options to set rpath with $ORIGIN.

Signed-off-by: Bhaktavatsal Reddy <bhamaram@in.ibm.com>