### PR TITLE
No warning message when failed to load native crypto library

### DIFF
--- a/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -25,21 +25,25 @@ import java.security.*;
 
 public class NativeCrypto {
 
-    public static boolean isLoaded = false;
+    private static boolean loaded = false;
 
     static {
         AccessController.doPrivileged(new PrivilegedAction<Void>() {
             public Void run() {
                 try {
                     System.loadLibrary("jncrypto"); // check for native library
-                    isLoaded = true;
+                    loaded = true;
                 } catch (UnsatisfiedLinkError usle) {
-                    isLoaded = false;
+                    loaded = false;
                 }
                 return null;
             }
         });
 
+    }
+
+    public static final boolean isLoaded() {
+        return loaded;
     }
 
     /* Native digest interfaces */

--- a/jdk/src/share/classes/sun/security/provider/SunEntries.java
+++ b/jdk/src/share/classes/sun/security/provider/SunEntries.java
@@ -420,11 +420,23 @@ final class SunEntries {
     }
 
     static {
-        if(NativeCrypto.isLoaded) {
-            useNativeDigest = Boolean.parseBoolean(
-                    GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto")) ||
-                        Boolean.parseBoolean(
-                            GetPropertyAction.privilegedGetProperty ("jdk.nativeDigest"));
+        useNativeDigest = Boolean.parseBoolean(
+                              GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto")) ||
+                          Boolean.parseBoolean(
+                              GetPropertyAction.privilegedGetProperty ("jdk.nativeDigest"));
+
+        if (useNativeDigest) {
+            /*
+             * User want to use native crypto implementation.
+             * Make sure the native crypto libraries are loaded successfully.
+             * Otherwise, throw a warning message and fall back to the in-built
+             * java crypto implementation.
+             */
+            if (!NativeCrypto.isLoaded()) {
+                System.err.println("Warning: Native crypto library load failed." +
+                                   " Using Java crypto implementation");
+                useNativeDigest = false;
+            }
         }
     }
 }


### PR DESCRIPTION
…s back to java crypto implementation

The following changes are made as part of this changeset:
   - Added a new warning message when native crypto library load failed and fallback to java crypto implementation.
   - The native crypto property is checked before loading the native crypto library. This will avoid unnecessary
     loading of the native library when user did not specify the native crypto property. Also, it avoids throwing
     the warning message when user did not specify the native crypto property.
   - Refine the use of native crypto property flags.
   - Use a method to check whether native crypto library is loaded successfully instead of accessing the class
     variable directly.

fixes #127

Signed-off-by: Nasser Ebrahim <enasser@in.ibm.com>