### PR TITLE
WIP: AccessControlException from CipherCore when Security manager enabled

### DIFF
--- a/jdk/src/share/classes/sun/security/provider/SunEntries.java
+++ b/jdk/src/share/classes/sun/security/provider/SunEntries.java
@@ -419,11 +419,26 @@ final class SunEntries {
         }
     }
 
+    /* Read the native crypto properties. The value can be YES or NO and case
+     * insensitive.
+     *
+     * User can specify enable all native crypto and disable specific crypto.
+     * For example -Djdk.nativeCrypto=YES -Djdk.nativeDigest=NO.
+     */
     static {
-        useNativeDigest = Boolean.parseBoolean(
-                              GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto")) ||
-                          Boolean.parseBoolean(
-                              GetPropertyAction.privilegedGetProperty ("jdk.nativeDigest"));
+        if (System.getProperty("jdk.nativeCrypto","NO").toUpperCase() == "YES") {
+            String prop;
+            if ((prop = System.getProperty("jdk.nativeDigest") != null) &&
+                prop.toUpperCase() == "NO") {
+                useNativeDigest = false;
+            } else {
+                useNativeDigest = true;
+            }
+        } else {
+            if (System.getProperty("jdk.nativeDigest","NO").toUpperCase() == "YES") {
+                useNativeDigest = true;
+            }
+        }
 
         if (useNativeDigest) {
             /*


### PR DESCRIPTION
The following changes are included in this changeset:
   - Removed the usage of sun.security.action.GetPropertyAction in
     com.sun.crypto.provider.CipherCore as it caused
     java.security.AccessControlException.
   - Change the value of native crypto properties from TRUE|FALSE to
     YES|NO as it makes more sense for end user to specify
     jdk.nativeCrypto=NO insted of jdk.nativeCrypto=FALSE.
   - Made the property value case insensitive so that user can
     specify 'YES' or 'Yes' or 'yes'.
   - Allow user to specify enable all native crypto and disable
     specific crypto

fixes #135

Signed-off-by: Nasser Ebrahim <enasser@in.ibm.com>