### PR TITLE
Fix crypto lib path when --with-openssl=/path/to/pre-built/openssl is used

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4336,7 +4336,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1539348366
+DATE_WHEN_GENERATED=1539368198
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -479,6 +479,9 @@ AC_DEFUN([CONFIGURE_OPENSSL],
         else
           BUILD_OPENSSL=yes
         fi
+        if test "x$BUNDLE_OPENSSL" = xyes; then
+          OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR
+        fi
         AC_MSG_RESULT([yes])
       else
         AC_MSG_RESULT([no])
@@ -518,12 +521,26 @@ AC_DEFUN([CONFIGURE_OPENSSL],
             FOUND_OPENSSL=yes
             OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
             OPENSSL_LIBS="-libpath:${OPENSSL_DIR}/lib libcrypto.lib"
+            if test "x$BUNDLE_OPENSSL" = xyes; then
+              OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR/bin
+              BASIC_FIXUP_PATH(OPENSSL_BUNDLE_LIB_PATH)
+            fi
           fi
         else
           if test -s "$OPENSSL_DIR/lib/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1"; then
             FOUND_OPENSSL=yes
             OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
             OPENSSL_LIBS="-L${OPENSSL_DIR}/lib -lcrypto"
+            if test "x$BUNDLE_OPENSSL" = xyes; then
+              OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR/lib
+            fi
+          elif test -s "$OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1"; then
+            FOUND_OPENSSL=yes
+            OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
+            OPENSSL_LIBS="-L${OPENSSL_DIR} -lcrypto"
+            if test "x$BUNDLE_OPENSSL" = xyes; then
+              OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR
+            fi
           fi
         fi
       fi
@@ -539,14 +556,6 @@ AC_DEFUN([CONFIGURE_OPENSSL],
 
     if test "x$OPENSSL_DIR" != x; then
       AC_MSG_CHECKING([if we should bundle openssl])
-      if test "x$BUNDLE_OPENSSL" = xyes; then
-         if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin; then
-           OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR/bin
-           BASIC_FIXUP_PATH(OPENSSL_BUNDLE_LIB_PATH)
-         else
-           OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR
-         fi
-      fi
       AC_MSG_RESULT([$BUNDLE_OPENSSL])
     fi
   fi

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -4432,7 +4432,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1539348366
+DATE_WHEN_GENERATED=1539368198
 
 ###############################################################################
 #
@@ -53980,6 +53980,9 @@ $as_echo "no" >&6; }
         else
           BUILD_OPENSSL=yes
         fi
+        if test "x$BUNDLE_OPENSSL" = xyes; then
+          OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR
+        fi
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
       else
@@ -54209,33 +54212,8 @@ $as_echo "$as_me: The path of OPENSSL_DIR, which resolves as \"$path\", is inval
             FOUND_OPENSSL=yes
             OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
             OPENSSL_LIBS="-libpath:${OPENSSL_DIR}/lib libcrypto.lib"
-          fi
-        else
-          if test -s "$OPENSSL_DIR/lib/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1"; then
-            FOUND_OPENSSL=yes
-            OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
-            OPENSSL_LIBS="-L${OPENSSL_DIR}/lib -lcrypto"
-          fi
-        fi
-      fi
-
-
-      #openssl is not found in user specified location. Abort.
-      if test "x$FOUND_OPENSSL" != xyes; then
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-        as_fn_error $? "Unable to find openssl in specified location $OPENSSL_DIR" "$LINENO" 5
-      fi
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-    fi
-
-    if test "x$OPENSSL_DIR" != x; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we should bundle openssl" >&5
-$as_echo_n "checking if we should bundle openssl... " >&6; }
-      if test "x$BUNDLE_OPENSSL" = xyes; then
-         if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin; then
-           OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR/bin
+            if test "x$BUNDLE_OPENSSL" = xyes; then
+              OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR/bin
 
   if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.cygwin"; then
 
@@ -54358,10 +54336,41 @@ $as_echo "$as_me: The path of OPENSSL_BUNDLE_LIB_PATH, which resolves as \"$path
     OPENSSL_BUNDLE_LIB_PATH="`cd "$path"; $THEPWDCMD -L`"
   fi
 
-         else
-           OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR
-         fi
+            fi
+          fi
+        else
+          if test -s "$OPENSSL_DIR/lib/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1"; then
+            FOUND_OPENSSL=yes
+            OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
+            OPENSSL_LIBS="-L${OPENSSL_DIR}/lib -lcrypto"
+            if test "x$BUNDLE_OPENSSL" = xyes; then
+              OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR/lib
+            fi
+          elif test -s "$OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1"; then
+            FOUND_OPENSSL=yes
+            OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
+            OPENSSL_LIBS="-L${OPENSSL_DIR} -lcrypto"
+            if test "x$BUNDLE_OPENSSL" = xyes; then
+              OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR
+            fi
+          fi
+        fi
       fi
+
+
+      #openssl is not found in user specified location. Abort.
+      if test "x$FOUND_OPENSSL" != xyes; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+        as_fn_error $? "Unable to find openssl in specified location $OPENSSL_DIR" "$LINENO" 5
+      fi
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+    fi
+
+    if test "x$OPENSSL_DIR" != x; then
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we should bundle openssl" >&5
+$as_echo_n "checking if we should bundle openssl... " >&6; }
       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $BUNDLE_OPENSSL" >&5
 $as_echo "$BUNDLE_OPENSSL" >&6; }
     fi


### PR DESCRIPTION
fixes #139 

This PR fix the path of OpenSSL crypto library from which build copies it to JDK. This is very similar to PR #134 

This fix checks for libcrypto.so.1.1 in both locations $OPENSSL_DIR/ and $OPENSSL_DIR/lib and set OPENSSL_BUNDLE_LIB_PATH accordingly. 

Signed-off-by: Bhaktavatsal Reddy <bhamaram@in.ibm.com>

