### PR TITLE
OpenJ9 JDK8 OSX Support

### DIFF
--- a/jdk/make/CreateJars.gmk
+++ b/jdk/make/CreateJars.gmk
@@ -264,7 +264,7 @@ $(IMAGES_OUTPUTDIR)/lib$(PROFILE)/_the.jars.contents: $(BUILD_TOOLS) $(IMAGES_OU
 	($(CD) $(JDK_OUTPUTDIR)/classes && \
 	$(TOOL_JARREORDER) \
 	    -o $@.tmp $(IMAGES_OUTPUTDIR)/lib/classlist $(IMAGES_OUTPUTDIR)/lib$(PROFILE)/_the.jars.exclude . )
-	$(SED) 's/\r//g' $@.tmp > $@
+	$(TR) -d '\r' < $@.tmp > $@
 	$(RM) $@.tmp
 
 $(IMAGES_OUTPUTDIR)/lib$(PROFILE)/_the.rt.jar.contents: $(IMAGES_OUTPUTDIR)/lib$(PROFILE)/_the.jars.contents

--- a/jdk/src/macosx/bin/x86_64/jvm.cfg
+++ b/jdk/src/macosx/bin/x86_64/jvm.cfg
@@ -1,3 +1,6 @@
+#
+# (c) Copyright IBM Corp. 2013, 2018 All Rights Reserved
+#
 # Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -30,5 +33,8 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
--server KNOWN
--client IGNORE
+-j9vm KNOWN
+-hotspot IGNORE
+-classic IGNORE
+-native IGNORE
+-green IGNORE


### PR DESCRIPTION
**1) sed on Mac OS doesn't recognize \r as a special character**

  \r - carriage return.

  tr on Mac OS recognizes \r. Thus, replaced sed with tr.

**2) Add jvm.cfg for Mac OSX**

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>