### PR TITLE
JDK8 OSX Support

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -373,6 +373,16 @@ define create_or_update
 	fi
 endef
 
+ifeq (1,$(OPENJ9_USE_CUSTOM_COMPILER))
+  SETUP_CUSTOM_COMPILER_ENV_VARS := \
+	DEVELOPER_DIR="$(OPENJ9_DEVELOPER_DIR)" \
+	CC="$(OPENJ9_CC)" \
+	CXX="$(OPENJ9_CXX)" \
+	#
+else
+  SETUP_CUSTOM_COMPILER_ENV_VARS :=
+endif
+
 run-preprocessors-j9 : stage-j9
 	@$(ECHO) Ensuring version information is up-to-date
 	$(call create_or_update, \
@@ -404,11 +414,11 @@ run-preprocessors-j9 : stage-j9
 build-j9 : run-preprocessors-j9
 	@$(ECHO) Compiling OpenJ9 in $(OUTPUT_ROOT)/vm
 ifeq (true,$(OPENJ9_ENABLE_CMAKE))
-	(export OPENJ9_BUILD=true $(EXPORT_MSVS_ENV_VARS) \
+	(export OPENJ9_BUILD=true $(EXPORT_MSVS_ENV_VARS) $(SETUP_CUSTOM_COMPILER_ENV_VARS) \
 		&& $(MAKE) -C $(OUTPUT_ROOT)/vm/build $(MAKEFLAGS) install \
 	)
 else
-	(export OPENJ9_BUILD=true $(EXPORT_NO_USE_MINGW) $(EXPORT_MSVS_ENV_VARS) \
+	(export OPENJ9_BUILD=true $(EXPORT_NO_USE_MINGW) $(EXPORT_MSVS_ENV_VARS) $(SETUP_CUSTOM_COMPILER_ENV_VARS) \
 		&& cd $(OUTPUT_ROOT)/vm \
 		&& $(MAKE) $(MAKEFLAGS) JAVA_VERSION=80 VERSION_MAJOR=8 all \
 	)

--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -92,3 +92,18 @@ export ac_cv_prog_CXX   := @CXX@
 MSVCP_DLL               := @MSVCP_DLL@
 
 COPY_JVM_CFG_FILE       := true
+
+ifeq ($(OPENJDK_BUILD_OS), macosx)
+  # MACOSX_DEPLOYMENT_TARGET acts similar to -mmacosx-version-min=version
+  # compiler option. If both the compiler option is specified and the
+  # environment variable is set, then the compiler option will take
+  # precedence. Here, MACOSX_DEPLOYMENT_TARGET environment variable and
+  # the compiler option will point to the same version. The environment
+  # variable is defined to support dependencies where the compiler option
+  # is not applied.
+  export MACOSX_DEPLOYMENT_TARGET := @MACOSX_VERSION_MIN@
+  ifeq ($(OPENJ9_LIBS_SUBDIR), compressedrefs)
+    # Set page zero size to 4KB for mapping memory below 4GB.
+    LDFLAGS_JDKEXE += -pagezero_size 0x1000
+  endif
+endif


### PR DESCRIPTION
**1) Use custom compiler to build OpenJ9 JDK8 on OSX**

On OSX, JDK8 is built using Xcode4.6.3 + gcc4.2. These tools won't
build OpenJ9. Tool requirements for OpenJ9 are: Xcode7.2.1 + gcc4.9.
But, Xcode7.2.1 + gcc4.9 can't be used to build JDK components.

This feature will allow a user to specify custom tools to build
OpenJ9. Usage on OSX:
```
export OPENJ9_USE_CUSTOM_COMPILER=1
export OPENJ9_DEVELOPER_DIR="/Applications/Xcode7/Xcode.app/Contents/Developer"
export OPENJ9_CC="/usr/local/bin/gcc-4.9"
export OPENJ9_CXX="/usr/local/bin/g++-4.9"
```
**2) Set MACOSX_DEPLOYMENT_TARGET and map memory below 4 GB**

- Setting `MACOSX_DEPLOYMENT_TARGET` environment variable will let OpenJ9
executables to run on OSX versions older than the OSX version on which
OpenJ9 was built. `MACOSX_DEPLOYMENT_TARGET` acts similar to 
`-mmacosx-version-min=version` compiler option. If both the compiler option 
is specified and the environment variable is set, then the compiler option will take
precedence. Here, `MACOSX_DEPLOYMENT_TARGET` environment variable and
the compiler option will point to the same version. The environment
variable is defined to support dependencies where the compiler option
is not applied. Issue: eclipse/openj9#3244

- Append "-pagezero_size 0x1000" to LDFLAGS_JDKEXE on OSX 64-bit
compressedrefs build. This allows memory to be mapped below 4GB.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>