### PR TITLE
Allow native crypto properties values YES/NO and TRUE/FALSE

### DIFF
--- a/jdk/src/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/jdk/src/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -64,18 +64,16 @@ import java.security.PrivilegedAction;
 final class CipherCore {
 
     /*
-     * Check whether native crypto is enabled with property.
+     * Check whether native crypto is disabled with property.
      *
      * By default, the native crypto is enabled and uses the native 
      * crypto library implementation.
      *
-     * The property 'jdk.nativeCBC' is used to enable Native CBC alone,
-     * 'jdk.nativeGCM' is used to enable Native GCM alone and
-     * 'jdk.nativeCrypto' is used to enable all native cryptos (Digest,
+     * The property 'jdk.nativeCBC' is used to disable Native CBC alone,
+     * 'jdk.nativeGCM' is used to disable Native GCM alone and
+     * 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
      * CBC and GCM).
      */
-    private static boolean useNativeCrypto = true;
-
     private static boolean useNativeCBC = true;
 
     private static boolean useNativeGCM = true;
@@ -1227,33 +1225,58 @@ final class CipherCore {
         cipher.updateAAD(src, offset, len);
     }
 
+    /*
+     * Get system property with privilage.
+     */
     private static String privilegedGetProperty(final String property) {
-        return AccessController.doPrivileged(new PrivilegedAction<String>() {
-            public String run() {
-                return System.getProperty(property);
-            }
+        return AccessController.doPrivileged(
+            (PrivilegedAction<String>) () -> {
+               return System.getProperty(property);
         });
     }
 
+    /* Read the native crypto properties. The value can be YES/NO or TRUE/FALSE
+     * and case insensitive.
+     *
+     * User can specify disable all native crypto and enable only specific native crypto.
+     * For example -Djdk.nativeCrypto=NO -Djdk.nativeCBC=YES.
+     */
     static {
-        String nativeCryptTrace = privilegedGetProperty("jdk.nativeCryptoTrace");
-        String nativeCryptStr   = privilegedGetProperty("jdk.nativeCrypto");
+        String nativeCryptoTrace = privilegedGetProperty("jdk.nativeCryptoTrace");
+        String nativeCryptoStr   = privilegedGetProperty("jdk.nativeCrypto");
         String nativeCBCStr     = privilegedGetProperty("jdk.nativeCBC");
         String nativeGCMStr     = privilegedGetProperty("jdk.nativeGCM");
 
-        useNativeCrypto = Boolean.parseBoolean(nativeCryptStr) || (nativeCryptStr == null);
+        if (nativeCryptoStr != null &&
+            (nativeCryptoStr.toUpperCase().equals("NO") ||
+             nativeCryptoStr.toUpperCase().equals("FALSE"))) {
+            if (nativeCBCStr == null ||
+                nativeCBCStr.toUpperCase().equals("NO") ||
+                nativeCBCStr.toUpperCase().equals("FALSE")) {
+                useNativeCBC = false;
+            }
 
-        if (!useNativeCrypto) {
-            useNativeCBC = false;
-            useNativeGCM = false;
+            if (nativeGCMStr == null ||
+                nativeGCMStr.toUpperCase().equals("NO") ||
+                nativeGCMStr.toUpperCase().equals("FALSE")) {
+                useNativeGCM = false;
+            }
         } else {
-            useNativeCBC = Boolean.parseBoolean(nativeCBCStr) || (nativeCBCStr == null);
-            useNativeGCM = Boolean.parseBoolean(nativeGCMStr) || (nativeGCMStr == null);
+            if (nativeCBCStr != null &&
+                (nativeCBCStr.toUpperCase().equals("NO") ||
+                 nativeCBCStr.toUpperCase().equals("FALSE"))) {
+                useNativeCBC = false;
+            }
+
+            if (nativeGCMStr != null &&
+                (nativeGCMStr.toUpperCase().equals("NO") ||
+                 nativeGCMStr.toUpperCase().equals("FALSE"))) {
+                useNativeGCM = false;
+            }
         }
 
         if (useNativeCBC || useNativeGCM) {
             /*
-             * User want to use native crypto implementation.
              * Make sure the native crypto libraries are loaded successfully.
              * Otherwise, throw a warning message and fall back to the in-built
              * java crypto implementation.
@@ -1262,19 +1285,19 @@ final class CipherCore {
                 useNativeCBC = false;
                 useNativeGCM = false;
 
-		if (nativeCryptTrace != null) {
-                   System.err.println("Warning: Native crypto library load failed." +
-                                   " Using Java crypto implementation");
-		}
+                if (nativeCryptoTrace != null) {
+                    System.err.println("Warning: Native crypto library load failed." +
+                                          " Using Java crypto implementation for CBC & GCM");
+                }
             } else {
-                if (nativeCryptTrace != null) {
-                   System.err.println("CipherCore Load - using native crypto library.");
+                if (nativeCryptoTrace != null) {
+                   System.err.println("Info: Using Native crypto implementation for CBC & GCM");
                 }
             }
         } else {
-                if (nativeCryptTrace != null) {
-                   System.err.println("CipherCore Load - native crypto library disabled.");
-                }
-	}
+            if (nativeCryptoTrace != null) {
+               System.err.println("Info: Using Java crypto implementation for CBC & GCM");
+            }
+        }
     }
 }

--- a/jdk/src/share/classes/sun/security/provider/SunEntries.java
+++ b/jdk/src/share/classes/sun/security/provider/SunEntries.java
@@ -91,10 +91,10 @@ final class SunEntries {
             ("jdk.security.legacyDSAKeyPairGenerator"));
 
     /*
-     * Check whether native crypto is enabled with property.
+     * Check whether native crypto is disabled with property.
      * By default, the native crypto is enabled and uses native library crypto.
-     * The property 'jdk.nativeDigest' is used to enable Native digest alone
-     * and 'jdk.nativeCrypto' is used to enable all native cryptos (Digest,
+     * The property 'jdk.nativeDigest' is used to disable Native digest alone
+     * and 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
      * CBC and GCM).
      */
     private static boolean useNativeDigest = true;
@@ -419,25 +419,37 @@ final class SunEntries {
         }
     }
 
+    /* Read the native crypto properties. The value can be YES/NO or TRUE/FALSE
+     * and case insensitive.
+     *
+     * User can specify disable all native crypto and enable only specific crypto.
+     * For example -Djdk.nativeCrypto=NO -Djdk.nativeDigest=YES.
+     */
     static {
 
-        String nativeCryptTrace = GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace");
-        String nativeCryptStr = GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto");
+        String nativeCryptoTrace = GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace");
+        String nativeCryptoStr = GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto");
         String nativeDigestStr = GetPropertyAction.privilegedGetProperty("jdk.nativeDigest");
 
-        if (Boolean.parseBoolean(nativeCryptStr) || nativeCryptStr == null) {
-                /* nativeCrypto is enabled */
-                if (!(Boolean.parseBoolean(nativeDigestStr) || nativeDigestStr == null)) {
-                        useNativeDigest = false;
-                }
-        } else {
-                /* nativeCrypto is disabled */
+        if (nativeCryptoStr != null &&
+            (nativeCryptoStr.toUpperCase().equals("NO") ||
+             nativeCryptoStr.toUpperCase().equals("FALSE"))) {
+
+            if (nativeDigestStr == null ||
+                nativeDigestStr.toUpperCase().equals("NO") ||
+                nativeDigestStr.toUpperCase().equals("FALSE")) {
                 useNativeDigest = false;
+            }
+        } else {
+            if (nativeDigestStr != null &&
+                (nativeDigestStr.toUpperCase().equals("NO") ||
+                nativeDigestStr.toUpperCase().equals("FALSE"))) {
+                useNativeDigest = false;
+            }
         }
 
         if (useNativeDigest) {
             /*
-             * User want to use native crypto implementation.
              * Make sure the native crypto libraries are loaded successfully.
              * Otherwise, throw a warning message and fall back to the in-built
              * java crypto implementation.
@@ -445,18 +457,18 @@ final class SunEntries {
             if (!NativeCrypto.isLoaded()) {
                 useNativeDigest = false;
 
-                if (nativeCryptTrace != null) {
-                   System.err.println("Warning: Native crypto library load failed." +
-                                   " Using Java crypto implementation");
+                if (nativeCryptoTrace != null) {
+                    System.err.println("Warning: Native crypto library load failed." +
+                                          " Using Java crypto implementation for Digest");
                 }
             } else {
-                if (nativeCryptTrace != null) {
-                   System.err.println("MessageDigest load - using Native crypto library.");
+                if (nativeCryptoTrace != null) {
+                   System.err.println("Info: Using Native crypto implementation for Digest");
                 }
             }
         } else {
-            if (nativeCryptTrace != null) {
-               System.err.println("MessageDigest load - Native crypto library disabled.");
+            if (nativeCryptoTrace != null) {
+               System.err.println("Info: Using Java crypto implementation for Digest");
             }
         }
     }


### PR DESCRIPTION
The following changes are included in this changeset:
   - Allow the value of native crypto properties as YES/NO in addition
      to TRUE/FALSE as it makes more sense for end user to specify
      jdk.nativeCrypto=NO insted of jdk.nativeCrypto=FALSE.
   - Made the property value case insensitive so that user can
     specify 'YES' or 'Yes' or 'yes'.
   - Allow user to specify enable all native crypto and disable
     specific crypto

Signed-off-by: Nasser Ebrahim <enasser@in.ibm.com>