### PR TITLE
Remove tools.jar from bootclasspath

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -158,7 +158,7 @@ define openj9_set_classlib_props
 $1 : $2/classlib.properties
 $2/classlib.properties : $3/classlib.properties
 	$(ECHO) Setting $1/classlib.properties
-	$(SED) -e 's/shape=vm.shape/shape=sun_openjdk\nbootpath=rt.jar:resources.jar:jsse.jar:charsets.jar:jce.jar:tools.jar/g' -e 's/version=1.9/version=1.8/g' < $$< > $$@
+	$(SED) -e 's/shape=vm.shape/shape=sun_openjdk\nbootpath=rt.jar:resources.jar:jsse.jar:charsets.jar:jce.jar/g' -e 's/version=1.9/version=1.8/g' < $$< > $$@
 endef
 
 # openj9_copy_prereq


### PR DESCRIPTION
It doesn't exist within the jre folder named by the expanded path.