### PR TITLE
Remove blank lines from jvm.cfg files

### DIFF
--- a/jdk/src/macosx/bin/x86_64/jvm.cfg
+++ b/jdk/src/macosx/bin/x86_64/jvm.cfg
@@ -30,11 +30,8 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
-
-#
 # (c) Copyright IBM Corp. 2013, 2018 All Rights Reserved
 #
-
 -j9vm KNOWN
 -hotspot IGNORE
 -classic IGNORE

--- a/jdk/src/solaris/bin/amd64/jvm.cfg
+++ b/jdk/src/solaris/bin/amd64/jvm.cfg
@@ -31,11 +31,9 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
-
 #
 # (c) Copyright IBM Corp. 2013, 2018 All Rights Reserved
 #
-
 -j9vm KNOWN
 -hotspot IGNORE
 -classic IGNORE

--- a/jdk/src/solaris/bin/ppc64/jvm.cfg
+++ b/jdk/src/solaris/bin/ppc64/jvm.cfg
@@ -30,11 +30,9 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
-
 #
 # (c) Copyright IBM Corp. 2013, 2018 All Rights Reserved
 #
-
 -j9vm KNOWN
 -hotspot IGNORE
 -classic IGNORE

--- a/jdk/src/solaris/bin/s390x/jvm.cfg
+++ b/jdk/src/solaris/bin/s390x/jvm.cfg
@@ -31,11 +31,9 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
-
 #
 # (c) Copyright IBM Corp. 2003, 2018 All Rights Reserved
 #
-
 -j9vm KNOWN
 -hotspot IGNORE
 -classic IGNORE

--- a/jdk/src/windows/bin/amd64/jvm.cfg
+++ b/jdk/src/windows/bin/amd64/jvm.cfg
@@ -31,11 +31,9 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
-
 #
 # (c) Copyright IBM Corp. 2003, 2018 All Rights Reserved
 #
-
 -j9vm KNOWN
 -server IGNORE
 -client IGNORE

--- a/jdk/src/windows/bin/i586/jvm.cfg
+++ b/jdk/src/windows/bin/i586/jvm.cfg
@@ -30,12 +30,10 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
-
 # ===========================================================================
 # (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
 # ===========================================================================
 #
-
 -j9vm KNOWN
 -server IGNORE
 -client IGNORE


### PR DESCRIPTION
The blank lines added for recent copyright updates lead to these warnings running:
`./bin/java -jar demo/jfc/Metalworks/Metalworks.jar`

```
Warning: No leading - on line 34 of .../jre/lib/amd64/jvm.cfg
Warning: Missing VM type on line 34 of .../jre/lib/amd64/jvm.cfg
```