### PR TITLE
Remove blank lines from jvm.cfg files

### DIFF
--- a/jdk/src/macosx/bin/x86_64/jvm.cfg
+++ b/jdk/src/macosx/bin/x86_64/jvm.cfg
@@ -21,11 +21,8 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-
-#
 # (c) Copyright IBM Corp. 2013, 2018 All Rights Reserved
 #
-
 # List of JVMs that can be used as an option to java, javac, etc.
 # Order is important -- first in this list is the default JVM.
 # NOTE that this both this file and its format are UNSUPPORTED and
@@ -35,7 +32,6 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
-
 -j9vm KNOWN
 -hotspot IGNORE
 -classic IGNORE

--- a/jdk/src/solaris/bin/amd64/jvm.cfg
+++ b/jdk/src/solaris/bin/amd64/jvm.cfg
@@ -21,12 +21,8 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-
-#
 # (c) Copyright IBM Corp. 2013, 2018 All Rights Reserved
 #
-
-# 
 # List of JVMs that can be used as an option to java, javac, etc.
 # Order is important -- first in this list is the default JVM.
 # NOTE that this both this file and its format are UNSUPPORTED and
@@ -36,7 +32,6 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
-
 -j9vm KNOWN
 -hotspot IGNORE
 -classic IGNORE

--- a/jdk/src/solaris/bin/ppc64/jvm.cfg
+++ b/jdk/src/solaris/bin/ppc64/jvm.cfg
@@ -21,11 +21,8 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-
-#
 # (c) Copyright IBM Corp. 2013, 2018 All Rights Reserved
 #
-
 # List of JVMs that can be used as an option to java, javac, etc.
 # Order is important -- first in this list is the default JVM.
 # NOTE that this both this file and its format are UNSUPPORTED and
@@ -35,7 +32,6 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
-
 -j9vm KNOWN
 -hotspot IGNORE
 -classic IGNORE

--- a/jdk/src/solaris/bin/s390x/jvm.cfg
+++ b/jdk/src/solaris/bin/s390x/jvm.cfg
@@ -21,12 +21,8 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-
-#
 # (c) Copyright IBM Corp. 2003, 2018 All Rights Reserved
 #
-
-# 
 # List of JVMs that can be used as an option to java, javac, etc.
 # Order is important -- first in this list is the default JVM.
 # NOTE that this both this file and its format are UNSUPPORTED and
@@ -36,7 +32,6 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
-
 -j9vm KNOWN
 -hotspot IGNORE
 -classic IGNORE

--- a/jdk/src/windows/bin/amd64/jvm.cfg
+++ b/jdk/src/windows/bin/amd64/jvm.cfg
@@ -21,11 +21,7 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-
-#
 # (c) Copyright IBM Corp. 2003, 2018 All Rights Reserved
-#
-
 #
 # List of JVMs that can be used as an option to java, javac, etc.
 # Order is important -- first in this list is the default JVM.
@@ -36,7 +32,6 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
-
 -j9vm KNOWN
 -server IGNORE
 -client IGNORE

--- a/jdk/src/windows/bin/i586/jvm.cfg
+++ b/jdk/src/windows/bin/i586/jvm.cfg
@@ -21,12 +21,8 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-
-# ===========================================================================
 # (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
-# ===========================================================================
 #
-
 # List of JVMs that can be used as an option to java, javac, etc.
 # Order is important -- first in this list is the default JVM.
 # NOTE that this both this file and its format are UNSUPPORTED and
@@ -36,7 +32,6 @@
 # "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
 # and may not be available in a future release.
 #
-
 -j9vm KNOWN
 -server IGNORE
 -client IGNORE


### PR DESCRIPTION
The blank lines added with copyright updates lead to these warnings
running:
./bin/java -jar demo/jfc/Metalworks/Metalworks.jar

Warning: No leading - on line 34 of `./jre/lib/amd64/jvm.cfg'
Warning: Missing VM type on line 34 of `./jre/lib/amd64/jvm.cfg'

This is a replay of https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/177 for the 0.11 release.