### PR TITLE
Use correct main class for TraceFormat

### DIFF
--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -422,7 +422,7 @@ $(eval $(call SetupLauncher,jdmpview, \
 
 $(eval $(call SetupLauncher,traceformat, \
     -DEXPAND_CLASSPATH_WILDCARDS \
-    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.ibm.jvm.format.TraceFormat" }'))
+    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.ibm.jvm.TraceFormat" }'))
 
 ifneq ($(findstring $(OPENJDK_TARGET_OS),aix linux),)
   $(eval $(call SetupLauncher,jextract, \


### PR DESCRIPTION
For consistency with newer Java versions.

This is a replay #169 for the 0.11 release.