### PR TITLE
Remove OpenJDK/Hotspot attach api classes

### DIFF
--- a/closed/make/CompileJavaClasses.gmk
+++ b/closed/make/CompileJavaClasses.gmk
@@ -1,0 +1,27 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+# 
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# 
+# ===========================================================================
+
+# Replace attach API classes on HotSpot with OpenJ9 implementation.
+ifeq ($(OPENJDK_TARGET_OS), windows)
+  EXFILES+=sun/tools/attach/WindowsAttachProvider.java \
+           sun/tools/attach/WindowsVirtualMachine.java
+endif

--- a/closed/make/CompileNativeLibraries.gmk
+++ b/closed/make/CompileNativeLibraries.gmk
@@ -1,0 +1,26 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+# 
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# 
+# ===========================================================================
+
+# Avoid generating attach.dll from the natives of attach APIs on Hotspot.
+ifeq ($(OPENJDK_TARGET_OS), windows)
+  BUILD_LIBRARIES := $(filter-out $(BUILD_LIBATTACH), $(BUILD_LIBRARIES))
+endif


### PR DESCRIPTION
The change is to remove these api classes
and stop them from generating attach.dll
on Windows as these classes are replaced
with the implementation in OpenJ9.

Related to https://github.com/eclipse/openj9/issues/3441

Signed-off-by: CHENGJin <jincheng@ca.ibm.com>