### PR TITLE
Adding full text of license to reorder-x86

### DIFF
--- a/jdk/make/mapfiles/libjava/reorder-x86
+++ b/jdk/make/mapfiles/libjava/reorder-x86
@@ -1,6 +1,22 @@
 # ===========================================================================
 # Portions Copyright 2018, 2018 IBM Corporation.
 # ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception 
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
 
 data = R0x2000;
 text = LOAD ?RXO;


### PR DESCRIPTION
A quote from a discussion with a legal advisor:
"we're applying [the license and CPE] to portions that IBM added."
 "I think its helpful for IBM to state the license under which we're
intending our contributions be used."

So this change is the addition of the license we're claiming IBM's code
changes to this file fall under.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>