### PR TITLE
Change MACOSX_VERSION_MIN to 10.9.0 for OpenJ9 JDK8

### DIFF
--- a/common/autoconf/flags.m4
+++ b/common/autoconf/flags.m4
@@ -23,6 +23,12 @@
 # questions.
 #
 
+#
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+#
+
 AC_DEFUN_ONCE([FLAGS_SETUP_INIT_FLAGS],
 [
   # Option used to tell the compiler whether to create 32- or 64-bit executables
@@ -574,7 +580,7 @@ AC_DEFUN_ONCE([FLAGS_SETUP_COMPILER_FLAGS_FOR_JDK],
       # newer than the given OS version and makes the linked binaries compatible 
       # even if built on a newer version of the OS.
       # The expected format is X.Y.Z
-      MACOSX_VERSION_MIN=10.7.0
+      MACOSX_VERSION_MIN=10.9.0
       AC_SUBST(MACOSX_VERSION_MIN)
     
       # The macro takes the version with no dots, ex: 1070

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -3685,6 +3685,12 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 # questions.
 #
 
+#
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+#
+
 
 
 
@@ -4336,7 +4342,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1541112610
+DATE_WHEN_GENERATED=1542039989
 
 ###############################################################################
 #
@@ -41771,7 +41777,7 @@ $as_echo "$supports" >&6; }
       # newer than the given OS version and makes the linked binaries compatible
       # even if built on a newer version of the OS.
       # The expected format is X.Y.Z
-      MACOSX_VERSION_MIN=10.7.0
+      MACOSX_VERSION_MIN=10.9.0
 
 
       # The macro takes the version with no dots, ex: 1070

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -3751,6 +3751,12 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 # questions.
 #
 
+#
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+#
+
 
 
 
@@ -4447,7 +4453,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1541112610
+DATE_WHEN_GENERATED=1542039989
 
 ###############################################################################
 #
@@ -43915,7 +43921,7 @@ $as_echo "$supports" >&6; }
       # newer than the given OS version and makes the linked binaries compatible
       # even if built on a newer version of the OS.
       # The expected format is X.Y.Z
-      MACOSX_VERSION_MIN=10.7.0
+      MACOSX_VERSION_MIN=10.9.0
 
 
       # The macro takes the version with no dots, ex: 1070


### PR DESCRIPTION
For OpenJ9 JDK8 on OSX, the JIT can't be built with MACOSX_VERSION_MIN
<= 10.8.0 using Xcode7 + clang. JIT needs libc++ which is only available when
MACOSX_VERSION_MIN is set to 10.9.0 or greater. With MACOSX_VERSION_MIN
<= 10.8.0, the Xcode7 build tools only provide an old version of stdlibc++, which
can't be used to build the JIT.

Thus, changing MACOSX_VERSION_MIN from 10.7.0 to 10.9.0 in order to
support the JIT when building OpenJ9 JDK8 on OSX using Xcode7 + clang.

Invoked autogen.sh.

Signed-off-by: Babneet Singh sbabneet@ca.ibm.com