### PR TITLE
Remove unused IncludeCustomExtension macro

### DIFF
--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -4,10 +4,10 @@
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
 # published by the Free Software Foundation.
-# 
+#
 # IBM designates this particular file as subject to the "Classpath" exception
 # as provided by IBM in the LICENSE file that accompanied this code.
-# 
+#
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 # FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
@@ -18,23 +18,7 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
-# This macro is called to allow inclusion of closed source counterparts.
-# If running without closed sources, it expands to nothing.
-# Usage: This function is called in an open makefile, with the following
-# arguments:
-# $1 the name of the repo, or empty if the top-level repo.
-# $2 the name of the makefile
-define IncludeCustomExtension
-  ifndef OPENJDK
-    custom_dir := closed/make
-    custom_include_file := $$(SRC_ROOT)/$$(custom_dir)/$(strip $2)
-    ifneq ($$(wildcard $$(custom_include_file)), )
-      include $$(custom_include_file)
-    endif
-  endif
-endef
-
-# Remove -R from MAKE settings as needed for omr compilation rules
+# Remove -R from MAKE settings as some built-in rules are needed for OMR.
 MAKE := $(filter-out -R,$(MAKE))
 
 OPENJ9_TOPDIR           := @OPENJ9_TOPDIR@
@@ -73,7 +57,7 @@ OPENJDK_TAG             := @OPENJDK_TAG@
 
 JDK_MOD_VERSION         := @JDK_MOD_VERSION@
 JDK_FIX_VERSION         := @JDK_FIX_VERSION@
-# J9JDK_EXT_VERSION := ${JDK_MINOR_VERSION}.${JDK_MICRO_VERSION}.${JDK_MOD_VERSION}.${JDK_FIX_VERSION}
+J9JDK_EXT_VERSION       := $(JDK_MINOR_VERSION).$(JDK_MICRO_VERSION).$(JDK_MOD_VERSION).$(JDK_FIX_VERSION)
 J9JDK_EXT_VERSION       := HEAD
 J9JDK_EXT_NAME          := Extensions for OpenJDK for Eclipse OpenJ9
 


### PR DESCRIPTION
Also, use `$()` for macro references for consistency.