### PR TITLE
Put jsig libraries in the correct places

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -95,6 +95,21 @@ $(foreach subdir, j9vm server, \
 		FILES := $(call SHARED_LIBRARY,jvm) \
 		)))
 
+# jsig
+
+$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
+	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR), \
+	SRC := $(OUTPUT_ROOT)/vm, \
+	FILES := $(call SHARED_LIBRARY,jsig) \
+	))
+
+$(foreach subdir, j9vm server, \
+	$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
+		DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(subdir), \
+		SRC := $(OUTPUT_ROOT)/vm, \
+		FILES := $(call SHARED_LIBRARY,jsig) \
+	)))
+
 # regular shared libraries
 
 $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
@@ -119,7 +134,6 @@ $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
 		j9vrb29 \
 		j9zlib29 \
 		jclse7b_29 \
-		jsig \
 		jvm \
 		management \
 		management_ext \
@@ -127,11 +141,18 @@ $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
 	))
 
 ifeq (windows,$(OPENJDK_TARGET_OS))
+
 $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
 	DEST := $(JDK_OUTPUTDIR)/lib, \
 	SRC := $(OUTPUT_ROOT)/vm/lib, \
-	FILES := $(call STATIC_LIBRARY,jvm) \
+	FILES := $(call STATIC_LIBRARY,jsig) \
 	))
+
+$(JDK_OUTPUTDIR)/lib/$(call STATIC_LIBRARY,jvm) : $(OUTPUT_ROOT)/vm/redirector/$(call STATIC_LIBRARY,redirector_jvm)
+	$(install-file)
+
+OPENJ9_STAGED_FILES += $(JDK_OUTPUTDIR)/lib/$(call STATIC_LIBRARY,jvm)
+
 endif # windows
 
 # classlib.properties


### PR DESCRIPTION
* On Windows the shared library should be in `bin`, `bin/j9vm` and `bin/server` (in an SDK, the static library should be in `lib`).
* On other platforms, the shared library should be in `lib/{arch}`, `lib/{arch}/j9vm` and `lib/{arch}/server`.