### PR TITLE
Restoring ResourceBundle to the OpenJDK version

### DIFF
--- a/jdk/src/share/classes/java/util/ResourceBundle.java
+++ b/jdk/src/share/classes/java/util/ResourceBundle.java
@@ -24,11 +24,9 @@
  */
 
 /*
- * ===========================================================================
- * (c) Copyright Taligent, Inc. 1996, 1997 All Rights Reserved
- * ===========================================================================
- * (c) Copyright IBM Corp. 1996, 2018 All Rights Reserved
- * ===========================================================================
+ * (C) Copyright Taligent, Inc. 1996, 1997 - All Rights Reserved
+ * (C) Copyright IBM Corp. 1996 - 1999 - All Rights Reserved
+ *
  * The original version of this source code and documentation
  * is copyrighted and owned by Taligent, Inc., a wholly-owned
  * subsidiary of IBM. These materials are provided under terms
@@ -37,7 +35,7 @@
  *
  * This notice and attribution to Taligent may not be removed.
  * Taligent is a registered trademark of Taligent, Inc.
- * ===========================================================================
+ *
  */
 
 package java.util;
@@ -1322,13 +1320,6 @@ public abstract class ResourceBundle {
         return Control.INSTANCE;
     }
 
-    /**
-     * volatile reference object to guard the ClassLoader object
-     * being garbage collected before getBundleImpl() method completes
-     * the caching and retrieving of requested Resourcebundle object
-     */
-    private static volatile Object vo = new Object();
-
     private static ResourceBundle getBundleImpl(String baseName, Locale locale,
                                                 ClassLoader loader, Control control) {
         if (locale == null || control == null) {
@@ -1407,13 +1398,15 @@ public abstract class ResourceBundle {
             bundle = baseBundle;
         }
 
-        //The OpenJ9 GC might collect the loader before we return here. This prevents that.
-        try {
-            return bundle;
-        } finally {
-            //Should never be true. Using the loader here prevents it being GC'd.
-            if (loader == vo) throw new Error("Unexpected error.");
-        }
+        keepAlive(loader);
+        return bundle;
+    }
+
+    /**
+     * Keeps the argument ClassLoader alive.
+     */
+    private static void keepAlive(ClassLoader loader){
+        // Do nothing.
     }
 
     /**


### PR DESCRIPTION
The latest ResourceBundle.java in a tagged version of OpenJDK8
contains a fix that renders our patch here superfluous.

Replacing this file with the version from OpenJDK8.

Note that this file will be different from master until we update
master again, just prior to the next release.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>