### PR TITLE
Include j9aixbaddep in test-image artifacts

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -235,6 +235,7 @@ $(foreach file, \
 		bcvwhite \
 		gptest \
 		hooktests \
+		j9aixbaddep \
 		j9ben \
 		j9lazyClassLoad \
 		j9thrnumanatives29 \


### PR DESCRIPTION
Fixes: eclipse/openj9#3942