### PR TITLE
OpenSSL Support: Changes to support on Mac OSX platform

### DIFF
--- a/closed/openssl.gmk
+++ b/closed/openssl.gmk
@@ -33,20 +33,13 @@ include $(SPEC)
 #     For Linux ppc64le, it is linux-ppc64le
 #     For Linux s390x, it is linux64-s390x
 #     For Linux x64, it is linux-x86_64
+#     For Mac OSX, it is darwin64-x86_64-cc
 #     For Windows x64, it is VC-WIN64A
 #     For Windows x32, it is VC-WIN32
 build_openssl:
 ifeq ($(BUILD_OPENSSL), yes)
 	$(ECHO) Compiling OpenSSL in $(OPENSSL_DIR)
-  ifeq ($(OPENJDK_TARGET_OS), aix)
-	($(CD) $(OPENSSL_DIR) && ./Configure aix64-cc && $(MAKE))
-  else ifeq ($(OPENJDK_TARGET_OS), windows)
-    ifeq ($(OPENJDK_TARGET_CPU), x86_64)
-	($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN64A && $(MAKE))
-    else
-	($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN32 && $(MAKE))
-    endif
-  else ifeq ($(OPENJDK_TARGET_OS), linux)
+  ifeq ($(OPENJDK_TARGET_OS), linux)
     ifeq ($(OPENJDK_TARGET_CPU), x86_64)
 	($(CD) $(OPENSSL_DIR) && ./Configure linux-x86_64 && $(MAKE))
     else ifeq ($(OPENJDK_TARGET_CPU), s390x)
@@ -56,6 +49,18 @@ ifeq ($(BUILD_OPENSSL), yes)
     else
 	($(CD) $(OPENSSL_DIR) && ./config && $(MAKE))
     endif
+  else ifeq ($(OPENJDK_TARGET_OS), macosx)
+	($(CD) $(OPENSSL_DIR) && ./Configure darwin64-x86_64-cc -shared  && $(MAKE))
+  else ifeq ($(OPENJDK_TARGET_OS), windows)
+    ifeq ($(OPENJDK_TARGET_CPU), x86_64)
+	($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN64A && $(MAKE))
+    else
+	($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN32 && $(MAKE))
+    endif
+  else ifeq ($(OPENJDK_TARGET_OS), aix)
+	($(CD) $(OPENSSL_DIR) && ./Configure aix64-cc && $(MAKE))
+  else
+	($(CD) $(OPENSSL_DIR) && ./config && $(MAKE))
   endif
 endif
 

--- a/jdk/make/CopyFiles.gmk
+++ b/jdk/make/CopyFiles.gmk
@@ -250,37 +250,44 @@ ifneq ($(FREETYPE_BUNDLE_LIB_PATH), )
 endif
 
 ##########################################################################################
-
-# Copy OpenSSL Crypto Lbrary
+# Optionally copy OpenSSL Crypto Lbrary
 ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
-  ifeq ($(OPENJDK_TARGET_OS), windows)
+  ifeq ($(OPENJDK_TARGET_OS), linux)
+    OPENSSL_LIB_NAME = libcrypto.so.1.1
+  else ifeq ($(OPENJDK_TARGET_OS), macosx)
+    OPENSSL_LIB_NAME = libcrypto.1.1.dylib
+  else ifeq ($(OPENJDK_TARGET_OS), windows)
     ifeq ($(OPENJDK_TARGET_CPU_BITS), 64)
       OPENSSL_LIB_NAME = libcrypto-1_1-x64.dll
     else
       OPENSSL_LIB_NAME = libcrypto-1_1.dll
     endif
-    OPENSSL_TARGET_LIB = $(JDK_OUTPUTDIR)/bin/$(OPENSSL_LIB_NAME)
   else ifeq ($(OPENJDK_TARGET_OS), aix)
-    #OpenSSL 1.1.1 on AIX has switched to use archive library files (natural way) instead of '.so' files.
-    #  For reference, corresponding OpenSSL PR is https://github.com/openssl/openssl/pull/6487
-    #OpenSSL v1.1.0 crypto library to bundle with JDK
+    # OpenSSL 1.1.1 on AIX has switched to use archive library files (natural way)
+    # instead of 'libcrypto.so' files.
+    # For reference, corresponding OpenSSL PR is
+    #     https://github.com/openssl/openssl/pull/6487
+    # For OpenSSL v1.1.0, bundle libcrypto.so library with JDK
     OPENSSL_LIB_NAME = libcrypto.so
     ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-      #OpenSSL v1.1.1 crypto library to bundle with JDK
+      # For OpenSSL v1.1.1, bundle libcrypto.a library with JDK
       OPENSSL_LIB_NAME = libcrypto.a
     endif
-    OPENSSL_TARGET_LIB = $(JDK_OUTPUTDIR)/lib$(OPENJDK_TARGET_CPU_LIBDIR)/$(OPENSSL_LIB_NAME)
   else
-    OPENSSL_LIB_NAME = libcrypto.so.1.1
+    OPENSSL_LIB_NAME = libcrypto.so
+  endif
+
+  ifeq ($(OPENJDK_TARGET_OS), windows)
+    OPENSSL_TARGET_LIB = $(JDK_OUTPUTDIR)/bin/$(OPENSSL_LIB_NAME)
+  else
     OPENSSL_TARGET_LIB = $(JDK_OUTPUTDIR)/lib$(OPENJDK_TARGET_CPU_LIBDIR)/$(OPENSSL_LIB_NAME)
   endif
 
- 
   $(OPENSSL_TARGET_LIB): $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME)
 	$(CP) $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME) $@
-        ifeq ($(OPENJDK_BUILD_OS), windows)
-	  $(CHMOD) +rx $@
-        endif
+    ifeq ($(OPENJDK_BUILD_OS), windows)
+	$(CHMOD) +rx $@
+    endif
 
   COPY_FILES += $(OPENSSL_TARGET_LIB)
 endif


### PR DESCRIPTION
The following changes are required to support openssl on Mac OSX.
  - Add the darwin compiler option to configure
  - Copy libcrypto.1.1.dylib to jdk with --enable-openssl-bundling

Signed-off-by: Nasser Ebrahim <enasser@in.ibm.com>