### PR TITLE
Dynamic loading of crypto library and support for OpenSSL 1.0.2

### DIFF
--- a/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,13 @@ public class NativeCrypto {
             public Void run() {
                 try {
                     System.loadLibrary("jncrypto"); // check for native library
-                    loaded = true;
+
+                    // load OpenSSL crypto library dynamically.
+                    if (loadCrypto() == 0) { 
+                        loaded = true;
+                    } else {
+                        loaded = false;
+                    }
                 } catch (UnsatisfiedLinkError usle) {
                     loaded = false;
                 }
@@ -50,6 +56,8 @@ public class NativeCrypto {
     }
 
     /* Native digest interfaces */
+    public static final native int loadCrypto();
+
     public static final native long DigestCreateContext(long nativeBuffer,
                                                         int algoIndex);
 

--- a/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto.c
+++ b/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,13 +26,78 @@
 #include <openssl/aes.h>
 #include <openssl/err.h>
 
+#include <assert.h>
 #include <jni.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "jdk_crypto_jniprovider_NativeCrypto.h"
+#include "NativeCrypto_md.h"
+
+//Type definitions of function pointers
+typedef char * OSSL_error_string_t(unsigned long, char *);
+typedef unsigned long OSSL_get_error_t();
+typedef const EVP_MD* OSSL_sha_t();
+typedef EVP_MD_CTX* OSSL_MD_CTX_new_t();
+typedef int OSSL_DigestInit_ex_t(EVP_MD_CTX *, const EVP_MD *, ENGINE *);
+typedef int OSSL_MD_CTX_copy_ex_t(EVP_MD_CTX *, const EVP_MD_CTX *);
+typedef int OSSL_DigestUpdate_t(EVP_MD_CTX *, const void *, size_t);
+typedef int OSSL_DigestFinal_ex_t(EVP_MD_CTX *, unsigned char *, unsigned int *);
+typedef int OSSL_MD_CTX_reset_t(EVP_MD_CTX *);
+typedef EVP_CIPHER_CTX* OSSL_CIPHER_CTX_new_t();
+typedef void OSSL_CIPHER_CTX_free_t(EVP_CIPHER_CTX *);
+typedef const EVP_CIPHER* OSSL_aes_t();
+typedef int OSSL_CipherInit_ex_t(EVP_CIPHER_CTX *, const EVP_CIPHER *,
+                              ENGINE *, const unsigned char *, const unsigned char *, int);
+typedef int OSSL_CIPHER_CTX_set_padding_t(EVP_CIPHER_CTX *, int);
+typedef int OSSL_CipherUpdate_t(EVP_CIPHER_CTX *, unsigned char *, int *,
+                              const unsigned char *, int);
+typedef int OSSL_CipherFinal_ex_t(EVP_CIPHER_CTX *, unsigned char *, int *);
+typedef int OSSL_CIPHER_CTX_ctrl_t(EVP_CIPHER_CTX *, int, int, void *);
+typedef int OSSL_DecryptInit_ex_t(EVP_CIPHER_CTX *, const EVP_CIPHER *,
+                             ENGINE *, const unsigned char *, const unsigned char *);
+typedef int OSSL_DecryptUpdate_t(EVP_CIPHER_CTX *, unsigned char *, int *,
+                             const unsigned char *, int);
+typedef int OSSL_DecryptFinal_t(EVP_CIPHER_CTX *, unsigned char *, int *);
+
+
+//Define pointers for OpenSSL functions to handle Errors.
+OSSL_error_string_t* OSSL_error_string;
+OSSL_get_error_t* OSSL_get_error;
+
+//Define pointers for OpenSSL functions to handle Message Digest algorithms.
+OSSL_sha_t* OSSL_sha1;
+OSSL_sha_t* OSSL_sha256;
+OSSL_sha_t* OSSL_sha224;
+OSSL_sha_t* OSSL_sha384;
+OSSL_sha_t* OSSL_sha512;
+OSSL_MD_CTX_new_t* OSSL_MD_CTX_new;
+OSSL_DigestInit_ex_t* OSSL_DigestInit_ex;
+OSSL_MD_CTX_copy_ex_t* OSSL_MD_CTX_copy_ex;
+OSSL_DigestUpdate_t* OSSL_DigestUpdate;
+OSSL_DigestFinal_ex_t* OSSL_DigestFinal_ex;
+OSSL_MD_CTX_reset_t* OSSL_MD_CTX_reset;
+
+//Define pointers for OpenSSL functions to handle CBC and GCM Cipher algorithms.
+OSSL_CIPHER_CTX_new_t* OSSL_CIPHER_CTX_new;
+OSSL_CIPHER_CTX_free_t* OSSL_CIPHER_CTX_free;
+OSSL_aes_t* OSSL_aes_128_cbc;
+OSSL_aes_t* OSSL_aes_192_cbc;
+OSSL_aes_t* OSSL_aes_256_cbc;
+OSSL_CipherInit_ex_t* OSSL_CipherInit_ex;
+OSSL_CIPHER_CTX_set_padding_t* OSSL_CIPHER_CTX_set_padding;
+OSSL_CipherUpdate_t* OSSL_CipherUpdate;
+OSSL_CipherFinal_ex_t* OSSL_CipherFinal_ex;
+
+//Define pointers for OpenSSL functions to handle GCM algorithm.
+OSSL_aes_t* OSSL_aes_128_gcm;
+OSSL_aes_t* OSSL_aes_192_gcm;
+OSSL_aes_t* OSSL_aes_256_gcm;
+OSSL_CIPHER_CTX_ctrl_t* OSSL_CIPHER_CTX_ctrl;
+OSSL_DecryptInit_ex_t* OSSL_DecryptInit_ex;
+OSSL_DecryptUpdate_t* OSSL_DecryptUpdate;
+OSSL_DecryptFinal_t* OSSL_DecryptFinal;
 
 /* Structure for OpenSSL Digest context */
 typedef struct OpenSSLMDContext {
@@ -56,14 +121,158 @@ static void handleErrors(void) {
 
     printf("An error occurred\n");
 
-    while(errCode = ERR_get_error())
+    while(errCode = (*OSSL_get_error)())
     {
-        char *err = ERR_error_string(errCode, NULL);
+        char *err = (*OSSL_error_string)(errCode, NULL);
         printf("Generating error message\n" );
         printf("%s\n", err);
     }
     abort();
 }
+
+/*
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    loadCrypto
+ * Signature: ()V
+ */
+JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
+  (JNIEnv *env, jclass thisObj){
+
+    void *handle;
+    char *error;
+    typedef const char* OSSL_version_t(int);
+
+     // Determine the version of OpenSSL.
+    OSSL_version_t* OSSL_version;
+    const char * openssl_version;
+    int ossl_ver;
+
+
+    // Load OpenSSL Crypto library
+    handle = load_crypto_library();
+    if (handle == NULL) {
+        fprintf(stderr, "FAILED TO LOAD OPENSSL CRYPTO LIBRARY\n");
+        fflush(stderr);
+        return -1;
+    }
+
+    // Different symbols are used by OpenSSL with 1.0 and 1.1.
+    // The symbol 'OpenSSL_version' is used by OpenSSL 1.1 where as
+    // the symbol "SSLeay_version" is used by OpenSSL 1.0.
+    // Currently only openssl 1.0.2 and 1.1.0 and 1.1.1 are supported.
+    OSSL_version = (OSSL_version_t*)find_crypto_symbol(handle, "OpenSSL_version");
+
+    if (OSSL_version == NULL)  {
+        OSSL_version = (OSSL_version_t*)find_crypto_symbol(handle, "SSLeay_version");
+
+        if (OSSL_version == NULL)  {
+            fprintf(stderr, "Only openssl 1.0.2 and 1.1.0 and 1.1.1 are supported\n");
+            fflush(stderr);
+            unload_crypto_library(handle);
+            return -1;
+        } else {
+            openssl_version = (*OSSL_version)(0); //get OPENSSL_VERSION
+            //Ensure the OpenSSL version is "OpenSSL 1.0.2"
+            if (strncmp(openssl_version, "OpenSSL 1.0.2", 13) != 0) {
+                fprintf(stderr, "Incompatable OpenSSL version: %s\n", openssl_version);
+                fflush(stderr);
+                unload_crypto_library(handle);
+                return -1;
+            }
+            ossl_ver = 0;
+        }
+    } else {
+        openssl_version = (*OSSL_version)(0); //get OPENSSL_VERSION
+        //Ensure the OpenSSL version is "OpenSSL 1.1.0" or "OpenSSL 1.1.0".
+        if (strncmp(openssl_version, "OpenSSL 1.1.0", 13) != 0 &&
+            strncmp(openssl_version, "OpenSSL 1.1.1", 13) != 0) {
+            fprintf(stderr, "Incompatable OpenSSL version: %s\n", openssl_version);
+            fflush(stderr);
+            unload_crypto_library(handle);
+            return -1;
+        }
+        ossl_ver = 1;
+    }
+
+    // Load the function symbols for OpenSSL errors.
+    OSSL_error_string = (OSSL_error_string_t*)find_crypto_symbol(handle, "ERR_error_string");
+    OSSL_get_error = (OSSL_get_error_t*)find_crypto_symbol(handle, "ERR_get_error");
+
+    //Load the function symbols for OpenSSL Message Digest algorithms.
+    OSSL_sha1 = (OSSL_sha_t*)find_crypto_symbol(handle, "EVP_sha1");
+    OSSL_sha256 = (OSSL_sha_t*)find_crypto_symbol(handle, "EVP_sha256");
+    OSSL_sha224 = (OSSL_sha_t*)find_crypto_symbol(handle, "EVP_sha224");
+    OSSL_sha384 = (OSSL_sha_t*)find_crypto_symbol(handle, "EVP_sha384");
+    OSSL_sha512 = (OSSL_sha_t*)find_crypto_symbol(handle, "EVP_sha512");
+
+    if (ossl_ver == 1) {
+        OSSL_MD_CTX_new = (OSSL_MD_CTX_new_t*)find_crypto_symbol(handle, "EVP_MD_CTX_new");
+        OSSL_MD_CTX_reset = (OSSL_MD_CTX_reset_t*)find_crypto_symbol(handle, "EVP_MD_CTX_reset");
+    } else {
+        OSSL_MD_CTX_new = (OSSL_MD_CTX_new_t*)find_crypto_symbol(handle, "EVP_MD_CTX_create");
+        OSSL_MD_CTX_reset = (OSSL_MD_CTX_reset_t*)find_crypto_symbol(handle, "EVP_MD_CTX_cleanup");
+    }
+
+    OSSL_DigestInit_ex = (OSSL_DigestInit_ex_t*)find_crypto_symbol(handle, "EVP_DigestInit_ex");
+    OSSL_MD_CTX_copy_ex = (OSSL_MD_CTX_copy_ex_t*)find_crypto_symbol(handle, "EVP_MD_CTX_copy_ex");
+    OSSL_DigestUpdate = (OSSL_DigestUpdate_t*)find_crypto_symbol(handle, "EVP_DigestUpdate");
+    OSSL_DigestFinal_ex = (OSSL_DigestFinal_ex_t*)find_crypto_symbol(handle, "EVP_DigestFinal_ex");
+
+    //Load the function symbols for OpenSSL CBC and GCM Cipher algorithms.
+    OSSL_CIPHER_CTX_new = (OSSL_CIPHER_CTX_new_t*)find_crypto_symbol(handle, "EVP_CIPHER_CTX_new");
+    OSSL_CIPHER_CTX_free = (OSSL_CIPHER_CTX_free_t*)find_crypto_symbol(handle, "EVP_CIPHER_CTX_free");
+    OSSL_aes_128_cbc = (OSSL_aes_t*)find_crypto_symbol(handle, "EVP_aes_128_cbc");
+    OSSL_aes_192_cbc = (OSSL_aes_t*)find_crypto_symbol(handle, "EVP_aes_192_cbc");
+    OSSL_aes_256_cbc = (OSSL_aes_t*)find_crypto_symbol(handle, "EVP_aes_256_cbc");
+    OSSL_CipherInit_ex = (OSSL_CipherInit_ex_t*)find_crypto_symbol(handle, "EVP_CipherInit_ex");
+    OSSL_CIPHER_CTX_set_padding = (OSSL_CIPHER_CTX_set_padding_t*)find_crypto_symbol(handle, "EVP_CIPHER_CTX_set_padding");
+    OSSL_CipherUpdate = (OSSL_CipherUpdate_t*)find_crypto_symbol(handle, "EVP_CipherUpdate");
+    OSSL_CipherFinal_ex = (OSSL_CipherFinal_ex_t*)find_crypto_symbol(handle, "EVP_CipherFinal_ex");
+    OSSL_aes_128_gcm = (OSSL_aes_t*)find_crypto_symbol(handle, "EVP_aes_128_gcm");
+    OSSL_aes_192_gcm = (OSSL_aes_t*)find_crypto_symbol(handle, "EVP_aes_192_gcm");
+    OSSL_aes_256_gcm = (OSSL_aes_t*)find_crypto_symbol(handle, "EVP_aes_256_gcm");
+    OSSL_CIPHER_CTX_ctrl = (OSSL_CIPHER_CTX_ctrl_t*)find_crypto_symbol(handle, "EVP_CIPHER_CTX_ctrl");
+    OSSL_DecryptInit_ex = (OSSL_DecryptInit_ex_t*)find_crypto_symbol(handle, "EVP_DecryptInit_ex");
+    OSSL_DecryptUpdate = (OSSL_DecryptUpdate_t*)find_crypto_symbol(handle, "EVP_DecryptUpdate");
+    OSSL_DecryptFinal = (OSSL_DecryptFinal_t*)find_crypto_symbol(handle, "EVP_DecryptFinal");
+
+    if ((OSSL_error_string == NULL) ||
+        (OSSL_get_error == NULL) ||
+        (OSSL_sha1 == NULL) ||
+        (OSSL_sha256 == NULL) ||
+        (OSSL_sha224 == NULL) ||
+        (OSSL_sha384 == NULL) ||
+        (OSSL_sha512 == NULL) ||
+        (OSSL_MD_CTX_new == NULL) ||
+        (OSSL_MD_CTX_reset == NULL) ||
+        (OSSL_DigestInit_ex == NULL) ||
+        (OSSL_MD_CTX_copy_ex == NULL) ||
+        (OSSL_DigestUpdate == NULL) ||
+        (OSSL_DigestFinal_ex == NULL) ||
+        (OSSL_CIPHER_CTX_new == NULL) ||
+        (OSSL_CIPHER_CTX_free == NULL) ||
+        (OSSL_aes_128_cbc == NULL) ||
+        (OSSL_aes_192_cbc == NULL) ||
+        (OSSL_aes_256_cbc == NULL) ||
+        (OSSL_CipherInit_ex == NULL) ||
+        (OSSL_CIPHER_CTX_set_padding == NULL) ||
+        (OSSL_CipherUpdate == NULL) ||
+        (OSSL_CipherFinal_ex == NULL) ||
+        (OSSL_aes_128_gcm == NULL) ||
+        (OSSL_aes_192_gcm == NULL) ||
+        (OSSL_aes_256_gcm == NULL) ||
+        (OSSL_CIPHER_CTX_ctrl == NULL) ||
+        (OSSL_DecryptInit_ex == NULL) ||
+        (OSSL_DecryptUpdate == NULL) ||
+        (OSSL_DecryptFinal == NULL)) {
+        fprintf(stderr, "One or more of the required symbols are missing in the crypto library\n");
+        fflush(stderr);
+        unload_crypto_library(handle);
+        return -1;
+    } else {
+        return 0;
+    }
+ }
 
 /* Create Digest context
  *
@@ -80,28 +289,28 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestCreateCon
 
     switch (algoIdx) {
         case 0:
-            digestAlg = EVP_sha1();
+            digestAlg = (*OSSL_sha1)();
             break;
         case 1:
-            digestAlg = EVP_sha256();
+            digestAlg = (*OSSL_sha256)();
             break;
         case 2:
-            digestAlg = EVP_sha224();
+            digestAlg = (*OSSL_sha224)();
             break;
         case 3:
-            digestAlg = EVP_sha384();
+            digestAlg = (*OSSL_sha384)();
             break;
         case 4:
-            digestAlg = EVP_sha512();
+            digestAlg = (*OSSL_sha512)();
             break;
         default:
             assert(0);
     }
 
-    if((ctx = EVP_MD_CTX_new()) == NULL)
+    if((ctx = (*OSSL_MD_CTX_new)()) == NULL)
         handleErrors();
 
-    if(1 != EVP_DigestInit_ex(ctx, digestAlg, NULL))
+    if(1 != (*OSSL_DigestInit_ex)(ctx, digestAlg, NULL))
         handleErrors();
 
     context = malloc(sizeof(OpenSSLMDContext));
@@ -110,11 +319,11 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestCreateCon
 
     if (copyContext != 0) {
         EVP_MD_CTX *contextToCopy = ((OpenSSLMDContext*) copyContext)->ctx;
-        EVP_MD_CTX_copy_ex(ctx,contextToCopy);
+        (*OSSL_MD_CTX_copy_ex)(ctx,contextToCopy);
     }
 
 
-    return (long)context;
+    return (jlong)context;
 }
 
 /* Update Digest context
@@ -131,7 +340,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestUpdate
 
     if (message == NULL) {
         // Data passed in through direct byte buffer
-        if (1 != EVP_DigestUpdate(context->ctx, context->nativeBuffer, messageLen))
+        if (1 != (*OSSL_DigestUpdate)(context->ctx, context->nativeBuffer, messageLen))
             handleErrors();
     } else {
         unsigned char* messageNative = (*env)->GetPrimitiveArrayCritical(env, message, 0);
@@ -139,7 +348,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestUpdate
             return -1;
         }
 
-        if (1 != EVP_DigestUpdate(context->ctx, (messageNative + messageOffset), messageLen))
+        if (1 != (*OSSL_DigestUpdate)(context->ctx, (messageNative + messageOffset), messageLen))
             handleErrors();
 
         (*env)->ReleasePrimitiveArrayCritical(env, message, messageNative, 0);
@@ -170,7 +379,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestComputeAnd
             return -1;
         }
 
-        if (1 != EVP_DigestUpdate(context->ctx, (messageNative + messageOffset), messageLen))
+        if (1 != (*OSSL_DigestUpdate)(context->ctx, (messageNative + messageOffset), messageLen))
             handleErrors();
         (*env)->ReleasePrimitiveArrayCritical(env, message, messageNative, 0);
     }
@@ -180,14 +389,14 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_DigestComputeAnd
         return -1;
     }
 
-    if (1 != EVP_DigestFinal_ex(context->ctx, (digestNative + digestOffset), &size))
+    if (1 != (*OSSL_DigestFinal_ex)(context->ctx, (digestNative + digestOffset), &size))
         handleErrors();
 
     (*env)->ReleasePrimitiveArrayCritical(env, digest, digestNative, 0);
 
-    EVP_MD_CTX_reset(context->ctx);
+    (*OSSL_MD_CTX_reset)(context->ctx);
 
-    if (1 != EVP_DigestInit_ex(context->ctx, context->digestAlg, NULL))
+    if (1 != (*OSSL_DigestInit_ex)(context->ctx, context->digestAlg, NULL))
         handleErrors();
 
     return size;
@@ -205,11 +414,8 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_CBCCreateContex
     EVP_CIPHER_CTX *ctx = NULL;
     OpenSSLCipherContext *context = NULL;
 
-    OpenSSL_add_all_algorithms();
-    ERR_load_crypto_strings();
-
     /* Create and initialise the context */
-    if (!(ctx = EVP_CIPHER_CTX_new()))
+    if ((ctx = (*OSSL_CIPHER_CTX_new)()) == NULL)
         handleErrors();
 
     context = malloc(sizeof(OpenSSLCipherContext));
@@ -217,7 +423,7 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_CBCCreateContex
     context->nativeBuffer2 = (unsigned char*)nativeBuffer2;
     context->ctx = ctx;
 
-    return (long)context;
+    return (jlong)context;
 }
 
 /* Destroy Cipher context
@@ -231,9 +437,9 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_CBCDestroyConte
 
      OpenSSLCipherContext *context = (OpenSSLCipherContext*) c;
 
-     EVP_CIPHER_CTX_free(context->ctx);
+     (*OSSL_CIPHER_CTX_free)(context->ctx);
      free(context);
-
+     return 0;
 }
 
 /* Initialize CBC context
@@ -253,14 +459,16 @@ JNIEXPORT void JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_CBCInit
 
     switch(key_len) {
         case 16:
-            evp_cipher1 = EVP_aes_128_cbc();
+            evp_cipher1 = (*OSSL_aes_128_cbc)();
             break;
         case 24:
-            evp_cipher1 = EVP_aes_192_cbc();
+            evp_cipher1 = (*OSSL_aes_192_cbc)();
             break;
         case 32:
-            evp_cipher1 = EVP_aes_256_cbc();
+            evp_cipher1 = (*OSSL_aes_256_cbc)();
             break;
+        default:
+            assert(32);
     }
 
     ivNative = (unsigned char*)((*env)->GetByteArrayElements(env, iv, 0));
@@ -273,10 +481,10 @@ JNIEXPORT void JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_CBCInit
         return;
     }
 
-    if (1 != EVP_CipherInit_ex(ctx, evp_cipher1, NULL, keyNative, ivNative, mode))
+    if (1 != (*OSSL_CipherInit_ex)(ctx, evp_cipher1, NULL, keyNative, ivNative, mode))
         handleErrors();
 
-    EVP_CIPHER_CTX_set_padding(ctx, 0);
+    (*OSSL_CIPHER_CTX_set_padding)(ctx, 0);
 
     (*env)->ReleaseByteArrayElements(env, iv, (jbyte*)ivNative, JNI_ABORT);
     (*env)->ReleaseByteArrayElements(env, key, (jbyte*)keyNative, JNI_ABORT);
@@ -308,7 +516,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_CBCUpdate
         return -1;
     }
 
-    if(1 != EVP_CipherUpdate(ctx, (outputNative + outputOffset), &outputLen, (inputNative + inputOffset), inputLen))
+    if (1 != (*OSSL_CipherUpdate)(ctx, (outputNative + outputOffset), &outputLen, (inputNative + inputOffset), inputLen))
         handleErrors();
 
     (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, 0);
@@ -347,10 +555,10 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_CBCFinalEncrypt
         return -1;
     }
 
-    if (1 != EVP_CipherUpdate(ctx, (outputNative + outputOffset), &outputLen, (inputNative + inputOffset), inputLen))
+    if (1 != (*OSSL_CipherUpdate)(ctx, (outputNative + outputOffset), &outputLen, (inputNative + inputOffset), inputLen))
         handleErrors();
 
-    if (1 != EVP_CipherFinal_ex(ctx, buf, &outputLen1))
+    if (1 != (*OSSL_CipherFinal_ex)(ctx, buf, &outputLen1))
         handleErrors();
 
     (*env)->ReleasePrimitiveArrayCritical(env, input, inputNative, 0);
@@ -358,8 +566,6 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_CBCFinalEncrypt
 
     return outputLen+outputLen1;
 }
-
-int first_time_gcm = 0;
 
 /* GCM Encryption
  *
@@ -372,7 +578,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_GCMEncrypt
   jbyteArray input, jint inOffset, jint inLen, jbyteArray output, jint outOffset,
   jbyteArray aad, jint aadLen, jint tagLen) {
 
-    unsigned char* inputNative;
+    unsigned char* inputNative = NULL;
     int len, len_cipher = 0;
     unsigned char* keyNative;
     unsigned char* ivNative;
@@ -380,7 +586,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_GCMEncrypt
     unsigned char* aadNative;
 
     EVP_CIPHER_CTX* ctx = NULL;
-    EVP_CIPHER* evp_gcm_cipher = NULL;
+    const EVP_CIPHER* evp_gcm_cipher = NULL;
 
     keyNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, key, 0));
     if (keyNative == NULL) {
@@ -419,54 +625,50 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_GCMEncrypt
         }
     }
 
-    if (first_time_gcm == 0) {
-        OpenSSL_add_all_algorithms();
-        ERR_load_crypto_strings();
-        first_time_gcm = 1;
-    }
-    
     switch(keyLen) {
         case 16:
-            evp_gcm_cipher = EVP_aes_128_gcm();
+            evp_gcm_cipher = (*OSSL_aes_128_gcm)();
             break;
         case 24:
-            evp_gcm_cipher = EVP_aes_192_gcm();
+            evp_gcm_cipher = (*OSSL_aes_192_gcm)();
             break;
         case 32:
-            evp_gcm_cipher = EVP_aes_256_gcm();
+            evp_gcm_cipher = (*OSSL_aes_256_gcm)();
             break;
+        default:
+            assert(32);
     }
 
-    ctx = EVP_CIPHER_CTX_new();
-    if(1 != EVP_CipherInit_ex(ctx, evp_gcm_cipher, NULL, NULL, NULL, 1 )) /* 1 - Encrypt mode 0 Decrypt Mode*/
+    ctx = (*OSSL_CIPHER_CTX_new)();
+    if(1 != (*OSSL_CipherInit_ex)(ctx, evp_gcm_cipher, NULL, NULL, NULL, 1 )) /* 1 - Encrypt mode 0 Decrypt Mode*/
         handleErrors();
 
-    if(1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, ivLen, NULL))
+    if(1 != (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_GCM_SET_IVLEN, ivLen, NULL))
         handleErrors();
 
-    if(1 != EVP_CipherInit_ex(ctx, NULL, NULL, keyNative, ivNative, -1))
+    if(1 != (*OSSL_CipherInit_ex)(ctx, NULL, NULL, keyNative, ivNative, -1))
         handleErrors();
 
     /* provide AAD */
-    if(1 != EVP_CipherUpdate(ctx, NULL, &len, aadNative, aadLen))
+    if(1 != (*OSSL_CipherUpdate)(ctx, NULL, &len, aadNative, aadLen))
         handleErrors();
 
     /* encrypt plaintext and obtain ciphertext */
     if (inLen > 0) {
-        if(1 != EVP_CipherUpdate(ctx, outputNative + outOffset, &len, inputNative + inOffset, inLen))
+        if(1 != (*OSSL_CipherUpdate)(ctx, outputNative + outOffset, &len, inputNative + inOffset, inLen))
             handleErrors();
         len_cipher = len;
     }
 
     /* finalize the encryption */
-    if(1 != EVP_CipherFinal_ex(ctx, outputNative + outOffset + len_cipher, &len))
+    if(1 != (*OSSL_CipherFinal_ex)(ctx, outputNative + outOffset + len_cipher, &len))
         handleErrors();
 
     /* Get the tag, place it at the end of the cipherText buffer */
-    if(1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, tagLen, outputNative + outOffset + len + len_cipher))
+    if(1 != (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_GCM_GET_TAG, tagLen, outputNative + outOffset + len + len_cipher))
         handleErrors();
 
-    EVP_CIPHER_CTX_free(ctx);
+    (*OSSL_CIPHER_CTX_free)(ctx);
 
     (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative,   0);
     (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative,    0);
@@ -477,6 +679,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_GCMEncrypt
     }
 
     (*env)->ReleasePrimitiveArrayCritical(env, aad, aadNative,  0);
+    return len_cipher;
 }
 
 /* GCM Decryption
@@ -490,14 +693,14 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_GCMDecrypt
   jbyteArray input, jint inOffset, jint inLen, jbyteArray output, jint outOffset,
   jbyteArray aad, jint aadLen, jint tagLen) {
 
-    unsigned char* inputNative;
-    unsigned char* aadNative;
+    unsigned char* inputNative = NULL;
+    unsigned char* aadNative = NULL;
     int ret, len, plaintext_len = 0;
     unsigned char* keyNative;
     unsigned char* ivNative;
     unsigned char* outputNative;
     EVP_CIPHER_CTX* ctx = NULL;
-    EVP_CIPHER* evp_gcm_cipher = NULL;
+    const EVP_CIPHER* evp_gcm_cipher = NULL;
 
     keyNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, key, 0));
     if (keyNative == NULL)
@@ -538,56 +741,51 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_GCMDecrypt
         }
     }
 
-    if (first_time_gcm == 0) {
-        //printf("Initializing OpenSSL GCM algorithm-1\n");
-        OpenSSL_add_all_algorithms();
-        ERR_load_crypto_strings();
-        first_time_gcm = 1;
-    }
-
     switch(keyLen) {
         case 16:
-            evp_gcm_cipher = EVP_aes_128_gcm();
+            evp_gcm_cipher = (*OSSL_aes_128_gcm)();
             break;
         case 24:
-            evp_gcm_cipher = EVP_aes_192_gcm();
+            evp_gcm_cipher = (*OSSL_aes_192_gcm)();
             break;
         case 32:
-            evp_gcm_cipher = EVP_aes_256_gcm();
+            evp_gcm_cipher = (*OSSL_aes_256_gcm)();
             break;
+        default:
+            assert(32);
     }
 
-    ctx = EVP_CIPHER_CTX_new();
+    ctx = (*OSSL_CIPHER_CTX_new)();
 
-    if(1 != EVP_CipherInit_ex(ctx, evp_gcm_cipher, NULL, NULL, NULL, 0 )) /* 1 - Encrypt mode 0 Decrypt Mode*/
+    if (1 != (*OSSL_CipherInit_ex)(ctx, evp_gcm_cipher, NULL, NULL, NULL, 0 )) /* 1 - Encrypt mode 0 Decrypt Mode*/
         handleErrors();
 
-    if(1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, ivLen, NULL))
+    if (1 != (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_GCM_SET_IVLEN, ivLen, NULL))
         handleErrors();
 
     /* Initialise key and IV */
-    if(!EVP_DecryptInit_ex(ctx, NULL, NULL, keyNative, ivNative))
+    if (1 != (*OSSL_DecryptInit_ex)(ctx, NULL, NULL, keyNative, ivNative))
         handleErrors();
 
     /* Provide any AAD data */
     if (aadLen > 0) {
-        if (!EVP_DecryptUpdate(ctx, NULL, &len, aadNative, aadLen))
+        if (1 != (*OSSL_DecryptUpdate)(ctx, NULL, &len, aadNative, aadLen))
             handleErrors();
     }
 
     if (inLen - tagLen > 0) {
-        if(!EVP_DecryptUpdate(ctx, outputNative + outOffset, &len, inputNative + inOffset, inLen - tagLen))
+        if (1 != (*OSSL_DecryptUpdate)(ctx, outputNative + outOffset, &len, inputNative + inOffset, inLen - tagLen))
             handleErrors();
 
         plaintext_len = len;
     }
 
-    if(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, tagLen, inputNative + inOffset + inLen - tagLen))
+    if (1 != (*OSSL_CIPHER_CTX_ctrl)(ctx, EVP_CTRL_GCM_SET_TAG, tagLen, inputNative + inOffset + inLen - tagLen))
         handleErrors();
 
-    ret = EVP_DecryptFinal(ctx, outputNative + outOffset + len, &len);
+    ret = (*OSSL_DecryptFinal)(ctx, outputNative + outOffset + len, &len);
 
-    EVP_CIPHER_CTX_free(ctx);
+    (*OSSL_CIPHER_CTX_free)(ctx);
 
     (*env)->ReleasePrimitiveArrayCritical(env, key, keyNative,   0);
     (*env)->ReleasePrimitiveArrayCritical(env, iv, ivNative,    0);

--- a/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto_md.h
+++ b/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto_md.h
@@ -1,0 +1,32 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+
+#ifndef NATIVECRYPTO_MD_H
+#define NATIVECRYPTO_MD_H
+
+void * load_crypto_library();
+void   unload_crypto_library(void *handle);
+void * find_crypto_symbol(void *handle, const char *symname);
+
+#endif

--- a/closed/adds/jdk/src/solaris/native/jdk/crypto/jniprovider/NativeCrypto_md.c
+++ b/closed/adds/jdk/src/solaris/native/jdk/crypto/jniprovider/NativeCrypto_md.c
@@ -1,0 +1,68 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <dlfcn.h>
+#include "NativeCrypto_md.h"
+
+/* Load the crypto library (return NULL on error) */
+void * load_crypto_library() {
+    void * result = NULL;
+    const char *libname;
+
+#ifdef MACOSX
+    libname = "libcrypto.dylib";
+#else
+    libname = "libcrypto.so";
+#endif
+
+    result = dlopen (libname,  RTLD_NOW);
+    
+    if (result == NULL) {
+        fputs (dlerror(), stderr);
+    }
+
+    return result;
+}
+
+/* Unload the crypto library */
+void unload_crypto_library(void *handle) {
+    (void)dlclose(handle);
+}
+
+/* Find the symbol in the crypto library (return NULL if not found) */
+void * find_crypto_symbol(void *handle, const char *symname) {
+    void * symptr;
+
+    symptr =  dlsym(handle, symname);
+
+    if (symptr == NULL) {
+        fputs (dlerror(), stderr);
+    }
+
+    return symptr;
+}

--- a/closed/adds/jdk/src/windows/native/jdk/crypto/jniprovider/NativeCrypto_md.c
+++ b/closed/adds/jdk/src/windows/native/jdk/crypto/jniprovider/NativeCrypto_md.c
@@ -1,0 +1,64 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+
+#include <windows.h>
+
+#include "NativeCrypto_md.h"
+
+/* Load the crypto library (return NULL on error) */
+void * load_crypto_library() {
+    void * result = NULL;
+    const char *libname;
+    const char *oldname;
+
+#ifdef WIN32
+    libname = "libcrypto-1_1.dll";
+#else
+    libname = "libcrypto-1_1-x64.dll"
+#endif
+
+    oldname = "libeay32.dll";
+
+    result = LoadLibrary(libname);
+    
+    if (result == NULL) {
+        result = LoadLibrary(oldname);
+    }
+
+    return result;
+}
+
+/* Unload the crypto library */
+void unload_crypto_library(void *handle) {
+	FreeLibrary(handle);
+}
+
+/* Find the symbol in the crypto library (return NULL if not found) */
+void * find_crypto_symbol(void *handle, const char *symname) {
+    void * symptr;
+
+    symptr =  GetProcAddress(handle, symname);
+
+    return symptr;
+}

--- a/closed/get_openssl_source.sh
+++ b/closed/get_openssl_source.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
   
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
 # ===========================================================================
 # 
 # This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 # ===========================================================================
 
 usage() {
-	echo "Usage: $0 [-h|--help] [--openssl-version=<openssl version 1.1.0 and above to download>]"
+	echo "Usage: $0 [-h|--help] [--openssl-version=<openssl version 1.0.2 and above to download>]"
 	echo "where:"
 	echo "  -h|--help             print this help, then exit"
 	echo "  --openssl-version     OpenSSL version to download. For example, 1.1.1"
@@ -59,7 +59,8 @@ do
 	esac
 done
 
-if [ ${OPENSSL_VERSION:0:4} != "1.1." ]; then
+if [ [${OPENSSL_VERSION:0:5} != "1.0.2" ] &&
+     [${OPENSSL_VERSION:0:4} != "1.1." ]]; then
 	usage
 fi
 

--- a/closed/make/mapfiles/libjncrypto/mapfile-vers
+++ b/closed/make/mapfiles/libjncrypto/mapfile-vers
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -24,6 +24,10 @@
 SUNWprivate_1.1 {
 	global:
             handleErrors;
+            load_crypto_library;
+            unload_crypto_library;
+            find_crypto_symbol;
+            Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto;
             Java_jdk_crypto_jniprovider_NativeCrypto_DigestCreateContext;
             Java_jdk_crypto_jniprovider_NativeCrypto_DigestUpdate;
             Java_jdk_crypto_jniprovider_NativeCrypto_DigestComputeAndReset;

--- a/closed/openssl.gmk
+++ b/closed/openssl.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -41,26 +41,26 @@ ifeq ($(BUILD_OPENSSL), yes)
 	$(ECHO) Compiling OpenSSL in $(OPENSSL_DIR)
   ifeq ($(OPENJDK_TARGET_OS), linux)
     ifeq ($(OPENJDK_TARGET_CPU), x86_64)
-	($(CD) $(OPENSSL_DIR) && ./Configure linux-x86_64 && $(MAKE))
+	($(CD) $(OPENSSL_DIR) && ./Configure linux-x86_64 shared && $(MAKE))
     else ifeq ($(OPENJDK_TARGET_CPU), s390x)
-	($(CD) $(OPENSSL_DIR) && ./Configure linux64-s390x && $(MAKE))
+	($(CD) $(OPENSSL_DIR) && ./Configure linux64-s390x shared && $(MAKE))
     else ifeq ($(OPENJDK_TARGET_CPU), ppc64le)
-	($(CD) $(OPENSSL_DIR) && ./Configure linux-ppc64le && $(MAKE))
+	($(CD) $(OPENSSL_DIR) && ./Configure linux-ppc64le shared && $(MAKE))
     else
-	($(CD) $(OPENSSL_DIR) && ./config && $(MAKE))
+	($(CD) $(OPENSSL_DIR) && ./config shared && $(MAKE))
     endif
   else ifeq ($(OPENJDK_TARGET_OS), macosx)
-	($(CD) $(OPENSSL_DIR) && ./Configure darwin64-x86_64-cc -shared  && $(MAKE))
+	($(CD) $(OPENSSL_DIR) && ./Configure darwin64-x86_64-cc shared  && $(MAKE))
   else ifeq ($(OPENJDK_TARGET_OS), windows)
     ifeq ($(OPENJDK_TARGET_CPU), x86_64)
-	($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN64A && $(MAKE))
+	($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN64A shared && $(MAKE))
     else
-	($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN32 && $(MAKE))
+	($(CD) $(OPENSSL_DIR) && ./Configure VC-WIN32 shared && $(MAKE))
     endif
   else ifeq ($(OPENJDK_TARGET_OS), aix)
-	($(CD) $(OPENSSL_DIR) && ./Configure aix64-cc && $(MAKE))
+	($(CD) $(OPENSSL_DIR) && ./Configure aix64-cc shared && $(MAKE))
   else
-	($(CD) $(OPENSSL_DIR) && ./config && $(MAKE))
+	($(CD) $(OPENSSL_DIR) && ./config shared && $(MAKE))
   endif
 endif
 

--- a/jdk/make/CopyFiles.gmk
+++ b/jdk/make/CopyFiles.gmk
@@ -23,7 +23,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
 # ===========================================================================
 #
 
@@ -251,16 +251,26 @@ endif
 
 ##########################################################################################
 # Optionally copy OpenSSL Crypto Lbrary
+# To bundle first search for openssl 1.1.x library, if not found, search for 1.0.x 
 ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
   ifeq ($(OPENJDK_TARGET_OS), linux)
     OPENSSL_LIB_NAME = libcrypto.so.1.1
+    ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
+      OPENSSL_LIB_NAME = libcrypto.so.1.0.0
+    endif
   else ifeq ($(OPENJDK_TARGET_OS), macosx)
     OPENSSL_LIB_NAME = libcrypto.1.1.dylib
+    ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
+      OPENSSL_LIB_NAME = libcrypto.1.0.0.dylib
+    endif
   else ifeq ($(OPENJDK_TARGET_OS), windows)
     ifeq ($(OPENJDK_TARGET_CPU_BITS), 64)
       OPENSSL_LIB_NAME = libcrypto-1_1-x64.dll
     else
       OPENSSL_LIB_NAME = libcrypto-1_1.dll
+    endif
+    ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
+      OPENSSL_LIB_NAME = libeay32.dll
     endif
   else ifeq ($(OPENJDK_TARGET_OS), aix)
     # OpenSSL 1.1.1 on AIX has switched to use archive library files (natural way)

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -477,7 +477,7 @@ AC_DEFUN([CONFIGURE_OPENSSL],
       BUNDLE_OPENSSL=no
     fi
 
-    # if --with-openssl=fetched
+    # Process --with-openssl=fetched
     if test "x$with_openssl" = xfetched ; then
       if test "x$OPENJDK_BUILD_OS" = xwindows ; then
         AC_MSG_RESULT([no])
@@ -487,10 +487,8 @@ AC_DEFUN([CONFIGURE_OPENSSL],
 
       if test -d "$SRC_ROOT/openssl" ; then
         OPENSSL_DIR=$SRC_ROOT/openssl
-        FOUND_OPENSSL=yes
         OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
-        OPENSSL_LIBS="-L${OPENSSL_DIR} -lcrypto"
-        if test -s $OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1 ; then
+        if test -s $OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}; then
           BUILD_OPENSSL=no
         else
           BUILD_OPENSSL=yes
@@ -502,82 +500,69 @@ AC_DEFUN([CONFIGURE_OPENSSL],
       else
         AC_MSG_RESULT([no])
         printf "$SRC_ROOT/openssl is not found.\n"
-        printf "  run get_source.sh --openssl-version=1.1.0h\n"
+        printf "  run get_source.sh --openssl-version=<version as 1.0.2p or later>\n"
         printf "  Then, run configure with '--with-openssl=fetched'\n"
         AC_MSG_ERROR([Cannot continue])
       fi
-    fi
 
-    # if --with-openssl=system
-    if test "x$FOUND_OPENSSL" != xyes && test "x$with_openssl" = xsystem ; then
-      if test "x$OPENJDK_BUILD_OS" = xwindows ; then
+    # Process --with-openssl=system
+    elif test "x$with_openssl" = xsystem ; then
+      # We can use the system installed openssl only when it is package installed.
+      # If not package installed, fail with an error message.
+      # PKG_CHECK_MODULES will setup the variable OPENSSL_CFLAGS and OPENSSL_LIB when successful.
+      PKG_CHECK_MODULES(OPENSSL, openssl >= 1.0.2, [FOUND_OPENSSL=yes], [FOUND_OPENSSL=no])
+      if test "x$FOUND_OPENSSL" != xyes; then
+        AC_MSG_ERROR([Unable to find openssl 1.0.2(and above) installed on System. Please use other options for '--with-openssl'])
+      fi
+
+      # The crypto library bundling option is not available when --with-openssl=system.
+      if test "x$BUNDLE_OPENSSL" = xyes ; then
         AC_MSG_RESULT([no])
-        printf "On Windows, value of \"system\" is currently not supported with --with-openssl. Please build OpenSSL using VisualStudio outside cygwin and specify the path with --with-openssl\n"
+        printf "The option --enable_openssl_bundling is not available with --with-openssl=system. Use option fetched or openssl path to bundle crypto library\n"
         AC_MSG_ERROR([Cannot continue])
       fi
 
-      # Check modules using pkg-config, but only if we have it
-      PKG_CHECK_MODULES(OPENSSL, openssl >= 1.1.0, [FOUND_OPENSSL=yes], [FOUND_OPENSSL=no])
-
-      if test "x$FOUND_OPENSSL" != xyes ; then
-        AC_MSG_ERROR([Unable to find openssl 1.1.0(and above) installed on System. Please use other options for '--with-openssl'])
-      fi
-    fi
-
-    # if --with-openssl=/custom/path/where/openssl/is/present
-    if test "x$FOUND_OPENSSL" != xyes ; then
-      # User specified path where openssl is installed
+    # Process --with-openssl=/custom/path/where/openssl/is/present
+    # As the value is not fetched or system, assume user specified the
+    # path where openssl is installed
+    else
       OPENSSL_DIR=$with_openssl
       BASIC_FIXUP_PATH(OPENSSL_DIR)
       if test -s "$OPENSSL_DIR/include/openssl/evp.h" ; then
-        if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
-          # On Windows, check for libcrypto.lib
-          if test -s "$OPENSSL_DIR/lib/libcrypto.lib" ; then
-            FOUND_OPENSSL=yes
-            OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
-            OPENSSL_LIBS="-libpath:${OPENSSL_DIR}/lib libcrypto.lib"
-            if test "x$BUNDLE_OPENSSL" = xyes ; then
+        OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
+        if test "x$BUNDLE_OPENSSL" = xyes ; then
+          if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
+            if test -s "$OPENSSL_DIR/bin" ; then
               OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR/bin
-              BASIC_FIXUP_PATH(OPENSSL_BUNDLE_LIB_PATH)
-            fi
-          fi
-        else
-          if test -s "$OPENSSL_DIR/lib/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1" ; then
-            FOUND_OPENSSL=yes
-            OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
-            OPENSSL_LIBS="-L${OPENSSL_DIR}/lib -lcrypto"
-            if test "x$BUNDLE_OPENSSL" = xyes ; then
-              OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR/lib
-            fi
-          elif test -s "$OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}.1.1" ; then
-            FOUND_OPENSSL=yes
-            OPENSSL_CFLAGS="-I${OPENSSL_DIR}/include"
-            OPENSSL_LIBS="-L${OPENSSL_DIR} -lcrypto"
-            if test "x$BUNDLE_OPENSSL" = xyes ; then
+            else
               OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR
+            fi
+          else
+            if test -s "$OPENSSL_DIR/lib/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}" ; then
+              OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR/lib
+            elif test -s "$OPENSSL_DIR/${LIBRARY_PREFIX}crypto${SHARED_LIBRARY_SUFFIX}" ; then
+              OPENSSL_BUNDLE_LIB_PATH=$OPENSSL_DIR
+            else
+              AC_MSG_RESULT([no])
+              AC_MSG_ERROR([Unable to find crypto library to bundle in specified location $OPENSSL_DIR])
             fi
           fi
         fi
-      fi
-
-      #openssl is not found in user specified location. Abort.
-      if test "x$FOUND_OPENSSL" != xyes ; then
+      else
+        # openssl is not found in user specified location. Abort.
         AC_MSG_RESULT([no])
         AC_MSG_ERROR([Unable to find openssl in specified location $OPENSSL_DIR])
       fi
       AC_MSG_RESULT([yes])
     fi
 
-    if test "x$OPENSSL_DIR" != x ; then
-      AC_MSG_CHECKING([if we should bundle openssl])
-      AC_MSG_RESULT([$BUNDLE_OPENSSL])
-    fi
+    AC_MSG_CHECKING([if we should bundle openssl])
+    AC_MSG_RESULT([$BUNDLE_OPENSSL])
   fi
 
   AC_SUBST(BUILD_OPENSSL)
   AC_SUBST(OPENSSL_BUNDLE_LIB_PATH)
   AC_SUBST(OPENSSL_CFLAGS)
   AC_SUBST(OPENSSL_DIR)
-  AC_SUBST(OPENSSL_LIBS)
   AC_SUBST(WITH_OPENSSL)
 ])

--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -42,7 +42,6 @@ endif
 OPENSSL_DIR             := @OPENSSL_DIR@
 BUILD_OPENSSL           := @BUILD_OPENSSL@
 OPENSSL_CFLAGS          := @OPENSSL_CFLAGS@
-OPENSSL_LIBS            := @OPENSSL_LIBS@
 OPENSSL_BUNDLE_LIB_PATH := @OPENSSL_BUNDLE_LIB_PATH@
 WITH_OPENSSL            := @WITH_OPENSSL@
 

--- a/jdk/make/lib/SecurityLibraries.gmk
+++ b/jdk/make/lib/SecurityLibraries.gmk
@@ -23,7 +23,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
 # ===========================================================================
 #
 
@@ -298,13 +298,16 @@ ifeq ($(WITH_OPENSSL), yes)
     $(eval $(call SetupNativeCompilation,BUILD_JNCRYPTO, \
         LIBRARY := jncrypto, \
         OUTPUT_DIR := $(INSTALL_LIBRARIES_HERE), \
-        SRC := $(SRC_ROOT)/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider, \
+        SRC := $(SRC_ROOT)/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider \
+               $(SRC_ROOT)/closed/adds/jdk/src/$(OPENJDK_TARGET_OS_API_DIR)/native/jdk/crypto/jniprovider, \
         LANG := C, \
         OPTIMIZATION := LOW, \
-        CFLAGS := $(CFLAGS_JDKLIB) -c $(OPENSSL_CFLAGS), \
+        CFLAGS := $(CFLAGS_JDKLIB) \
+            -I$(SRC_ROOT)/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider \
+            -c $(OPENSSL_CFLAGS), \
         MAPFILE := $(SRC_ROOT)/closed/make/mapfiles/libjncrypto/mapfile-vers, \
-        LDFLAGS := $(SHARED_LIBRARY_FLAGS) $(LDFLAGS_JDKLIB) $(call SET_SHARED_LIBRARY_ORIGIN), \
-        LDFLAGS_SUFFIX := $(OPENSSL_LIBS), \
+        LDFLAGS := $(LDFLAGS_JDKLIB) $(call SET_SHARED_LIBRARY_ORIGIN), \
+        LDFLAGS_SUFFIX_posix := $(LIBDL), \
         VERSIONINFO_RESOURCE := $(JDK_TOPDIR)/src/windows/resource/version.rc, \
         RC_FLAGS := $(RC_FLAGS) \
             -D "JDK_FNAME=jncrypto.dll" \


### PR DESCRIPTION
In this changeset, the following changes are added:
    - Support of dynamic loading of OpenSSL crypto library
    - Support for 1.0.2, 1.1.0 and 1.1.1 OpenSSL releases

Signed-off-by: Nasser Ebrahim <enasser@in.ibm.com>