### PR TITLE
Remove blank line from jvm.cfg

### DIFF
--- a/jdk/src/solaris/bin/ppc64le/jvm.cfg
+++ b/jdk/src/solaris/bin/ppc64le/jvm.cfg
@@ -37,4 +37,3 @@
 -classic IGNORE
 -native IGNORE
 -green IGNORE
-


### PR DESCRIPTION
Blank lines cause the build to fail with warnings like:
```
06:39:34 Warning: No leading - on line 40 of '/home/jenkins/workspace/openjdk8_j9_systemtest_ppc64le_linux/openjdkbinary/j2sdk-image/jre/lib/ppc64le/jvm.cfg'
```
Replaces #230 which was targeted to the `openj9` branch but based off the milestone branch.

Signed-off-by: Dan Heidinga <daniel_heidinga@ca.ibm.com>