### PR TITLE
Native RSA implementation with OpenSSL

### DIFF
--- a/closed/adds/jdk/src/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
+++ b/closed/adds/jdk/src/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
@@ -51,7 +51,7 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
     protected final static int numContexts = 4096;
     protected static long[] contexts;
     protected static ArrayDeque<Integer> avStack = new ArrayDeque<Integer>(numContexts);
- 
+
     private static NativeCrypto nativeCrypto;
 
     /*

--- a/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -80,8 +80,6 @@ public class NativeCrypto {
                                          int messageOffset,
                                          int messageLen);
 
-    public final native void DigestReset(long context);
-
     public final native int DigestComputeAndReset(long context,
                                                   byte[] message,
                                                   int messageOffset,
@@ -89,6 +87,8 @@ public class NativeCrypto {
                                                   byte[] digest,
                                                   int digestOffset,
                                                   int digestLen);
+
+    public final native void DigestReset(long context);
 
     /* Native CBC interfaces */
     public final native long CBCCreateContext(long nativeBuffer,
@@ -143,5 +143,41 @@ public class NativeCrypto {
                                        byte[] aad,
                                        int aadLen,
                                        int tagLen);
+
+    /* Native RSA interfaces */
+    public final native long createRSAPublicKey(byte[] n,
+                                                int nLen,
+                                                byte[] e,
+                                                int eLen);
+
+    public final native long createRSAPrivateCrtKey(byte[] n,
+                                                    int nLen,
+                                                    byte[] d,
+                                                    int dLen,
+                                                    byte[] e,
+                                                    int eLen,
+                                                    byte[] p,
+                                                    int pLen,
+                                                    byte[] q,
+                                                    int qLen,
+                                                    byte[] dp,
+                                                    int dpLen,
+                                                    byte[] dq,
+                                                    int dqLen,
+                                                    byte[] qinv,
+                                                    int qinvLen);
+
+    public final native void destroyRSAKey(long key);
+
+    public final native int RSADP(byte[] k,
+                                  int kLen,
+                                  byte[] m,
+                                  int verify,
+                                  long RSAPrivateCrtKey);
+
+    public final native int RSAEP(byte[] k,
+                                  int kLen,
+                                  byte[] m,
+                                  long RSAPublicKey);
 
 }

--- a/closed/adds/jdk/src/share/classes/sun/security/rsa/NativeRSACore.java
+++ b/closed/adds/jdk/src/share/classes/sun/security/rsa/NativeRSACore.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * ===========================================================================
+ */
+
+package sun.security.rsa;
+
+import java.math.BigInteger;
+import java.util.*;
+
+import java.security.SecureRandom;
+import java.security.interfaces.*;
+
+import javax.crypto.BadPaddingException;
+import sun.security.action.GetPropertyAction;
+import jdk.crypto.jniprovider.NativeCrypto;
+
+import sun.security.jca.JCAUtil;
+
+/**
+ * Core of the RSA implementation. Has code to perform public and private key
+ * RSA operations (with and without CRT for private key ops). Private CRT ops
+ * also support blinding to twart timing attacks.
+ *
+ * The code in this class only does the core RSA operation. Padding and
+ * unpadding must be done externally.
+ *
+ * Note: RSA keys should be at least 512 bits long
+ *
+ * @since   1.5
+ * @author  Andreas Sterbenz
+ */
+public final class NativeRSACore {
+
+    private static NativeCrypto nativeCrypto;
+
+    static {
+        nativeCrypto = NativeCrypto.getNativeCrypto();
+    }
+
+    /**
+     * Return the number of bytes required to store the magnitude byte[] of
+     * this BigInteger. Do not count a 0x00 byte toByteArray() would
+     * prefix for 2's complement form.
+     */
+    public static int getByteLength(BigInteger b) {
+        int n = b.bitLength();
+        return (n + 7) >> 3;
+    }
+
+    /**
+     * Perform an RSA public key operation.
+     */
+    public static byte[] rsa(byte[] msg, sun.security.rsa.RSAPublicKeyImpl key)
+        throws BadPaddingException {
+        return crypt_Native(msg, key);
+    }
+
+    /**
+     * Perform an RSA private key operation. Uses CRT if the key is a
+     * CRT key. Set 'verify' to true if this function is used for
+     * generating a signature.
+     */
+    public static byte[] rsa(byte[] msg,sun.security.rsa.RSAPrivateCrtKeyImpl key, boolean verify)
+        throws BadPaddingException {
+        return crtCrypt_Native(msg, key, verify);
+    }
+
+    /**
+     * RSA public key ops. Simple modPow().
+     */
+    synchronized private static byte[] crypt_Native(byte[] msg, sun.security.rsa.RSAPublicKeyImpl key)
+        throws BadPaddingException {
+
+        long nativePtr = key.getNativePtr();
+
+        if (nativePtr == -1) {
+            return null;
+        }
+
+        BigInteger n = key.getModulus();
+        byte[] output = new byte[getByteLength(n)];
+
+        int outputLen = nativeCrypto.RSAEP(msg, msg.length, output, nativePtr);
+
+        if (outputLen == -1) {
+            return null;
+        }
+        return output;
+    }
+
+    /**
+     * RSA private key operations with CRT. Algorithm and variable naming
+     * are taken from PKCS#1 v2.1, section 5.1.2.
+     */
+    synchronized private static byte[] crtCrypt_Native(byte[] msg, sun.security.rsa.RSAPrivateCrtKeyImpl key,
+            boolean verify) throws BadPaddingException {
+        long nativePtr = key.getNativePtr();
+
+        if (nativePtr == -1) {
+            return null;
+        }
+
+        int verifyInt;
+        BigInteger n = key.getModulus();
+        int outputLen = getByteLength(n);
+        byte[] output = new byte[outputLen];
+
+        if(verify) {
+            verifyInt = outputLen;
+        } else {
+            verifyInt = -1;
+        }
+
+        outputLen = nativeCrypto.RSADP(msg, msg.length, output, verifyInt, nativePtr);
+
+        if (outputLen == -1) {
+            return null;
+        } else if (outputLen == -2) {
+            throw new BadPaddingException("RSA private key operation failed");
+        }
+
+        return output;
+    }
+}

--- a/closed/make/mapfiles/libjncrypto/mapfile-vers
+++ b/closed/make/mapfiles/libjncrypto/mapfile-vers
@@ -25,8 +25,8 @@ SUNWprivate_1.1 {
 	global:
             handleErrors;
             Java_jdk_crypto_jniprovider_NativeCrypto_DigestCreateContext;
-            Java_jdk_crypto_jniprovider_NativeCrypto_DigestUpdate;
             Java_jdk_crypto_jniprovider_NativeCrypto_DigestDestroyContext;
+            Java_jdk_crypto_jniprovider_NativeCrypto_DigestUpdate;
             Java_jdk_crypto_jniprovider_NativeCrypto_DigestComputeAndReset;
             Java_jdk_crypto_jniprovider_NativeCrypto_DigestReset;
             Java_jdk_crypto_jniprovider_NativeCrypto_CBCCreateContext;
@@ -36,6 +36,11 @@ SUNWprivate_1.1 {
             Java_jdk_crypto_jniprovider_NativeCrypto_CBCFinalEncrypt;
             Java_jdk_crypto_jniprovider_NativeCrypto_GCMEncrypt;
             Java_jdk_crypto_jniprovider_NativeCrypto_GCMDecrypt;
+            Java_jdk_crypto_jniprovider_NativeCrypto_createRSAPublicKey;
+            Java_jdk_crypto_jniprovider_NativeCrypto_createRSAPrivateCrtKey;
+            Java_jdk_crypto_jniprovider_NativeCrypto_destroyRSAKey;
+            Java_jdk_crypto_jniprovider_NativeCrypto_RSADP;
+            Java_jdk_crypto_jniprovider_NativeCrypto_RSAEP;
         local:
 	    *;
 };

--- a/jdk/src/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/jdk/src/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  */
 
@@ -64,15 +64,15 @@ import java.security.PrivilegedAction;
 final class CipherCore {
 
     /*
-     * Check whether native crypto is enabled with property.
+     * Check whether native crypto is disabled with property.
      *
-     * By default, the native crypto is enabled and uses the native 
+     * By default, the native crypto is enabled and uses the native
      * crypto library implementation.
      *
-     * The property 'jdk.nativeCBC' is used to enable Native CBC alone,
-     * 'jdk.nativeGCM' is used to enable Native GCM alone and
-     * 'jdk.nativeCrypto' is used to enable all native cryptos (Digest,
-     * CBC and GCM).
+     * The property 'jdk.nativeCBC' is used to disable Native CBC alone,
+     * 'jdk.nativeGCM' is used to disable Native GCM alone and
+     * 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
+     * CBC, GCM, and RSA).
      */
     private static boolean useNativeCrypto = true;
 

--- a/jdk/src/share/classes/sun/security/provider/SunEntries.java
+++ b/jdk/src/share/classes/sun/security/provider/SunEntries.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  */
 
@@ -92,10 +92,13 @@ final class SunEntries {
 
     /*
      * Check whether native crypto is enabled with property.
-     * By default, the native crypto is enabled and uses native library crypto.
-     * The property 'jdk.nativeDigest' is used to enable Native digest alone
-     * and 'jdk.nativeCrypto' is used to enable all native cryptos (Digest,
-     * CBC and GCM).
+     *
+     * By default, the native crypto is enabled and uses the native
+     * crypto library implementation.
+     *
+     * The property 'jdk.nativeDigest' is used to disable Native digest alone
+     * and 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
+     * CBC, GCM, and RSA).
      */
     private static boolean useNativeDigest = true;
 

--- a/jdk/src/share/classes/sun/security/rsa/RSAPrivateCrtKeyImpl.java
+++ b/jdk/src/share/classes/sun/security/rsa/RSAPrivateCrtKeyImpl.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * ===========================================================================
+ */
 
 package sun.security.rsa;
 
@@ -35,6 +40,7 @@ import sun.security.util.*;
 import sun.security.x509.AlgorithmId;
 import sun.security.pkcs.PKCS8Key;
 
+import jdk.crypto.jniprovider.NativeCrypto;
 /**
  * Key implementation for RSA private keys, CRT form. For non-CRT private
  * keys, see RSAPrivateKeyImpl. We need separate classes to ensure
@@ -65,6 +71,12 @@ public final class RSAPrivateCrtKeyImpl
     // algorithmId used to identify RSA keys
     final static AlgorithmId rsaId =
         new AlgorithmId(AlgorithmId.RSAEncryption_oid);
+
+    private static NativeCrypto nativeCrypto;
+
+    static {
+        nativeCrypto = NativeCrypto.getNativeCrypto();
+    }
 
     /**
      * Generate a new key from its encoding. Returns a CRT key if possible
@@ -174,6 +186,50 @@ public final class RSAPrivateCrtKeyImpl
     // see JCA doc
     public BigInteger getCrtCoefficient() {
         return coeff;
+    }
+
+    private long nativeRSAKey = 0x0;
+
+    /**
+     * Get native RSA Public Key context pointer. 
+     * Create native context if uninitialized.
+     */
+    protected long getNativePtr() {
+        if (nativeRSAKey != 0x0) {
+            return nativeRSAKey;
+        }
+
+        BigInteger n =    this.getModulus();
+        BigInteger d =    this.getPrivateExponent();
+        BigInteger e =    this.getPublicExponent();
+        BigInteger p =    this.getPrimeP();
+        BigInteger q =    this.getPrimeQ();
+        BigInteger dP =   this.getPrimeExponentP();
+        BigInteger dQ =   this.getPrimeExponentQ();
+        BigInteger qInv = this.getCrtCoefficient();
+
+        byte[] n_2c = n.toByteArray();
+        byte[] d_2c = d.toByteArray();
+        byte[] e_2c = e.toByteArray();
+
+        byte[] p_2c = p.toByteArray();
+        byte[] q_2c = q.toByteArray();
+
+        byte[] dP_2c   = dP.toByteArray();
+        byte[] dQ_2c   = dQ.toByteArray();
+        byte[] qInv_2c = qInv.toByteArray();
+
+        nativeRSAKey = nativeCrypto.createRSAPrivateCrtKey(n_2c,n_2c.length, d_2c, d_2c.length, e_2c, e_2c.length,
+                p_2c, p_2c.length, q_2c, q_2c.length,
+                dP_2c, dP_2c.length, dQ_2c, dQ_2c.length, qInv_2c, qInv_2c.length);
+        return nativeRSAKey;
+    }
+
+    @Override
+    public void finalize() {
+        if (nativeRSAKey != 0x0 && nativeRSAKey != -1) {
+            nativeCrypto.destroyRSAKey(nativeRSAKey);
+        }
     }
 
     /**


### PR DESCRIPTION
Added modifications to RSACore and relevant RSA classes to leverage OpenSSL by default, there is an option jdk.nativeRSA=false to disable. The existing option to manipulate native crypto are also supported (jdk.NativeCrypto).