### PR TITLE
Fix windows compiler error on NativeCrypto and compiler warnings

### DIFF
--- a/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto.c
+++ b/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto.c
@@ -660,6 +660,10 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_createRSAPublic
 
     unsigned char* nNative;
     unsigned char* eNative;
+    RSA* publicRSAKey;
+    BIGNUM* nBN;
+    BIGNUM* eBN;
+    int ret = 0;
 
     nNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, n, 0));
     if (nNative == NULL) {
@@ -668,31 +672,31 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_createRSAPublic
 
     eNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, e, 0));
     if (eNative == NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
         return -1;
     }
 
-    RSA* publicRSAKey = RSA_new();
+    publicRSAKey = RSA_new();
 
-    BIGNUM* nBN = convertJavaBItoBN(nNative,nLen);
-    BIGNUM* eBN = convertJavaBItoBN(eNative,eLen);
-    
+    nBN = convertJavaBItoBN(nNative, nLen);
+    eBN = convertJavaBItoBN(eNative, eLen);
+
     if (publicRSAKey == NULL || nBN == NULL || eBN == NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative, 0);
         return -1;
     }
 
-    int ret = RSA_set0_key(publicRSAKey, nBN, eBN, NULL);
+    ret = RSA_set0_key(publicRSAKey, nBN, eBN, NULL);
 
-    (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
-    (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
+    (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, e, eNative, 0);
 
     if (ret == 0) {
         return -1;
     }
 
-    return (jlong)publicRSAKey;
+    return (jlong)(intptr_t)publicRSAKey;
 }
 
 /* Create an RSA Private CRT Key
@@ -712,80 +716,91 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_createRSAPrivat
     unsigned char* dpNative;
     unsigned char* dqNative;
     unsigned char* qinvNative;
+    RSA* privateRSACrtKey;
+    BIGNUM* nBN;
+    BIGNUM* eBN;
+    BIGNUM* dBN;
+    BIGNUM* pBN;
+    BIGNUM* qBN;
+    BIGNUM* dpBN;
+    BIGNUM* dqBN;
+    BIGNUM* qinvBN;
 
-    nNative    = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, n, 0));
+    int ret = 0;
+
+    nNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, n, 0));
     if (nNative == NULL) {
         return -1;
     }
 
-    dNative    = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, d, 0));
+    dNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, d, 0));
     if (dNative == NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
         return -1;
     }
 
-    eNative    = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, e, 0));
+    eNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, e, 0));
     if (eNative == NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative, 0);
         return -1;
     }
 
-    pNative    = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, p, 0));
+    pNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, p, 0));
     if (pNative == NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative, 0);
         return -1;
     }
 
-    qNative    = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, q, 0));
+    qNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, q, 0));
     if (qNative == NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative, 0);
         return -1;
     }
 
-    dpNative   = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, dp, 0));
+    dpNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, dp, 0));
     if (dpNative == NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, q, qNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, q, qNative, 0);
         return -1;
     }
 
-    dqNative   = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, dq, 0));
+    dqNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, dq, 0));
     if (dqNative == NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, q, qNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, dp, dpNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, q, qNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, dp, dpNative, 0);
         return -1;
     }
 
     qinvNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, qinv, 0));
     if (qinvNative == NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, q, qNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, dp, dpNative,  0);
-        (*env)->ReleasePrimitiveArrayCritical(env, dq, dqNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, d, dNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, e, eNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, p, pNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, q, qNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, dp, dpNative, 0);
+        (*env)->ReleasePrimitiveArrayCritical(env, dq, dqNative, 0);
         return -1;
     }
 
-    RSA* privateRSACrtKey = RSA_new();
+    privateRSACrtKey = RSA_new();
 
-    BIGNUM* nBN = convertJavaBItoBN(nNative,nLen);
-    BIGNUM* eBN = convertJavaBItoBN(eNative,eLen);
-    BIGNUM* dBN = convertJavaBItoBN(dNative,dLen);
+    nBN = convertJavaBItoBN(nNative, nLen);
+    eBN = convertJavaBItoBN(eNative, eLen);
+    dBN = convertJavaBItoBN(dNative, dLen);
 
     if (privateRSACrtKey == NULL || nBN == NULL || eBN == NULL || dBN == NULL) {
 
@@ -800,12 +815,10 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_createRSAPrivat
         return -1;
     }
 
-    int ret;
-
     ret = RSA_set0_key(privateRSACrtKey, nBN, eBN, dBN);
 
-    BIGNUM* pBN = convertJavaBItoBN(pNative,pLen);
-    BIGNUM* qBN = convertJavaBItoBN(qNative,qLen);
+    pBN = convertJavaBItoBN(pNative, pLen);
+    qBN = convertJavaBItoBN(qNative, qLen);
 
     if (ret == 0 || pBN == NULL || qBN == NULL) {
         (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
@@ -821,9 +834,9 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_createRSAPrivat
 
     ret = RSA_set0_factors(privateRSACrtKey, pBN, qBN);
 
-    BIGNUM* dpBN   = convertJavaBItoBN(dpNative,  dpLen);
-    BIGNUM* dqBN   = convertJavaBItoBN(dqNative,  dqLen);
-    BIGNUM* qinvBN = convertJavaBItoBN(qinvNative,qinvLen);
+    dpBN = convertJavaBItoBN(dpNative, dpLen);
+    dqBN = convertJavaBItoBN(dqNative, dqLen);
+    qinvBN = convertJavaBItoBN(qinvNative, qinvLen);
 
     if (ret == 0 || dpBN == NULL || dqBN == NULL || qinvBN == NULL) {
         (*env)->ReleasePrimitiveArrayCritical(env, n, nNative, 0);
@@ -847,11 +860,11 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_createRSAPrivat
     (*env)->ReleasePrimitiveArrayCritical(env, dp, dpNative, 0);
     (*env)->ReleasePrimitiveArrayCritical(env, dq, dqNative, 0);
     (*env)->ReleasePrimitiveArrayCritical(env, qinv, qinvNative, 0);
-    
+
     if (ret == 0)
         return -1;
 
-    return (jlong)privateRSACrtKey;
+    return (jlong)(intptr_t)privateRSACrtKey;
 }
 
 /* Free RSA Public/Private Key
@@ -876,6 +889,8 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_RSAEP
 
     unsigned char* kNative;
     unsigned char* mNative;
+    RSA* rsaKey;
+    int msg_len;
 
     kNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, k, 0));
     if (kNative == NULL) {
@@ -884,18 +899,18 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_RSAEP
 
     mNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, m, 0));
     if (mNative == NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, k, kNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, k, kNative, 0);
         return -1;
     }
 
-    RSA* rsaKey = (RSA*)publicRSAKey;
+    rsaKey = (RSA*)publicRSAKey;
 
     // OSSL_RSA_public_decrypt returns -1 on error
-    int msg_len = RSA_public_decrypt(kLen, kNative, mNative, rsaKey, RSA_NO_PADDING);
+    msg_len = RSA_public_decrypt(kLen, kNative, mNative, rsaKey, RSA_NO_PADDING);
 
-    (*env)->ReleasePrimitiveArrayCritical(env, k, kNative,  0);
-    (*env)->ReleasePrimitiveArrayCritical(env, m, mNative,  0);
-    return msg_len;
+    (*env)->ReleasePrimitiveArrayCritical(env, k, kNative, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, m, mNative, 0);
+    return (jint)msg_len;
 }
 
 /* RSADP Cryptographic Primitive, RSA Private Key operation
@@ -911,6 +926,10 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_RSADP
 
     unsigned char* kNative;
     unsigned char* mNative;
+    int msg_len;
+    int msg_len2;
+    unsigned char* k2;
+    RSA* rsaKey;
 
     kNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, k, 0));
     if (kNative == NULL) {
@@ -919,22 +938,22 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_RSADP
 
     mNative = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, m, 0));
     if (mNative == NULL) {
-        (*env)->ReleasePrimitiveArrayCritical(env, k, kNative,  0);
+        (*env)->ReleasePrimitiveArrayCritical(env, k, kNative, 0);
         return -1;
     }
 
-    RSA* rsaKey = (RSA*)privateRSAKey;
+    rsaKey = (RSA*)privateRSAKey;
 
     // OSSL_RSA_private_encrypt returns -1 on error
-    int msg_len = RSA_private_encrypt(kLen, kNative, mNative, rsaKey, RSA_NO_PADDING);
+    msg_len = RSA_private_encrypt(kLen, kNative, mNative, rsaKey, RSA_NO_PADDING);
 
     if (verify != -1 && msg_len != -1) {
         if (verify == kLen) {
-            unsigned char* k2 = malloc(kLen * (sizeof(unsigned char)));
+            k2 = malloc(kLen * (sizeof(unsigned char)));
             if (k2 != NULL) {
 
                 //mNative is size 'verify'
-                int msg_len2 = RSA_public_decrypt(verify, mNative, k2, rsaKey, RSA_NO_PADDING);
+                msg_len2 = RSA_public_decrypt(verify, mNative, k2, rsaKey, RSA_NO_PADDING);
                 if (msg_len2 != -1) {
 
                     int i;
@@ -956,10 +975,10 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_RSADP
         }
     }
 
-    (*env)->ReleasePrimitiveArrayCritical(env, k, kNative,  0);
-    (*env)->ReleasePrimitiveArrayCritical(env, m, mNative,  0);
+    (*env)->ReleasePrimitiveArrayCritical(env, k, kNative, 0);
+    (*env)->ReleasePrimitiveArrayCritical(env, m, mNative, 0);
 
-    return msg_len;
+    return (jint)msg_len;
 }
 
 /*
@@ -969,11 +988,14 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_RSADP
 BIGNUM* convertJavaBItoBN(unsigned char* in, int len) {
     // first bit is neg
     int neg = (in[0] & 0x80);
+    int c;
+    int i;
+    BIGNUM* bn;
     if (neg != 0) {
         // number is negative in two's complement form
         // need to extract magnitude
-        int c = 1;
-        int i = 0;
+        c = 1;
+        i = 0;
         for (i = len - 1; i >= 0; i--) {
             in[i] ^= 0xff; // flip bits
             if(c) { // add 1 for as long as needed
@@ -981,7 +1003,7 @@ BIGNUM* convertJavaBItoBN(unsigned char* in, int len) {
             }
         }
     }
-    BIGNUM* bn = BN_bin2bn(in, len, NULL);
+    bn = BN_bin2bn(in, len, NULL);
     if (bn != NULL) {
         BN_set_negative(bn, neg);
     }


### PR DESCRIPTION
-Fixes compiler error on windows
-Applies changes from https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/108 to RSA routines to fix compiler warnings