### PR TITLE
Turn off native digest

### DIFF
--- a/jdk/src/share/classes/sun/security/provider/SunEntries.java
+++ b/jdk/src/share/classes/sun/security/provider/SunEntries.java
@@ -97,7 +97,7 @@ final class SunEntries {
      * and 'jdk.nativeCrypto' is used to enable all native cryptos (Digest,
      * CBC and GCM).
      */
-    private static boolean useNativeDigest = true;
+    private static boolean useNativeDigest = false;
 
     private SunEntries() {
         // empty


### PR DESCRIPTION
This change will disable OpenSSL based accelerated Digest, it cannot be re-enabled with the command line option. This was done due to a segfault under some conditions when the Digest is invoked.
https://github.com/eclipse/openj9/issues/4530