### PR TITLE
Revert "Turn off native digest"

### DIFF
--- a/jdk/src/share/classes/sun/security/provider/SunEntries.java
+++ b/jdk/src/share/classes/sun/security/provider/SunEntries.java
@@ -100,7 +100,7 @@ final class SunEntries {
      * and 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
      * CBC, GCM, and RSA).
      */
-    private static boolean useNativeDigest = false;
+    private static boolean useNativeDigest = true;
 
     private SunEntries() {
         // empty


### PR DESCRIPTION
Reverts ibmruntimes/openj9-openjdk-jdk8#259

There is nothing wrong with the change, but it is causing the OpenJ9 OpenSSL_0  and cmdLineTester_CryptoTest_0 testing to fail. The tests need to be fixed. Reverting until the fix is ready.