### PR TITLE
Revert "Run 'java -version' if not cross compiling"

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -24,8 +24,8 @@ clean-j9vm :
 .PHONY : \
 	j9vm-build \
 	j9vm-compose-buildjvm \
+	openj9-test-image \
 	test-image \
-	test-image-openj9 \
 	#
 
 OPENJ9_MAKE := $(MAKE) -f $(SRC_ROOT)/closed/OpenJ9.gmk SPEC=$(SPEC)
@@ -41,14 +41,12 @@ j9vm-build : openssl-build
 j9vm-compose-buildjvm : j9vm-build
 	+$(OPENJ9_MAKE) stage_openj9_build_jdk
 
-test-image : test-image-openj9
+images :: test-image
 
-# If not cross-compiling, capture 'java -version' output.
-test-image-openj9 : images
+test-image : openj9-test-image
+
+openj9-test-image : j9vm-build
 	+$(OPENJ9_MAKE) openj9_test_image
-ifneq ($(COMPILE_TYPE), cross)
-	$(JRE_IMAGE_DIR)/bin/java -version > $(IMAGES_OUTPUTDIR)/test/openj9/java-version.txt 2>&1
-endif
 
 # Shortly after this makefile fragment is included, Main.gmk computes the list
 # of Java source files. Unless a goal is for 'help' or to 'clean' something, we


### PR DESCRIPTION
Reverts ibmruntimes/openj9-openjdk-jdk8#269

Reverting as I think this change is causing test binaries like pltest to be missing when running functionality tests.