### PR TITLE
Move classlib.properties to Java 8 extension repo

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -156,12 +156,8 @@ OPENJ9_STAGED_FILES += $(JDK_OUTPUTDIR)/lib/$(call STATIC_LIBRARY,jvm)
 endif # windows
 
 # classlib.properties
-
-$(JDK_OUTPUTDIR)/lib/classlib.properties : $(OUTPUT_ROOT)/vm/classlib.properties
-	$(ECHO) Setting classlib.properties
-	$(SED) > $@ < $< \
-		-e 's/shape=vm.shape/shape=sun_openjdk\nbootpath=rt.jar:resources.jar:jsse.jar:charsets.jar:jce.jar/g' \
-		-e 's/version=1.9/version=1.8/g'
+$(JDK_OUTPUTDIR)/lib/classlib.properties : $(SRC_ROOT)/closed/classlib.properties
+	$(install-file)
 
 OPENJ9_STAGED_FILES += $(JDK_OUTPUTDIR)/lib/classlib.properties
 

--- a/closed/classlib.properties
+++ b/closed/classlib.properties
@@ -1,0 +1,27 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+# Properties file for Java 8 (not required by Java 11 and beyond)
+
+# List of bootstrap classpath entries, separated by colon.
+bootpath=rt.jar:resources.jar:jsse.jar:charsets.jar:jce.jar
+
+# Version of the class library
+version=1.8


### PR DESCRIPTION
Move `classlib.properties` to `Java 8 extension` repo

`classlib.properties` is only used by `Java 8`;
Moving it to `Java 8 extension` repo;
Updated `OpenJ9.gmk` to copy the file without modification.

Additional note: historically this file was owned by `JCL`, at one point it was moved to `JVM` to accommodated different `JVM shape and JCL level`. Since the `shape` has been removed by https://github.com/eclipse/openj9/pull/4795, this file can be moved back to `JCL`, i.e., `extension` now. 

Related: https://github.com/eclipse/openj9/pull/5186

Reviewer: @pshipton 
FYI: @DanHeidinga @andrew-m-leonard 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>