### PR TITLE
Add launcher for jstack

### DIFF
--- a/closed/make/CreateJars.gmk
+++ b/closed/make/CreateJars.gmk
@@ -86,6 +86,9 @@ EXPORTED_PRIVATE_PKGS += \
 	jdk.internal.org.objectweb.asm.util \
 	openj9.lang.management \
 	openj9.lang.management.internal \
+	openj9.tools.attach.diagnostics.base \
+	openj9.tools.attach.diagnostics.info \
+	openj9.tools.attach.diagnostics.spi \
 	#
 
 RT_JAR_EXCLUDES += \
@@ -97,7 +100,8 @@ RT_JAR_EXCLUDES += \
 	com/ibm/jvm/j9 \
 	com/ibm/jvm/trace \
 	com/ibm/tools/attach/attacher \
-	openj9/tools/attach/diagnostics \
+	openj9/tools/attach/diagnostics/attacher \
+	openj9/tools/attach/diagnostics/tools \
 	#
 
 OPENJ9_MANAGEMENT_PACKAGES := \

--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -459,7 +459,11 @@ ifeq ($(OPENJDK_TARGET_OS), windows)
 endif
 
 $(eval $(call SetupLauncher,jps, \
-    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "openj9.tools.attach.diagnostics.Jps" }' \
+    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "openj9.tools.attach.diagnostics.tools.Jps" }' \
+    -DAPP_CLASSPATH='{ "/lib/tools.jar" }'))
+
+$(eval $(call SetupLauncher,jstack, \
+    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "openj9.tools.attach.diagnostics.tools.Jstack" }' \
     -DAPP_CLASSPATH='{ "/lib/tools.jar" }'))
 
 ##########################################################################################

--- a/jdk/make/CreateJars.gmk
+++ b/jdk/make/CreateJars.gmk
@@ -516,11 +516,13 @@ TOOLS_JAR_INCLUDES := \
     sun/tools/native2ascii \
     sun/tools/serialver \
     sun/tools/tree \
-    sun/tools/util \
-    openj9/tools/attach/diagnostics
+    sun/tools/util
 
 # Contributions from OpenJ9:
-TOOLS_JAR_INCLUDES += com/ibm/tools/attach/attacher 
+TOOLS_JAR_INCLUDES += \
+    com/ibm/tools/attach/attacher \
+    openj9/tools/attach/diagnostics/attacher \
+    openj9/tools/attach/diagnostics/tools
 
 # The sjavac tools is not ready for public consumption.
 TOOLS_JAR_EXCLUDES = com/sun/tools/sjavac

--- a/jdk/src/share/classes/sun/tools/attach/META-INF/services/openj9.tools.attach.diagnostics.spi.TargetDiagnosticsProvider
+++ b/jdk/src/share/classes/sun/tools/attach/META-INF/services/openj9.tools.attach.diagnostics.spi.TargetDiagnosticsProvider
@@ -1,0 +1,22 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+openj9.tools.attach.diagnostics.target.TargetDiagnosticsProviderImpl
+


### PR DESCRIPTION
Update package names to match OpenJ9, add new packages.

Requires https://github.com/eclipse/openj9/pull/5150

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>