### PR TITLE
Synchronize debug loop with JVM initialization

### DIFF
--- a/jdk/src/share/back/debugInit.h
+++ b/jdk/src/share/back/debugInit.h
@@ -1,4 +1,6 @@
-/*
+/*******************************************************************************
+ * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ *
  * Copyright (c) 1998, 2005, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,7 +30,8 @@
 
 void debugInit_waitInitComplete(void);
 jboolean debugInit_isInitComplete(void);
-
+void debugInit_waitVMInitComplete(void);
+void debugInit_setVMInitComplete(void);
 /*
  * Access to debug options
  */

--- a/jdk/src/share/back/eventHelper.c
+++ b/jdk/src/share/back/eventHelper.c
@@ -1,4 +1,6 @@
-/*
+/*******************************************************************************
+ * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ *
  * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -574,6 +576,7 @@ handleReportVMInitCommand(JNIEnv* env, ReportVMInitCommand *command)
         (void)threadControl_suspendThread(command->thread, JNI_FALSE);
     }
 
+    debugInit_setVMInitComplete();
     outStream_initCommand(&out, uniqueID(), 0x0,
                           JDWP_COMMAND_SET(Event),
                           JDWP_COMMAND(Event, Composite));


### PR DESCRIPTION
Normally, the event helper thread suspends all threads, then the debug loop in
the listener thread receives a command to resume.  The debugger may deadlock if
the debug loop in the listener thread starts processing commands (e.g. resume
threads) before the event helper completes the initialization (and suspends
threads).

This patch adds synchronization to ensure the event helper completes the
initialization sequence before debugger commands are processed.

Signed-off-by: Peter Bain <peter_bain@ca.ibm.com>