### PR TITLE
Add a check for illegal key size for native AES-CBC and AES-GCM

### DIFF
--- a/closed/adds/jdk/src/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
+++ b/closed/adds/jdk/src/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
@@ -33,6 +33,7 @@ package com.sun.crypto.provider;
 
 import java.security.InvalidKeyException;
 import java.security.ProviderException;
+import com.sun.crypto.provider.AESCrypt;
 
 import java.util.ArrayDeque;
 import jdk.crypto.jniprovider.NativeCrypto;
@@ -155,6 +156,11 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
 
         if ((key == null) || (iv == null) || (iv.length != blockSize)) {
             throw new InvalidKeyException("Internal error");
+        }
+
+        if (!AESCrypt.isKeySizeValid(key.length)) {
+            throw new InvalidKeyException("Invalid AES key length: " +
+                key.length + " bytes");
         }
 
         this.iv = iv.clone();

--- a/closed/adds/jdk/src/share/classes/com/sun/crypto/provider/NativeGaloisCounterMode.java
+++ b/closed/adds/jdk/src/share/classes/com/sun/crypto/provider/NativeGaloisCounterMode.java
@@ -319,6 +319,11 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
             throw new InvalidKeyException("Internal error");
         }
 
+        if (!AESCrypt.isKeySizeValid(keyValue.length)) {
+            throw new InvalidKeyException("Invalid AES key length: " +
+                keyValue.length + " bytes");
+        }
+
         //// always encrypt mode for embedded cipher
         //this.embeddedCipher.init(false, algorithm, keyValue);
         //this.subkeyH = new byte[AES_BLOCK_SIZE];


### PR DESCRIPTION
Same as https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/152