### PR TITLE
Verify the minimum NASM version requirement is met on x86

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -1010,7 +1010,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -1251,7 +1250,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1504,15 +1502,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1650,7 +1639,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1803,7 +1792,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -4396,7 +4384,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1555491912
+DATE_WHEN_GENERATED=1556287488
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -52,6 +52,7 @@ AC_DEFUN_ONCE([CUSTOM_EARLY_HOOK],
   AC_SUBST(MSVCP_DLL)
 
   OPENJ9_THIRD_PARTY_REQUIREMENTS
+  OPENJ9_CHECK_NASM_VERSION
 ])
 
 AC_DEFUN([OPENJ9_CONFIGURE_CMAKE],
@@ -244,6 +245,44 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
   AC_SUBST(OPENJ9_BUILDSPEC)
   AC_SUBST(OPENJ9_PLATFORM_CODE)
   AC_SUBST(OPENJ9_LIBS_SUBDIR)
+])
+
+AC_DEFUN_ONCE([OPENJ9_CHECK_NASM_VERSION],
+[
+  OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU($host_cpu)
+
+  # OPENJ9_CPU == x86-64 even for win32 builds
+  if test "x$OPENJ9_CPU" = xx86-64 ; then
+    AC_CHECK_PROG(NASM_INSTALLED,nasm,yes,no)
+    if test "x$NASM_INSTALLED" = xyes ; then
+      AC_MSG_CHECKING([whether nasm version requirement is met])
+
+      # Require NASM v2.13+. This is checked by trying to build conftest.c
+      # containing an AVX512 instruction that is supported in v2.13+
+      AC_LANG_CONFTEST([AC_LANG_SOURCE([vinserti32x8 zmm0, ymm1, 1;])])
+
+      # the following hack is needed because conftest.c contains C preprocessor
+      # directives defined in confdefs.h that would cause nasm to error out
+      $SED -i -e '/vinsert/!d' conftest.c
+
+      if nasm -f elf64 conftest.c 2> /dev/null ; then
+        AC_MSG_RESULT([yes])
+      else
+        # NASM version string is of the following format:
+        #  ---
+        #  NASM version 2.14.02 compiled on Dec 27 2018
+        #  ---
+        # Some builds may not contain any text after the version number
+        #
+        # NASM_VERSION is set within square brackets so that the sed expression would not
+        # require quadrigraps to represent square brackets
+        [NASM_VERSION=`nasm -v | $SED -e 's/^.* \([2-9]\.[0-9][0-9]\.[0-9][0-9]\).*$/\1/'`]
+        AC_MSG_ERROR([nasm version detected: $NASM_VERSION; required version 2.13+])
+      fi
+    else
+      AC_MSG_ERROR([nasm not found])
+    fi
+  fi
 ])
 
 AC_DEFUN_ONCE([OPENJDK_VERSION_DETAILS],


### PR DESCRIPTION
OpenJ9 JIT requires NASM version 2.13+ to build on x86.

Re-ran autogen.sh to update the generated scripts.

Issue: eclipse/openj9#4653

Signed-off-by: Nazim Uddin Bhuiyan <Nazim.Uddin.Bhuiyan@ibm.com>