### PR TITLE
(v0.14.2) Disable openssl native crypto for MessageDigest

### DIFF
--- a/jdk/src/share/classes/sun/security/provider/SunEntries.java
+++ b/jdk/src/share/classes/sun/security/provider/SunEntries.java
@@ -95,12 +95,15 @@ final class SunEntries {
      *
      * By default, the native crypto is enabled and uses the native
      * crypto library implementation.
+     * 
+     * The native crypto for MessageDigest is disabled until
+     * https://github.com/eclipse/openj9/issues/5611 can be resolved.
      *
      * The property 'jdk.nativeDigest' is used to disable Native digest alone
      * and 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
      * CBC, GCM, and RSA).
      */
-    private static boolean useNativeDigest = true;
+    private static boolean useNativeDigest = false;
 
     private SunEntries() {
         // empty


### PR DESCRIPTION
Avoid problems such as eclipse/openj9#5611

Doc issue eclipse/openj9-docs#269

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>