### PR TITLE
Add OpenSSL related settings to CUSTOM_COMPILER_ENV_VARS

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -408,11 +408,6 @@ endif
 ifneq (,$(OPENJ9_DEVELOPER_DIR))
   CUSTOM_COMPILER_ENV_VARS += DEVELOPER_DIR="$(OPENJ9_DEVELOPER_DIR)"
 endif
-ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
-  ifneq (true,$(OPENJ9_ENABLE_CMAKE))
-    CUSTOM_COMPILER_ENV_VARS += JITSERVER_SUPPORT=1
-  endif
-endif
 
 generate-j9-version-headers :
 	@$(ECHO) Ensuring version information is up-to-date
@@ -470,9 +465,21 @@ ifneq (,$(CCACHE))
 endif # CCACHE
 ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
   CMAKE_ARGS += -DJITSERVER_SUPPORT=ON
+
+  ifneq (,$(OPENSSL_CFLAGS))
+    CMAKE_ARGS += -DOPENSSL_CFLAGS="$(OPENSSL_CFLAGS)"
+  endif
+
+  ifneq (,$(OPENSSL_DIR))
+    CMAKE_ARGS += -DOPENSSL_DIR="$(OPENSSL_DIR)"
+  endif
+
+  ifneq (,$(OPENSSL_BUNDLE_LIB_PATH))
+    CMAKE_ARGS += -DOPENSSL_BUNDLE_LIB_PATH="$(OPENSSL_BUNDLE_LIB_PATH)"
+  endif
 else
   CMAKE_ARGS += -DJITSERVER_SUPPORT=OFF
-endif
+endif # OPENJ9_ENABLE_JITSERVER
 
   CMAKE_ARGS += $(EXTRA_CMAKE_ARGS)
 
@@ -484,6 +491,22 @@ $(OUTPUT_ROOT)/vm/cmake.stamp :
 run-preprocessors-j9 : $(OUTPUT_ROOT)/vm/cmake.stamp
 
 else # OPENJ9_ENABLE_CMAKE
+
+ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
+  CUSTOM_COMPILER_ENV_VARS += JITSERVER_SUPPORT=1
+
+  ifneq (,$(OPENSSL_CFLAGS))
+    CUSTOM_COMPILER_ENV_VARS += OPENSSL_CFLAGS="$(OPENSSL_CFLAGS)"
+  endif
+
+  ifneq (,$(OPENSSL_DIR))
+    CUSTOM_COMPILER_ENV_VARS += OPENSSL_DIR="$(OPENSSL_DIR)"
+  endif
+
+  ifneq (,$(OPENSSL_BUNDLE_LIB_PATH))
+    CUSTOM_COMPILER_ENV_VARS += OPENSSL_BUNDLE_LIB_PATH="$(OPENSSL_BUNDLE_LIB_PATH)"
+  endif
+endif # OPENJ9_ENABLE_JITSERVER
 
 run-preprocessors-j9 : stage-j9
 	@$(ECHO) Running OpenJ9 preprocessors with OPENJ9_BUILDSPEC: $(OPENJ9_BUILDSPEC)

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4397,7 +4397,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1574278275
+DATE_WHEN_GENERATED=1576018331
 
 ###############################################################################
 #

--- a/jdk/make/CopyFiles.gmk
+++ b/jdk/make/CopyFiles.gmk
@@ -323,7 +323,30 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
 
     COPY_FILES += $(OPENSSL_TARGET_LIB)
   endif
-endif
+
+  ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
+    # Copy OpenSSL SSL Lbrary
+    # To bundle first search for libssl 1.1.x library, if not found, search for 1.0.x
+    ifeq ($(OPENJDK_TARGET_OS), linux)
+      OPENSSL_SSL_LIB_NAME = libssl.so.1.1
+      ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_SSL_LIB_NAME))", "")
+        OPENSSL_SSL_LIB_NAME = libssl.so.1.0.0
+        ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_SSL_LIB_NAME))", "")
+          OPENSSL_SSL_LIB_NAME =
+        endif
+      endif
+
+      ifneq ($(OPENSSL_SSL_LIB_NAME), )
+        OPENSSL_SSL_TARGET_LIB = $(JDK_OUTPUTDIR)/lib$(OPENJDK_TARGET_CPU_LIBDIR)/$(OPENSSL_SSL_LIB_NAME)
+
+        $(OPENSSL_SSL_TARGET_LIB): $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_SSL_LIB_NAME)
+			$(call install-file)
+
+        COPY_FILES += $(OPENSSL_SSL_TARGET_LIB)
+      endif # OPENSSL_SSL_LIB_NAME
+    endif # OPENJDK_TARGET_OS
+  endif # OPENJ9_ENABLE_JITSERVER
+endif # OPENSSL_BUNDLE_LIB_PATH
 
 ##########################################################################################
 

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -702,6 +702,20 @@ AC_DEFUN([CONFIGURE_OPENSSL],
 
     AC_MSG_CHECKING([if we should bundle openssl])
     AC_MSG_RESULT([$BUNDLE_OPENSSL])
+
+    if test "x$OPENJ9_ENABLE_JITSERVER" = xtrue ; then
+      if test "x$OPENJDK_TARGET_OS" = xlinux ; then
+        if test "x$OPENSSL_DIR" != x ; then
+          AC_MSG_CHECKING([if the required OPENSSL API exists for JITServer in $OPENSSL_DIR])
+          if $GREP -q -w SSL_CTX_set_ecdh_auto "$OPENSSL_DIR/include/openssl/ssl.h" 2> /dev/null ; then
+            AC_MSG_RESULT([yes])
+          else
+            AC_MSG_RESULT([no])
+            AC_MSG_ERROR([SSL_CTX_set_ecdh_auto is required by JITServer])
+          fi
+        fi
+      fi
+    fi
   fi
 
   AC_SUBST(OPENSSL_BUNDLE_LIB_PATH)

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -4576,7 +4576,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1574278275
+DATE_WHEN_GENERATED=1576018331
 
 ###############################################################################
 #
@@ -55786,6 +55786,23 @@ $as_echo "yes" >&6; }
 $as_echo_n "checking if we should bundle openssl... " >&6; }
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $BUNDLE_OPENSSL" >&5
 $as_echo "$BUNDLE_OPENSSL" >&6; }
+
+    if test "x$OPENJ9_ENABLE_JITSERVER" = xtrue ; then
+      if test "x$OPENJDK_TARGET_OS" = xlinux ; then
+        if test "x$OPENSSL_DIR" != x ; then
+          { $as_echo "$as_me:${as_lineno-$LINENO}: checking if the required OPENSSL API exists for JITServer in $OPENSSL_DIR" >&5
+$as_echo_n "checking if the required OPENSSL API exists for JITServer in $OPENSSL_DIR... " >&6; }
+          if $GREP -q -w SSL_CTX_set_ecdh_auto "$OPENSSL_DIR/include/openssl/ssl.h" 2> /dev/null ; then
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+          else
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+            as_fn_error $? "SSL_CTX_set_ecdh_auto is required by JITServer" "$LINENO" 5
+          fi
+        fi
+      fi
+    fi
   fi
 
 


### PR DESCRIPTION
`JITServer` needs to be built with `libssl`. By default, it
is built against the `OpenSSL` installed on the build machine.

This change passes the `OpenSSL` build flags from OpenJDK to
JIT build environment.
- Add `OPENSSL_DIR`, `OPENSSL_CFLAGS`, `OPENSSL_LIBS`,
  and `OPENSSL_BUNDLE_LIB_PATH` to `CUSTOM_COMPILER_ENV_VARS`.
- Bundle `libssl` if `--with-openssl=fetched --enable-openssl-bundling`
  is set.

The JIT build change is addressed in: 
eclipse/openj9#5789, eclipse/openj9#7846

Examples on the supported flags:
```
--enable-jitserver --with-openssl=fetched
--enable-jitserver --with-openssl=fetched --enable-openssl-bundling
--enable-jitserver --with-openssl=system
```
Issue: eclipse/openj9#5720

Signed-off-by: Annabelle Huo <Annabelle.Huo@ibm.com>