### PR TITLE
AArch64: Allow aarch64 as the target processor

### DIFF
--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -178,7 +178,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_DDR],
     OPENJ9_ENABLE_DDR=false
   elif test "x$enable_ddr" = x ; then
     case "$OPENJ9_PLATFORM_CODE" in
-      ap64|oa64|wa64|wi32|xa64|xl64|xz64)
+      ap64|oa64|wa64|wi32|xa64|xl64|xr64|xz64)
         AC_MSG_RESULT([yes (default for $OPENJ9_PLATFORM_CODE)])
         OPENJ9_ENABLE_DDR=true
         ;;
@@ -209,6 +209,9 @@ AC_DEFUN([OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU],
       ;;
     powerpc64)
       OPENJ9_CPU=ppc-64
+      ;;
+    aarch64)
+      OPENJ9_CPU=aarch64
       ;;
     *)
       AC_MSG_ERROR([unsupported OpenJ9 cpu $1])
@@ -289,6 +292,8 @@ AC_DEFUN([OPENJ9_PLATFORM_SETUP],
     OPENJ9_PLATFORM_CODE=xz64
   elif test "x$OPENJ9_CPU" = xppc-64 ; then
     OPENJ9_PLATFORM_CODE=ap64
+  elif test "x$OPENJ9_CPU" = xaarch64 ; then
+    OPENJ9_PLATFORM_CODE=xr64
   else
     AC_MSG_ERROR([Unsupported OpenJ9 cpu ${OPENJ9_CPU}!])
   fi

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -15196,6 +15196,9 @@ fi
     powerpc64)
       OPENJ9_CPU=ppc-64
       ;;
+    aarch64)
+      OPENJ9_CPU=aarch64
+      ;;
     *)
       as_fn_error $? "unsupported OpenJ9 cpu $build_cpu" "$LINENO" 5
       ;;
@@ -15243,6 +15246,8 @@ fi
     OPENJ9_PLATFORM_CODE=xz64
   elif test "x$OPENJ9_CPU" = xppc-64 ; then
     OPENJ9_PLATFORM_CODE=ap64
+  elif test "x$OPENJ9_CPU" = xaarch64 ; then
+    OPENJ9_PLATFORM_CODE=xr64
   else
     as_fn_error $? "Unsupported OpenJ9 cpu ${OPENJ9_CPU}!" "$LINENO" 5
   fi
@@ -15864,7 +15869,7 @@ $as_echo "no (explicitly disabled)" >&6; }
     OPENJ9_ENABLE_DDR=false
   elif test "x$enable_ddr" = x ; then
     case "$OPENJ9_PLATFORM_CODE" in
-      ap64|oa64|wa64|wi32|xa64|xl64|xz64)
+      ap64|oa64|wa64|wi32|xa64|xl64|xr64|xz64)
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes (default for $OPENJ9_PLATFORM_CODE)" >&5
 $as_echo "yes (default for $OPENJ9_PLATFORM_CODE)" >&6; }
         OPENJ9_ENABLE_DDR=true
@@ -17668,6 +17673,9 @@ $as_echo "no" >&6; }
       ;;
     powerpc64)
       OPENJ9_CPU=ppc-64
+      ;;
+    aarch64)
+      OPENJ9_CPU=aarch64
       ;;
     *)
       as_fn_error $? "unsupported OpenJ9 cpu $host_cpu" "$LINENO" 5

--- a/jdk/make/lib/SoundLibraries.gmk
+++ b/jdk/make/lib/SoundLibraries.gmk
@@ -23,7 +23,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2011, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2011, 2020 All Rights Reserved
 # ===========================================================================
 
 LIBJSOUND_SRC_DIRS := \
@@ -149,6 +149,10 @@ else
 
   ifeq ($(OPENJDK_TARGET_CPU), s390x)
     LIBJSOUND_CFLAGS += -DX_ARCH=X_S390X
+  endif
+
+  ifeq ($(OPENJDK_TARGET_CPU), aarch64)
+    LIBJSOUND_CFLAGS += -DX_ARCH=X_AARCH64
   endif
 
 endif

--- a/jdk/src/share/native/com/sun/media/sound/SoundDefs.h
+++ b/jdk/src/share/native/com/sun/media/sound/SoundDefs.h
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+ * ===========================================================================
+ */
 
 #ifndef __SOUNDDEFS_INCLUDED__
 #define __SOUNDDEFS_INCLUDED__
@@ -45,6 +50,8 @@
 #define X_PPC           8
 #define X_PPC64         9
 #define X_PPC64LE      10
+#define X_S390X        11
+#define X_AARCH64      12
 
 // **********************************
 // Make sure you set X_PLATFORM and X_ARCH defines correctly.

--- a/jdk/src/solaris/bin/aarch64/jvm.cfg
+++ b/jdk/src/solaris/bin/aarch64/jvm.cfg
@@ -1,0 +1,39 @@
+# Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+# List of JVMs that can be used as an option to java, javac, etc.
+# Order is important -- first in this list is the default JVM.
+# NOTE that this both this file and its format are UNSUPPORTED and
+# WILL GO AWAY in a future release.
+#
+# You may also select a JVM in an arbitrary location with the
+# "-XXaltjvm=<jvm_dir>" option, but that too is unsupported
+# and may not be available in a future release.
+#
+-j9vm KNOWN
+-hotspot IGNORE
+-classic IGNORE
+-native IGNORE
+-green IGNORE


### PR DESCRIPTION
This commit adds support for AArch64 in configuring the build.

Signed-off-by: knn-k <konno@jp.ibm.com>