### PR TITLE
Allow multiple possible library paths

### DIFF
--- a/jdk/src/share/back/export/sys.h
+++ b/jdk/src/share/back/export/sys.h
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * ===========================================================================
+ */
+
 #ifndef JDWP_SYS_H
 #define JDWP_SYS_H
 
@@ -37,7 +43,7 @@
 
 /* Implemented in linker_md.c */
 
-void    dbgsysBuildLibName(char *, int, const char *, const char *);
+void    dbgsysBuildLibName(char *, size_t, const char *, const char *);
 void *  dbgsysLoadLibrary(const char *, char *err_buf, int err_buflen);
 void    dbgsysUnloadLibrary(void *);
 void *  dbgsysFindLibraryEntry(void *, const char *);

--- a/jdk/src/windows/back/linker_md.c
+++ b/jdk/src/windows/back/linker_md.c
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
  * ===========================================================================
  */
 
@@ -47,6 +47,7 @@
 static void dll_build_name(char* buffer, size_t buflen,
                            const char* paths, const char* fname) {
     char *path, *paths_copy, *next_token;
+    *buffer = '\0';
 
     paths_copy = strdup(paths);
     if (paths_copy == NULL) {
@@ -110,11 +111,9 @@ dbgsysGetLastErrorString(char *buf, int len)
  * Build a machine dependent library name out of a path and file name.
  */
 void
-dbgsysBuildLibName(char *holder, int holderlen, const char *pname, const char *fname)
+dbgsysBuildLibName(char *holder, size_t holderlen, const char *pname, const char *fname)
 {
     const int pnamelen = pname ? (int)strlen(pname) : 0;
-
-    *holder = '\0';
 
     if (pnamelen == 0) {
         size_t result_len = (size_t)_snprintf(holder, holderlen, "%s.dll", fname);


### PR DESCRIPTION
Currently, if the cumulative total length of all possible library
paths is greater than the maximum length of a single path (on this
OS), then the path to the library is left blank. This results in
failure to load the library.

This fix is the all-platforms (other than windows) port for the PR
linked below, and enables each separate path to be measured for
length independent of its neighbours.

https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/107

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>