### PR TITLE
NativeDigest context free via Cleaner API

### DIFF
--- a/jdk/src/share/classes/sun/security/provider/SunEntries.java
+++ b/jdk/src/share/classes/sun/security/provider/SunEntries.java
@@ -96,14 +96,11 @@ final class SunEntries {
      * By default, the native crypto is enabled and uses the native
      * crypto library implementation.
      *
-     * The native crypto for MessageDigest is disabled until
-     * https://github.com/eclipse/openj9/issues/5611 can be resolved.
-     * 
      * The property 'jdk.nativeDigest' is used to disable Native digest alone
      * and 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
      * CBC, GCM, and RSA).
      */
-    private static boolean useNativeDigest = false;
+    private static boolean useNativeDigest = true;
 
     private SunEntries() {
         // empty


### PR DESCRIPTION
Changing the native context release code from using a finalizer to using the Cleaner API to resolve intermittent failures.

Signed-off-by: Alon Shalev Housfater <alonsh@ca.ibm.com>