### PR TITLE
WIP:Fixed JDk8 Copyright issue

### DIFF
--- a/jdk/make/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
+++ b/jdk/make/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
@@ -4,7 +4,9 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -20,6 +22,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * (C) Copyright IBM Corp. 2019 - All Rights Reserved
+*/
 
 package build.tools.generatelsrequivmaps;
 


### PR DESCRIPTION
Issue: https://github.ibm.com/runtimes/openjdk-contribution/issues/983
Fixed JDk8 Copyright issue
:make/src/classes/build/tools/generatelsrequivmaps/EquivMapsGenerator.java
is GPL with no Classpath exception

Signed-off-by: Archana Nogriya <archana.nogriya@uk.ibm.com>