### PR TITLE
Fix LUDCL optimization

### DIFF
--- a/jdk/src/share/classes/java/io/ObjectInputStream.java
+++ b/jdk/src/share/classes/java/io/ObjectInputStream.java
@@ -346,12 +346,12 @@ public class ObjectInputStream
         classCache = (isClassCachingEnabled ? new ClassCache() : null);
     }
 
-    /** if true LUDCL/forName results would be cached, false by default starting Java8 */
+    /** if true LUDCL/forName results would be cached, true by default starting Java8 */
     private static final class GetClassCachingSettingAction
     implements PrivilegedAction<Boolean> {
         public Boolean run() {
             String property =
-                System.getProperty("com.ibm.enableClassCaching", "false");
+                System.getProperty("com.ibm.enableClassCaching", "true");
             return property.equalsIgnoreCase("true");
         }
     }

--- a/jdk/src/share/classes/java/io/ObjectInputStream.java
+++ b/jdk/src/share/classes/java/io/ObjectInputStream.java
@@ -337,25 +337,24 @@ public class ObjectInputStream
      * read* requests
      */
 
-      /* ClassCache Entry for caching class.forName results upon enableClassCaching */
-     private static final ClassCache classCache;
-     private static final boolean isClassCachingEnabled;
-     static {
-          isClassCachingEnabled =
-             AccessController.doPrivileged(new GetClassCachingSettingAction());
-         classCache = (isClassCachingEnabled ? new ClassCache() : null);
-     }
-  
+    /* ClassCache Entry for caching class.forName results upon enableClassCaching */
+    private static final ClassCache classCache;
+    private static final boolean isClassCachingEnabled;
+    static {
+        isClassCachingEnabled =
+            AccessController.doPrivileged(new GetClassCachingSettingAction());
+        classCache = (isClassCachingEnabled ? new ClassCache() : null);
+    }
 
-      /** if true LUDCL/forName results would be cached, false by default starting Java8 */
-     private static final class GetClassCachingSettingAction
-     implements PrivilegedAction<Boolean> {
- public Boolean run() {
-     String property =
-         System.getProperty("com.ibm.enableClassCaching", "false");
-     return property.equalsIgnoreCase("true");
- }
- }
+    /** if true LUDCL/forName results would be cached, false by default starting Java8 */
+    private static final class GetClassCachingSettingAction
+    implements PrivilegedAction<Boolean> {
+        public Boolean run() {
+            String property =
+                System.getProperty("com.ibm.enableClassCaching", "false");
+            return property.equalsIgnoreCase("true");
+        }
+    }
     private ClassLoader cachedLudcl;
 
     /**


### PR DESCRIPTION
Fixes: https://github.com/eclipse/openj9/issues/7332
Doc issue: https://github.com/eclipse/openj9-docs/issues/413

Ports:
ibmruntimes/openj9-openjdk-jdk11#226
ibmruntimes/openj9-openjdk-jdk13#25
ibmruntimes/openj9-openjdk-jdk#149

**Summary:**
- The assumption that the ludcl will not change during a call to readObject/readUnshared can only be made if user code is not invoked. This change triggers a refresh of the cachedLudcl when a user method is invoked.
- Re-enable ludcl caching by default (com.ibm.enableClassCaching)

**Performance assessment:** (pending)
- Daytrader7: as a general benchmark for OpenJ9
- second benchmark that to more clearly show benchmark benefits: I am working with the perf team to get results for this. From previous documentation the patches in ObjectInputStream were critical to its performance

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>