### PR TITLE
Set default load address for launchers on s390x

### DIFF
--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -224,11 +224,21 @@ else
   JAVA_RC_FLAGS += -i "$(JDK_TOPDIR)/src/closed/windows/native/sun/windows"
 endif
 
+ifeq ($(OPENJDK_TARGET_OS), linux)
+################################################################################
+# Set the image base address for zLinux 64 to 0x60000 for java and javaw launchers,
+# to make compressedRefsShift to have 0 when -Xmx is set to 2040m or more.
+# / RTC PR 100052
+  ifeq ($(OPENJDK_TARGET_CPU), s390x)
+    JAVA_LDFLAGS += -Wl,-Ttext-segment=0x60000
+  endif
+endif
+
 # On windows, the debuginfo files get the same name as for java.dll. Build
 # into another dir and copy selectively so debuginfo for java.dll isn't
 # overwritten.
 $(eval $(call SetupLauncher,java, \
-    -DEXPAND_CLASSPATH_WILDCARDS,,,user32.lib comctl32.lib, \
+    -DEXPAND_CLASSPATH_WILDCARDS,$(JAVA_LDFLAGS),,user32.lib comctl32.lib, \
     $(JDK_OUTPUTDIR)/objs/jli_static.lib, $(JAVA_RC_FLAGS), \
     $(JDK_TOPDIR)/src/windows/resource/java.rc, $(JDK_OUTPUTDIR)/objs/java_objs,true))
 
@@ -241,7 +251,7 @@ BUILD_LAUNCHERS += $(JDK_OUTPUTDIR)/bin$(OUTPUT_SUBDIR)/java$(EXE_SUFFIX)
 
 ifeq ($(OPENJDK_TARGET_OS), windows)
   $(eval $(call SetupLauncher,javaw, \
-      -DJAVAW -DEXPAND_CLASSPATH_WILDCARDS,,,user32.lib comctl32.lib, \
+      -DJAVAW -DEXPAND_CLASSPATH_WILDCARDS,$(JAVA_LDFLAGS),,user32.lib comctl32.lib, \
       $(JDK_OUTPUTDIR)/objs/jli_static.lib, $(JAVA_RC_FLAGS), \
       $(JDK_TOPDIR)/src/windows/resource/java.rc,,true))
 endif

--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -239,7 +239,7 @@ endif
 # into another dir and copy selectively so debuginfo for java.dll isn't
 # overwritten.
 $(eval $(call SetupLauncher,java, \
-    -DEXPAND_CLASSPATH_WILDCARDS,$(JAVA_LDFLAGS),,user32.lib comctl32.lib, \
+    -DEXPAND_CLASSPATH_WILDCARDS,,,user32.lib comctl32.lib, \
     $(JDK_OUTPUTDIR)/objs/jli_static.lib, $(JAVA_RC_FLAGS), \
     $(JDK_TOPDIR)/src/windows/resource/java.rc, $(JDK_OUTPUTDIR)/objs/java_objs,true))
 

--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -93,6 +93,17 @@ define SetupLauncher
   endif
 
   $1_LDFLAGS := $3
+  
+  ifeq ($(OPENJDK_TARGET_OS), linux)
+  ################################################################################
+  # Set the image base address for zLinux 64 to 0x60000 for java launchers,
+  # to make compressedRefsShift to have 0 when -Xmx is set to 2040m or more.
+  # / RTC PR 100052
+    ifeq ($(OPENJDK_TARGET_CPU), s390x)
+      $1_LDFLAGS += -Wl,-Ttext-segment=0x60000
+    endif
+  endif
+
   $1_LDFLAGS_SUFFIX :=
   ifeq ($(OPENJDK_TARGET_OS), macosx)
     $1_PLIST_FILE := Info-cmdline.plist
@@ -224,16 +235,6 @@ else
   JAVA_RC_FLAGS += -i "$(JDK_TOPDIR)/src/closed/windows/native/sun/windows"
 endif
 
-ifeq ($(OPENJDK_TARGET_OS), linux)
-################################################################################
-# Set the image base address for zLinux 64 to 0x60000 for java and javaw launchers,
-# to make compressedRefsShift to have 0 when -Xmx is set to 2040m or more.
-# / RTC PR 100052
-  ifeq ($(OPENJDK_TARGET_CPU), s390x)
-    JAVA_LDFLAGS += -Wl,-Ttext-segment=0x60000
-  endif
-endif
-
 # On windows, the debuginfo files get the same name as for java.dll. Build
 # into another dir and copy selectively so debuginfo for java.dll isn't
 # overwritten.
@@ -251,7 +252,7 @@ BUILD_LAUNCHERS += $(JDK_OUTPUTDIR)/bin$(OUTPUT_SUBDIR)/java$(EXE_SUFFIX)
 
 ifeq ($(OPENJDK_TARGET_OS), windows)
   $(eval $(call SetupLauncher,javaw, \
-      -DJAVAW -DEXPAND_CLASSPATH_WILDCARDS,$(JAVA_LDFLAGS),,user32.lib comctl32.lib, \
+      -DJAVAW -DEXPAND_CLASSPATH_WILDCARDS,,,user32.lib comctl32.lib, \
       $(JDK_OUTPUTDIR)/objs/jli_static.lib, $(JAVA_RC_FLAGS), \
       $(JDK_TOPDIR)/src/windows/resource/java.rc,,true))
 endif

--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -96,11 +96,13 @@ define SetupLauncher
   
   ifeq ($(OPENJDK_TARGET_OS), linux)
   ################################################################################
-  # Set the image base address for zLinux 64 to 0x60000 for java launchers,
-  # to make compressedRefsShift to have 0 when -Xmx is set to 2040m or more.
+  # Set the image base address for zLinux 64 to 0x60000 for launchers,
+  # to make compressedRefsShift to allow compressedRefsShift to be 0 when -Xmx is set to 2040m or more.
   # / RTC PR 100052
     ifeq ($(OPENJDK_TARGET_CPU), s390x)
-      $1_LDFLAGS += -Wl,-Ttext-segment=0x60000
+      ifeq ($(OPENJDK_TARGET_CPU_BITS), 64)
+        $1_LDFLAGS += -Wl,-Ttext-segment=0x60000
+      endif
     endif
   endif
 


### PR DESCRIPTION
Sets 0x60000 as the base load address for all launchers on s390x systems to enable compressed references.

**Before:**
```
80000000-80001000 r-xp 00000000 fd:01 12062765                           /root/jdk8u232-b09/bin/java
80001000-80002000 r--p 00000000 fd:01 12062765                           /root/jdk8u232-b09/bin/java
80002000-80003000 rw-p 00001000 fd:01 12062765                           /root/jdk8u232-b09/bin/java
```
<img width="1310" alt="Screenshot 2019-11-15 at 14 46 34" src="https://user-images.githubusercontent.com/25231953/68951835-bd530b80-07b6-11ea-9203-d14e936b5917.png">

**After:**
```
00060000-00061000 r-xp 00000000 fd:01 15742334                           /root/SharedDocker/openj9-openjdk-jdk8/build/linux-s390x-normal-server-release/images/j2sdk-image/bin/java
00061000-00062000 r--p 00000000 fd:01 15742334                           /root/SharedDocker/openj9-openjdk-jdk8/build/linux-s390x-normal-server-release/images/j2sdk-image/bin/java
00062000-00063000 rw-p 00001000 fd:01 15742334                           /root/SharedDocker/openj9-openjdk-jdk8/build/linux-s390x-normal-server-release/images/j2sdk-image/bin/java
```
<img width="1309" alt="Screenshot 2019-11-15 at 14 48 41" src="https://user-images.githubusercontent.com/25231953/68952009-0905b500-07b7-11ea-830f-30a7c7797ab7.png">

Fixes: https://github.com/eclipse/openj9/issues/7115

Signed-off-by: Morgan Davies morgandavies2020@gmail.com