### PR TITLE
Set default load address for launchers on s390x

### DIFF
--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -93,6 +93,16 @@ define SetupLauncher
   endif
 
   $1_LDFLAGS := $3
+  
+  ifeq ($(OPENJDK_TARGET_OS), linux)
+  # Set the image base address for zLinux 64 to 0x60000 for launchers,
+  # allows compressedRefsShift to be 0 when -Xmx is set to 2040m or more.
+  # / RTC PR 100052
+    ifeq ($(OPENJDK_TARGET_CPU), s390x)
+      $1_LDFLAGS += -Wl,-Ttext-segment=0x60000
+    endif
+  endif
+  
   $1_LDFLAGS_SUFFIX :=
   ifeq ($(OPENJDK_TARGET_OS), macosx)
     $1_PLIST_FILE := Info-cmdline.plist


### PR DESCRIPTION
Sets the load address of the launchers to 0x60000 on zlinux 64 systems. This enables compressed references with shift 0 for big heap sizes between 2040m and 4000m.

**Before:**
```
80000000-80001000 r-xp 00000000 fd:01 12062765                           /root/jdk8u232-b09/bin/java
80001000-80002000 r--p 00000000 fd:01 12062765                           /root/jdk8u232-b09/bin/java
80002000-80003000 rw-p 00001000 fd:01 12062765                           /root/jdk8u232-b09/bin/java
```
<img width="1310" alt="Screenshot 2019-11-15 at 14 46 34" src="https://user-images.githubusercontent.com/25231953/68951835-bd530b80-07b6-11ea-9203-d14e936b5917.png">

**After:**
```
00060000-00061000 r-xp 00000000 fd:01 15742334                           /root/SharedDocker/openj9-openjdk-jdk8/build/linux-s390x-normal-server-release/images/j2sdk-image/bin/java
00061000-00062000 r--p 00000000 fd:01 15742334                           /root/SharedDocker/openj9-openjdk-jdk8/build/linux-s390x-normal-server-release/images/j2sdk-image/bin/java
00062000-00063000 rw-p 00001000 fd:01 15742334                           /root/SharedDocker/openj9-openjdk-jdk8/build/linux-s390x-normal-server-release/images/j2sdk-image/bin/java
```
<img width="1309" alt="Screenshot 2019-11-15 at 14 48 41" src="https://user-images.githubusercontent.com/25231953/68952009-0905b500-07b7-11ea-830f-30a7c7797ab7.png">

Issue: https://github.com/eclipse/openj9/issues/7115

Signed-off-by: Morgan Davies morgan.davies@ibm.com