### PR TITLE
Set base text/data load address on aix

### DIFF
--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -104,6 +104,17 @@ define SetupLauncher
   endif
   
   $1_LDFLAGS_SUFFIX :=
+
+  # Set text/data load address for 64 bit aix to 0x100,0000,0000 (1TB) for launchers,
+  # ensures that it's out of the way of compressed heap allocation.
+  ifeq ($(OPENJDK_TARGET_OS), aix)
+    ifeq ($(OPENJDK_TARGET_CPU_BITS), 32)
+      $1_LDFLAGS_SUFFIX += -bmaxdata:0xa0000000/dsa
+    else
+      $1_LDFLAGS_SUFFIX += -bpT:0x10000000000
+    endif
+  endif
+  
   ifeq ($(OPENJDK_TARGET_OS), macosx)
     $1_PLIST_FILE := Info-cmdline.plist
     ifneq ($(11), )


### PR DESCRIPTION
Set the load address for 64 bit aix to 0x100,0000,0000 (1TB) for launchers. This ensures that the text/data segment is out of the way of compressed heap allocation.

**Before:**
```
100000000         100020961             130K r-x   s     MAINTEXT   886b77           java 
110000f5d         110001e30               3K rw-   sm    MAINDATA   873d68           java 
```
**After:**
```
10000000000       100000209e9           130K r-x   s     MAINTEXT   8d969b           java 
10010000f7d       10010001e50             3K rw-   sm    MAINDATA   8e3d94           java 
```

Issue: https://github.com/eclipse/openj9/issues/7458 

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>