### PR TITLE
Remove the check on a specific OpenSSL API for JITServer

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4397,7 +4397,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1576018331
+DATE_WHEN_GENERATED=1577815762
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -702,20 +702,6 @@ AC_DEFUN([CONFIGURE_OPENSSL],
 
     AC_MSG_CHECKING([if we should bundle openssl])
     AC_MSG_RESULT([$BUNDLE_OPENSSL])
-
-    if test "x$OPENJ9_ENABLE_JITSERVER" = xtrue ; then
-      if test "x$OPENJDK_TARGET_OS" = xlinux ; then
-        if test "x$OPENSSL_DIR" != x ; then
-          AC_MSG_CHECKING([if the required OPENSSL API exists for JITServer in $OPENSSL_DIR])
-          if $GREP -q -w SSL_CTX_set_ecdh_auto "$OPENSSL_DIR/include/openssl/ssl.h" 2> /dev/null ; then
-            AC_MSG_RESULT([yes])
-          else
-            AC_MSG_RESULT([no])
-            AC_MSG_ERROR([SSL_CTX_set_ecdh_auto is required by JITServer])
-          fi
-        fi
-      fi
-    fi
   fi
 
   AC_SUBST(OPENSSL_BUNDLE_LIB_PATH)

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -4576,7 +4576,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1576018331
+DATE_WHEN_GENERATED=1577815762
 
 ###############################################################################
 #
@@ -55786,23 +55786,6 @@ $as_echo "yes" >&6; }
 $as_echo_n "checking if we should bundle openssl... " >&6; }
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $BUNDLE_OPENSSL" >&5
 $as_echo "$BUNDLE_OPENSSL" >&6; }
-
-    if test "x$OPENJ9_ENABLE_JITSERVER" = xtrue ; then
-      if test "x$OPENJDK_TARGET_OS" = xlinux ; then
-        if test "x$OPENSSL_DIR" != x ; then
-          { $as_echo "$as_me:${as_lineno-$LINENO}: checking if the required OPENSSL API exists for JITServer in $OPENSSL_DIR" >&5
-$as_echo_n "checking if the required OPENSSL API exists for JITServer in $OPENSSL_DIR... " >&6; }
-          if $GREP -q -w SSL_CTX_set_ecdh_auto "$OPENSSL_DIR/include/openssl/ssl.h" 2> /dev/null ; then
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-          else
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-            as_fn_error $? "SSL_CTX_set_ecdh_auto is required by JITServer" "$LINENO" 5
-          fi
-        fi
-      fi
-    fi
   fi
 
 


### PR DESCRIPTION
With the change in eclipse/openj9#8145, `OpenSSL` symbols are dynamically loaded at the runtime. During the build time, there is no longer a dependency on the installed `OpenSSL` version on the build machines. Removed the code that checks `SSL_CTX_set_ecdh_auto` during config.

Signed-off-by: a7ehuo <Annabelle.Huo@ibm.com>