### PR TITLE
CMake: Respect '--enable-cuda' configure option

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -467,11 +467,21 @@ ifneq (,$(OPENJ9_CXX))
 else
   CMAKE_ARGS += -DCMAKE_CXX_COMPILER="$(ac_cv_prog_CXX)"
 endif
-ifeq (true,$(OPENJ9_ENABLE_DDR))
-  CMAKE_ARGS += "-DOMR_DDR=ON"
+
+ifeq (true,$(OPENJ9_ENABLE_CUDA))
+  CMAKE_ARGS += -DJ9VM_OPT_CUDA=ON
+  CMAKE_CUDA_ENV := CUDA_BIN_PATH="$(CUDA_HOME)"
 else
-   CMAKE_ARGS += "-DOMR_DDR=OFF"
-endif
+  CMAKE_ARGS += -DJ9VM_OPT_CUDA=OFF
+  CMAKE_CUDA_ENV :=
+endif # OPENJ9_ENABLE_CUDA
+
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+  CMAKE_ARGS += -DOMR_DDR=ON
+else
+  CMAKE_ARGS += -DOMR_DDR=OFF
+endif # OPENJ9_ENABLE_DDR
+
 ifneq (,$(CCACHE))
   # openjdk makefiles adds a bunch of environemnt variables to the ccache command.
   # CMake will not parse this properly, so we wrap the whole thing in the env command.
@@ -486,6 +496,7 @@ ifneq (,$(CCACHE))
   CMAKE_ARGS += "-DCMAKE_CXX_COMPILER_LAUNCHER=$(ESCAPED_CCACHE)"
   CMAKE_ARGS += "-DCMAKE_C_COMPILER_LAUNCHER=$(ESCAPED_CCACHE)"
 endif # CCACHE
+
 ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
   CMAKE_ARGS += -DJITSERVER_SUPPORT=ON
 
@@ -508,7 +519,7 @@ endif # OPENJ9_ENABLE_JITSERVER
 
 $(OUTPUT_ROOT)/vm/cmake.stamp :
 	cd $(OUTPUT_ROOT)/vm && \
-	$(CMAKE) $(CMAKE_ARGS) $(OPENJ9_TOPDIR)
+	$(CMAKE_CUDA_ENV) $(CMAKE) $(CMAKE_ARGS) $(OPENJ9_TOPDIR)
 	$(TOUCH) $@
 
 run-preprocessors-j9 : $(OUTPUT_ROOT)/vm/cmake.stamp


### PR DESCRIPTION
With cmake, `J9VM_OPT_CUDA` is off by default and `OMR_OPT_CUDA` is derived from `J9VM_OPT_CUDA`. We must set `J9VM_OPT_CUDA` on the cmake command line to enable CUDA.