### PR TITLE
CMake: Fix race creating $(OUTPUT_ROOT)/vm

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -515,8 +515,8 @@ endif # OPENJ9_ENABLE_JITSERVER
   CMAKE_ARGS += $(EXTRA_CMAKE_ARGS)
 
 $(OUTPUT_ROOT)/vm/cmake.stamp :
-	cd $(OUTPUT_ROOT)/vm && \
-	$(CMAKE_CUDA_ENV) $(CMAKE) $(CMAKE_ARGS) $(OPENJ9_TOPDIR)
+	@$(MKDIR) -p $(@D)
+	cd $(@D) && $(CMAKE_CUDA_ENV) $(CMAKE) $(CMAKE_ARGS) $(OPENJ9_TOPDIR)
 	$(TOUCH) $@
 
 run-preprocessors-j9 : $(OUTPUT_ROOT)/vm/cmake.stamp


### PR DESCRIPTION
There was a race in `OpenJ9.gmk` that apparently since #361 is now more likely to go wrong. That file has these dependencies:
```
run-preprocessors-j9 : $(OUTPUT_ROOT)/vm/cmake.stamp
run-preprocessors-j9 : generate-j9-version-headers
```
A side-effect of `generate-j9-version-headers` is the creation of the directory needed by `$(OUTPUT_ROOT)/vm/cmake.stamp`. This removes the dependency on that ordering.

Also make more like equivalent code in jdk11.