### PR TITLE
Improve integration of OpenJ9 JCL code generation

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -371,6 +371,7 @@ build-openj9-tools :
 	@$(ECHO) Building OpenJ9 Java Preprocessor
 	@$(MKDIR) -p $(J9TOOLS_DIR)
 	$(MAKE) -C $(OPENJ9_TOPDIR)/sourcetools $(MAKEFLAGS) -f buildj9tools.mk \
+		BOOT_JDK=$(BOOT_JDK) \
 		DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
 		JAVA_HOME=$(BOOT_JDK) \
 		$(call FixPath,$(JPP_JAR))
@@ -541,9 +542,11 @@ endif # OPENJ9_ENABLE_JITSERVER
 
 run-preprocessors-j9 : stage-j9
 	@$(ECHO) Running OpenJ9 preprocessors with OPENJ9_BUILDSPEC: $(OPENJ9_BUILDSPEC)
-	export BOOT_JDK=$(BOOT_JDK) $(EXPORT_MSVS_ENV_VARS) \
+	@$(MKDIR) -p $(J9TOOLS_DIR)
+	export $(EXPORT_MSVS_ENV_VARS) \
 		OPENJDK_VERSION_NUMBER_FOUR_POSITIONS=$(VERSION_NUMBER_FOUR_POSITIONS) \
 		&& $(MAKE) -C $(OUTPUT_ROOT)/vm $(MAKEFLAGS) -f $(OPENJ9_TOPDIR)/runtime/buildtools.mk \
+			BOOT_JDK=$(BOOT_JDK) \
 			BUILD_ID=$(BUILD_ID) \
 			DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
 			FREEMARKER_JAR="$(FREEMARKER_JAR)" \

--- a/closed/make/BuildJdk.gmk
+++ b/closed/make/BuildJdk.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -18,36 +18,14 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
-clean-j9vm :
-	$(call CleanComponent,vm)
+# Generate J9JCL source just before openjdk source generation.
 
-.PHONY : \
-	j9vm-build \
-	j9vm-compose-buildjvm \
-	test-image \
-	test-image-openj9 \
-	#
+gensrc-only : generate_openj9_j9jcl
 
 OPENJ9_MAKE := $(MAKE) -f $(SRC_ROOT)/closed/OpenJ9.gmk SPEC=$(SPEC)
 
-OPENSSL_MAKE := $(MAKE) -f $(SRC_ROOT)/closed/openssl.gmk SPEC=$(SPEC)
+.PHONY : generate_openj9_j9jcl
 
-openssl-build :
-	+$(OPENSSL_MAKE)
-
-j9vm-build : openssl-build
-	+$(OPENJ9_MAKE) build-j9
-
-j9vm-compose-buildjvm : j9vm-build
-	+$(OPENJ9_MAKE) stage_openj9_build_jdk
-
-all : test-image
-
-test-image : test-image-openj9
-
-# If not cross-compiling, capture 'java -version' output.
-test-image-openj9 : images
-	+$(OPENJ9_MAKE) openj9_test_image
-ifneq ($(COMPILE_TYPE), cross)
-	$(JRE_IMAGE_DIR)/bin/java -version 2>&1 | $(TEE) $(IMAGES_OUTPUTDIR)/test/openj9/java-version.txt
-endif
+generate_openj9_j9jcl :
+	+$(OPENJ9_MAKE) build-openj9-tools
+	+$(OPENJ9_MAKE) generate-j9jcl-sources


### PR DESCRIPTION
Generation of J9JCL code was connected to the build system in an unusual manner that triggered the work at least twice and hid all diagnostics from the build log. This adds a new target that is a prerequisite of `gensrc-only` which operates as a normal make rule. It similar in spirit to ibmruntimes/openj9-openjdk-jdk11#256.

