### PR TITLE
(0.18.1) Use codesign as appropriate on OSX

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -86,51 +86,68 @@ endif
 	stage_openj9_build_jdk \
 	#
 
-# jitserver
+define copy_and_sign
+	$(call install-file)
+	$(if $(CODESIGN),$(CODESIGN) --sign "$(MACOSX_CODESIGN_IDENTITY)" "$@")
+endef
 
 ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
-$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	DEST := $(JDK_OUTPUTDIR)/bin, \
+  # sign the jitserver executable as we copy it to bin
+  $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
+	MACRO := copy_and_sign, \
 	SRC := $(OPENJ9_VM_BUILD_DIR), \
+	DEST := $(JDK_OUTPUTDIR)/bin, \
 	FILES := jitserver$(EXE_SUFFIX) \
 	))
 
-$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
+  # copy the signed jitserver executable to jre/bin
+  $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
+	MACRO := install-file, \
+	SRC := $(JDK_OUTPUTDIR)/bin, \
 	DEST := $(JDK_OUTPUTDIR)/jre/bin, \
-	SRC := $(OPENJ9_VM_BUILD_DIR), \
 	FILES := jitserver$(EXE_SUFFIX) \
 	))
 endif # OPENJ9_ENABLE_JITSERVER
 
-# redirector
-
-$(foreach subdir, j9vm server, \
-	$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-		DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(subdir), \
-		SRC := $(OPENJ9_VM_BUILD_DIR)/redirector, \
-		FILES := $(call SHARED_LIBRARY,jvm) \
-		)))
-
-# jsig
-
+# sign the redirector library as we copy it to j9vm
 $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR), \
+	MACRO := copy_and_sign, \
+	SRC := $(OPENJ9_VM_BUILD_DIR)/redirector, \
+	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm, \
+	FILES := $(call SHARED_LIBRARY,jvm) \
+	))
+
+# copy the signed redirector library to server
+$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
+	MACRO := install-file, \
+	SRC := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm, \
+	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/server, \
+	FILES := $(call SHARED_LIBRARY,jvm) \
+	))
+
+# sign the jsig library as we copy it to lib
+$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
+	MACRO := copy_and_sign, \
 	SRC := $(OPENJ9_VM_BUILD_DIR), \
+	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR), \
 	FILES := $(call SHARED_LIBRARY,jsig) \
 	))
 
+# copy the signed jsig library to j9vm and server directories
 $(foreach subdir, j9vm server, \
 	$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
+		MACRO := install-file, \
+		SRC := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR), \
 		DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(subdir), \
-		SRC := $(OPENJ9_VM_BUILD_DIR), \
 		FILES := $(call SHARED_LIBRARY,jsig) \
 	)))
 
 # regular shared libraries
 
 $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR), \
+	MACRO := copy_and_sign, \
 	SRC := $(OPENJ9_VM_BUILD_DIR), \
+	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR), \
 	FILES := $(patsubst %, $(call SHARED_LIBRARY,%), \
 		cuda4j29 \
 		j9dmp29 \
@@ -159,8 +176,9 @@ $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
 ifeq (windows,$(OPENJDK_TARGET_OS))
 
 $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	DEST := $(JDK_OUTPUTDIR)/lib, \
+	MACRO := install-file, \
 	SRC := $(OPENJ9_VM_BUILD_DIR)/lib, \
+	DEST := $(JDK_OUTPUTDIR)/lib, \
 	FILES := $(call STATIC_LIBRARY,jsig) \
 	))
 
@@ -171,32 +189,37 @@ OPENJ9_STAGED_FILES += $(JDK_OUTPUTDIR)/lib/$(call STATIC_LIBRARY,jvm)
 
 endif # windows
 
-# classlib.properties
-
-$(JDK_OUTPUTDIR)/lib/classlib.properties : $(SRC_ROOT)/closed/classlib.properties
-	$(install-file)
-
-OPENJ9_STAGED_FILES += $(JDK_OUTPUTDIR)/lib/classlib.properties
+$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
+	MACRO := install-file, \
+	SRC := $(SRC_ROOT)/closed, \
+	DEST := $(JDK_OUTPUTDIR)/lib, \
+	FILES := classlib.properties \
+	))
 
 $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR), \
+	MACRO := install-file, \
 	SRC := $(OPENJ9_VM_BUILD_DIR), \
+	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR), \
 	FILES := \
 		$(notdir $(wildcard $(OUTPUT_ROOT)/vm/java*.properties)) \
 		options.default \
 	))
 
 $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	DEST := $(JDK_OUTPUTDIR)/lib, \
+	MACRO := install-file, \
 	SRC := $(OPENJ9_VM_BUILD_DIR), \
+	DEST := $(JDK_OUTPUTDIR)/lib, \
 	FILES := \
 		J9TraceFormat.dat \
 		OMRTraceFormat.dat \
 	))
 
 ifeq (true,$(OPENJ9_ENABLE_DDR))
+
 .PHONY : run-ddrgen
+
 $(OPENJ9_VM_BUILD_DIR)/j9ddr.dat : run-ddrgen
+
 run-ddrgen :
 ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 	$(MAKE) -C $(OPENJ9_VM_BUILD_DIR) j9ddr
@@ -204,11 +227,14 @@ else # OPENJ9_ENABLE_CMAKE
 	export CC="$(CC)" CXX="$(CXX)" VERSION_MAJOR=8 $(EXPORT_MSVS_ENV_VARS) \
 		&& $(MAKE) -C $(OPENJ9_VM_BUILD_DIR)/ddr -f run_omrddrgen.mk
 endif # OPENJ9_ENABLE_CMAKE
+
 $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR), \
+	MACRO := install-file, \
 	SRC := $(OPENJ9_VM_BUILD_DIR), \
+	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR), \
 	FILES := j9ddr.dat \
 	))
+
 endif # OPENJ9_ENABLE_DDR
 
 stage_openj9_build_jdk : $(OPENJ9_STAGED_FILES)
@@ -239,7 +265,7 @@ OPENJ9_TEST_IMAGE_DIR := $(IMAGES_OUTPUTDIR)/test/openj9
 define openj9_test_image_rules
 openj9_test_image : $(OPENJ9_TEST_IMAGE_DIR)/$(notdir $(strip $1))
 $(OPENJ9_TEST_IMAGE_DIR)/$(notdir $(strip $1)) : $(strip $1)
-	$$(call install-file)
+	$$(copy_and_sign)
 endef
 
 $(foreach file, \

--- a/common/autoconf/basics.m4
+++ b/common/autoconf/basics.m4
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+
 # Test if $1 is a valid argument to $3 (often is $JAVA passed as $3)
 # If so, then append $1 to $2 \
 # Also set JVM_ARG_OK to true/false depending on outcome.
@@ -847,12 +851,22 @@ AC_DEFUN_ONCE([BASIC_SETUP_COMPLEX_TOOLS],
     BASIC_REQUIRE_PROGS(XATTR, xattr)
     BASIC_PATH_PROGS(CODESIGN, codesign)
     if test "x$CODESIGN" != "x"; then
-      # Verify that the openjdk_codesign certificate is present
-      AC_MSG_CHECKING([if openjdk_codesign certificate is present])
-      rm -f codesign-testfile
-      touch codesign-testfile
-      codesign -s openjdk_codesign codesign-testfile 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD || CODESIGN=
-      rm -f codesign-testfile
+      # Check for user provided code signing identity.
+      # If no identity was provided, fall back to "openjdk_codesign".
+      AC_ARG_WITH([macosx-codesign-identity], [AS_HELP_STRING([--with-macosx-codesign-identity],
+        [specify the code signing identity])],
+        [MACOSX_CODESIGN_IDENTITY=$with_macosx_codesign_identity],
+        [MACOSX_CODESIGN_IDENTITY=openjdk_codesign]
+      )
+
+      AC_SUBST(MACOSX_CODESIGN_IDENTITY)
+
+      # Verify that the codesign certificate is present
+      AC_MSG_CHECKING([if codesign certificate is present])
+      $RM codesign-testfile
+      $TOUCH codesign-testfile
+      $CODESIGN -s "$MACOSX_CODESIGN_IDENTITY" codesign-testfile 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD || CODESIGN=
+      $RM codesign-testfile
       if test "x$CODESIGN" = x; then
         AC_MSG_RESULT([no])
       else

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -856,6 +856,7 @@ OS_VERSION_MICRO
 OS_VERSION_MINOR
 OS_VERSION_MAJOR
 PKG_CONFIG
+MACOSX_CODESIGN_IDENTITY
 CODESIGN
 XATTR
 DSYMUTIL
@@ -1050,6 +1051,7 @@ with_toolchain_path
 with_extra_path
 with_xcode_path
 with_conf_name
+with_macosx_codesign_identity
 with_builddeps_conf
 with_builddeps_server
 with_builddeps_dir
@@ -1896,6 +1898,8 @@ Optional Packages:
                           10.9 and later)
   --with-conf-name        use this as the name of the configuration [generated
                           from important configuration options]
+  --with-macosx-codesign-identity
+                          specify the code signing identity
   --with-builddeps-conf   use this configuration file for the builddeps
   --with-builddeps-server download and use build dependencies from this server
                           url
@@ -3365,6 +3369,10 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+
 # Test if $1 is a valid argument to $3 (often is $JAVA passed as $3)
 # If so, then append $1 to $2 \
 # Also set JVM_ARG_OK to true/false depending on outcome.
@@ -4397,7 +4405,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1577815762
+DATE_WHEN_GENERATED=1580305659
 
 ###############################################################################
 #
@@ -19387,13 +19395,27 @@ $as_echo "$tool_specified" >&6; }
 
 
     if test "x$CODESIGN" != "x"; then
-      # Verify that the openjdk_codesign certificate is present
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking if openjdk_codesign certificate is present" >&5
-$as_echo_n "checking if openjdk_codesign certificate is present... " >&6; }
-      rm -f codesign-testfile
-      touch codesign-testfile
-      codesign -s openjdk_codesign codesign-testfile 2>&5 >&5 || CODESIGN=
-      rm -f codesign-testfile
+      # Check for user provided code signing identity.
+      # If no identity was provided, fall back to "openjdk_codesign".
+
+# Check whether --with-macosx-codesign-identity was given.
+if test "${with_macosx_codesign_identity+set}" = set; then :
+  withval=$with_macosx_codesign_identity; MACOSX_CODESIGN_IDENTITY=$with_macosx_codesign_identity
+else
+  MACOSX_CODESIGN_IDENTITY=openjdk_codesign
+
+fi
+
+
+
+
+      # Verify that the codesign certificate is present
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking if codesign certificate is present" >&5
+$as_echo_n "checking if codesign certificate is present... " >&6; }
+      $RM codesign-testfile
+      $TOUCH codesign-testfile
+      $CODESIGN -s "$MACOSX_CODESIGN_IDENTITY" codesign-testfile 2>&5 >&5 || CODESIGN=
+      $RM codesign-testfile
       if test "x$CODESIGN" = x; then
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }

--- a/common/autoconf/spec.gmk.in
+++ b/common/autoconf/spec.gmk.in
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2020 All Rights Reserved
 # ===========================================================================
 
 # Configured @DATE_WHEN_CONFIGURED@ to build
@@ -331,6 +331,9 @@ X_LIBS:=@X_LIBS@
 
 # The lowest required version of macosx to enforce compatiblity for
 MACOSX_VERSION_MIN=@MACOSX_VERSION_MIN@
+
+# The macosx code signing identity to use
+MACOSX_CODESIGN_IDENTITY=@MACOSX_CODESIGN_IDENTITY@
 
 # Toolchain type: gcc, clang, solstudio, lxc, microsoft...
 TOOLCHAIN_TYPE:=@TOOLCHAIN_TYPE@

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -918,6 +918,7 @@ OS_VERSION_MICRO
 OS_VERSION_MINOR
 OS_VERSION_MAJOR
 PKG_CONFIG
+MACOSX_CODESIGN_IDENTITY
 CODESIGN
 XATTR
 DSYMUTIL
@@ -1153,6 +1154,7 @@ with_tools_dir
 with_toolchain_path
 with_extra_path
 with_xcode_path
+with_macosx_codesign_identity
 with_builddeps_conf
 with_builddeps_server
 with_builddeps_dir
@@ -2024,6 +2026,8 @@ Optional Packages:
   --with-extra-path       prepend these directories to the default path
   --with-xcode-path       explicit path to Xcode 4 (generally for building on
                           10.9 and later)
+  --with-macosx-codesign-identity
+                          specify the code signing identity
   --with-builddeps-conf   use this configuration file for the builddeps
   --with-builddeps-server download and use build dependencies from this server
                           url
@@ -3495,6 +3499,10 @@ ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+
 # Test if $1 is a valid argument to $3 (often is $JAVA passed as $3)
 # If so, then append $1 to $2 \
 # Also set JVM_ARG_OK to true/false depending on outcome.
@@ -4576,7 +4584,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1577815762
+DATE_WHEN_GENERATED=1580305659
 
 ###############################################################################
 #
@@ -22074,13 +22082,27 @@ $as_echo "$tool_specified" >&6; }
 
 
     if test "x$CODESIGN" != "x"; then
-      # Verify that the openjdk_codesign certificate is present
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking if openjdk_codesign certificate is present" >&5
-$as_echo_n "checking if openjdk_codesign certificate is present... " >&6; }
-      rm -f codesign-testfile
-      touch codesign-testfile
-      codesign -s openjdk_codesign codesign-testfile 2>&5 >&5 || CODESIGN=
-      rm -f codesign-testfile
+      # Check for user provided code signing identity.
+      # If no identity was provided, fall back to "openjdk_codesign".
+
+# Check whether --with-macosx-codesign-identity was given.
+if test "${with_macosx_codesign_identity+set}" = set; then :
+  withval=$with_macosx_codesign_identity; MACOSX_CODESIGN_IDENTITY=$with_macosx_codesign_identity
+else
+  MACOSX_CODESIGN_IDENTITY=openjdk_codesign
+
+fi
+
+
+
+
+      # Verify that the codesign certificate is present
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking if codesign certificate is present" >&5
+$as_echo_n "checking if codesign certificate is present... " >&6; }
+      $RM codesign-testfile
+      $TOUCH codesign-testfile
+      $CODESIGN -s "$MACOSX_CODESIGN_IDENTITY" codesign-testfile 2>&5 >&5 || CODESIGN=
+      $RM codesign-testfile
       if test "x$CODESIGN" = x; then
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+
 # When you read this source. Remember that $(sort ...) has the side effect
 # of removing duplicates. It is actually this side effect that is
 # desired whenever sort is used below!
@@ -624,11 +628,11 @@ endif # no MacOS X support yet
         ifneq (,$$($1_GEN_MANIFEST))
 	  $(MT) -nologo -manifest $$($1_GEN_MANIFEST) -outputresource:$$@;#1
         endif
-        # This only works if the openjdk_codesign identity is present on the system. Let
-        # silently fail otherwise.
+        # This only works if the codesign identity is present on the system.
+        # Let it silently fail otherwise.
         ifneq (,$(CODESIGN))
           ifneq (,$$($1_CODESIGN))
-	    $(CODESIGN) -s openjdk_codesign $$@
+	    $(CODESIGN) -s "$(MACOSX_CODESIGN_IDENTITY)" $$@
           endif
         endif
   endif


### PR DESCRIPTION
A replay of https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/367 for the 0.18.1 release branch.