### PR TITLE
Sign bundled crypto libraries

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -86,7 +86,7 @@ endif
 
 define copy_and_sign
 	$(call install-file)
-	$(if $(CODESIGN),$(CODESIGN) --sign "$(MACOSX_CODESIGN_IDENTITY)" "$@")
+	$(call CodesignFile,"$@")
 endef
 
 ifeq (true,$(OPENJ9_ENABLE_JITSERVER))

--- a/jdk/make/CopyFiles.gmk
+++ b/jdk/make/CopyFiles.gmk
@@ -23,9 +23,8 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2020 All Rights Reserved
 # ===========================================================================
-#
 
 INCLUDEDIR = $(JDK_OUTPUTDIR)/include
 
@@ -251,99 +250,65 @@ endif
 
 ##########################################################################################
 # Optionally copy OpenSSL Crypto Lbrary
-# To bundle first search for openssl 1.1.x library, if not found, search for 1.0.x 
+# To bundle first search for openssl 1.1.x library, if not found, search for 1.0.x
 ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
   ifeq ($(OPENJDK_TARGET_OS), linux)
-    OPENSSL_LIB_NAME = libcrypto.so.1.1
-    ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-      OPENSSL_LIB_NAME = libcrypto.so.1.0.0
-      ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-        OPENSSL_LIB_NAME = 
-      endif
-    endif
+    LIBCRYPTO_NAMES := libcrypto.so.1.1 libcrypto.so.1.0.0
   else ifeq ($(OPENJDK_TARGET_OS), macosx)
-    OPENSSL_LIB_NAME = libcrypto.1.1.dylib
-    ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-      OPENSSL_LIB_NAME = libcrypto.1.0.0.dylib
-      ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-        OPENSSL_LIB_NAME = 
-      endif
-    endif
+    LIBCRYPTO_NAMES := libcrypto.1.1.dylib libcrypto.1.0.0.dylib
   else ifeq ($(OPENJDK_TARGET_OS), windows)
     ifeq ($(OPENJDK_TARGET_CPU_BITS), 64)
-      OPENSSL_LIB_NAME = libcrypto-1_1-x64.dll
+      LIBCRYPTO_NAMES := libcrypto-1_1-x64.dll
     else
-      OPENSSL_LIB_NAME = libcrypto-1_1.dll
+      LIBCRYPTO_NAMES := libcrypto-1_1.dll
     endif
-    ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-      OPENSSL_LIB_NAME = libeay32.dll
-      ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-        OPENSSL_LIB_NAME = 
-      endif
-    endif
+    LIBCRYPTO_NAMES += libeay32.dll
   else ifeq ($(OPENJDK_TARGET_OS), aix)
     # OpenSSL 1.1.1 on AIX has switched to use archive library files (natural way)
     # instead of 'libcrypto.so' files.
     # For reference, corresponding OpenSSL PR is
     #     https://github.com/openssl/openssl/pull/6487
-    # For OpenSSL v1.1.0, bundle libcrypto.so.1.0.0 library with JDK
-    OPENSSL_LIB_NAME = libcrypto.so.1.1
-    ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-      # For OpenSSL v1.0.0, bundle libcrypto.so.1.1 library with JDK
-      OPENSSL_LIB_NAME = libcrypto.so.1.0.0
-      ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME))", "")
-        # For OpenSSL v1.1.1, bundle libcrypto.a library with JDK
-        OPENSSL_LIB_NAME = libcrypto.a
-      endif
-    endif
+    LIBCRYPTO_NAMES := libcrypto.so.1.1 libcrypto.so.1.0.0 libcrypto.a
   else
-    OPENSSL_LIB_NAME = 
+    LIBCRYPTO_NAMES := libcrypto.so
+  endif
+  LIBCRYPTO_PATH := $(firstword $(wildcard $(addprefix $(OPENSSL_BUNDLE_LIB_PATH)/, $(LIBCRYPTO_NAMES))))
+  ifeq ($(LIBCRYPTO_PATH), )
+    $(error Cannot bundle OpenSSL - none of $(LIBCRYPTO_NAMES) are present in $(OPENSSL_BUNDLE_LIB_PATH))
   endif
 
-  ifneq ($(OPENSSL_LIB_NAME), )
-    ifeq ($(OPENJDK_TARGET_OS), windows)
-      OPENSSL_TARGET_LIB = $(JDK_OUTPUTDIR)/bin/$(OPENSSL_LIB_NAME)
-    else
-      OPENSSL_TARGET_LIB = $(JDK_OUTPUTDIR)/lib$(OPENJDK_TARGET_CPU_LIBDIR)/$(OPENSSL_LIB_NAME)
-    endif
-
-    # On Mac OS, update the crypto library path to @rpath as the default is /usr/local/lib/
-    ifeq ($(OPENJDK_BUILD_OS), macosx)
-      .PHONY : RPATH_CRYPTO_LIB
-      COPY_FILES += RPATH_CRYPTO_LIB
-      RPATH_CRYPTO_LIB :
-	install_name_tool -id "@rpath/$(OPENSSL_LIB_NAME)" "$(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME)"
-    endif
-
-    $(OPENSSL_TARGET_LIB): $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME)
-	$(CP) $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_LIB_NAME) $@
-    ifeq ($(OPENJDK_BUILD_OS), windows)
-	$(CHMOD) +rx $@
-    endif
-
-    COPY_FILES += $(OPENSSL_TARGET_LIB)
+  ifeq ($(OPENJDK_TARGET_OS), windows)
+    LIBCRYPTO_TARGET_LIB := $(JDK_OUTPUTDIR)/bin/$(notdir $(LIBCRYPTO_PATH))
+  else
+    LIBCRYPTO_TARGET_LIB := $(JDK_OUTPUTDIR)/lib$(OPENJDK_TARGET_CPU_LIBDIR)/$(notdir $(LIBCRYPTO_PATH))
   endif
+
+  $(LIBCRYPTO_TARGET_LIB) : $(LIBCRYPTO_PATH)
+	$(call install-file)
+  ifeq ($(OPENJDK_BUILD_OS), macosx)
+    # update @rpath of the crypto library as the default is /usr/local/lib/
+	install_name_tool -id "@rpath/$(@F)" $@
+  else ifeq ($(OPENJDK_BUILD_OS), windows)
+	$(CHMOD) a+rx $@
+  endif
+	$(call CodesignFile,"$@")
+
+  COPY_FILES += $(LIBCRYPTO_TARGET_LIB)
 
   ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
-    # Copy OpenSSL SSL Lbrary
-    # To bundle first search for libssl 1.1.x library, if not found, search for 1.0.x
     ifeq ($(OPENJDK_TARGET_OS), linux)
-      OPENSSL_SSL_LIB_NAME = libssl.so.1.1
-      ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_SSL_LIB_NAME))", "")
-        OPENSSL_SSL_LIB_NAME = libssl.so.1.0.0
-        ifeq ("$(wildcard $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_SSL_LIB_NAME))", "")
-          OPENSSL_SSL_LIB_NAME =
-        endif
-      endif
+      LIBSSL_NAMES := libssl.so.1.1 libssl.so.1.0.0
+      LIBSSL_PATH := $(firstword $(wildcard $(addprefix $(OPENSSL_BUNDLE_LIB_PATH)/, $(LIBSSL_NAMES))))
 
-      ifneq ($(OPENSSL_SSL_LIB_NAME), )
-        OPENSSL_SSL_TARGET_LIB = $(JDK_OUTPUTDIR)/lib$(OPENJDK_TARGET_CPU_LIBDIR)/$(OPENSSL_SSL_LIB_NAME)
-
-        $(OPENSSL_SSL_TARGET_LIB): $(OPENSSL_BUNDLE_LIB_PATH)/$(OPENSSL_SSL_LIB_NAME)
+      ifneq ($(LIBSSL_PATH), )
+        LIBSSL_TARGET_LIB = $(JDK_OUTPUTDIR)/lib$(OPENJDK_TARGET_CPU_LIBDIR)/$(notdir $(LIBSSL_PATH))
+        TARGETS += $(LIBSSL_TARGET_LIB)
+        $(LIBSSL_TARGET_LIB) : $(LIBSSL_PATH)
 			$(call install-file)
+			$(call CodesignFile,"$@")
 
-        COPY_FILES += $(OPENSSL_SSL_TARGET_LIB)
-      endif # OPENSSL_SSL_LIB_NAME
+        COPY_FILES += $(LIBSSL_TARGET_LIB)
+      endif # LIBSSL_PATH
     endif # OPENJDK_TARGET_OS
   endif # OPENJ9_ENABLE_JITSERVER
 endif # OPENSSL_BUNDLE_LIB_PATH

--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -97,9 +97,20 @@ ifeq ($(OPENJDK_BUILD_OS), macosx)
   # variable is defined to support dependencies where the compiler option
   # is not applied.
   export MACOSX_DEPLOYMENT_TARGET := @MACOSX_VERSION_MIN@
-    
+
   # Set page zero size to 4KB for mapping memory below 4GB.
   LDFLAGS_JDKEXE += -pagezero_size 0x1000
+endif
+
+# Usage: $(call CodesignFile, files ...)
+ifeq (,$(CODESIGN))
+  CodesignFile =
+else
+  CodesignFile = $(CODESIGN) --sign "$(MACOSX_CODESIGN_IDENTITY)" \
+	--entitlements $(TOPDIR)/jdk/make/data/macosxsigning/entitlements.plist \
+	--options runtime \
+	--timestamp \
+	$1
 endif
 
 ifeq (true,$(OPENJ9_ENABLE_CMAKE))

--- a/jdk/make/data/macosxsigning/entitlements.plist
+++ b/jdk/make/data/macosxsigning/entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+</dict>
+</plist>

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -53,6 +53,12 @@ else ifeq ($(OPENJDK_BUILD_OS_ENV), windows.msys)
   UNIX_PATH_PREFIX :=
 endif
 
+CODESIGN_OPTIONS := \
+  --sign "$(MACOSX_CODESIGN_IDENTITY)" \
+  --entitlements $(TOPDIR)/jdk/make/data/macosxsigning/entitlements.plist \
+  --options runtime \
+  --timestamp
+
 define add_native_source
   # param 1 = BUILD_MYPACKAGE
   # parma 2 = the source file name (..../alfa.c or .../beta.cpp)
@@ -529,7 +535,9 @@ endif # no MacOS X support yet
 	$$($1_LD) $$($1_LDFLAGS) $$($1_EXTRA_LDFLAGS) $(LD_OUT_OPTION)$$@ \
 	$$($1_EXPECTED_OBJS) $$($1_RES) $$($1_LDFLAGS_SUFFIX) \
 	$$($1_EXTRA_LDFLAGS_SUFFIX)
-
+      ifneq (,$(CODESIGN))
+	$(CODESIGN) $(CODESIGN_OPTIONS) $$@
+      endif
   endif
 
   ifneq (,$$($1_STATIC_LIBRARY))
@@ -632,7 +640,7 @@ endif # no MacOS X support yet
         # Let it silently fail otherwise.
         ifneq (,$(CODESIGN))
           ifneq (,$$($1_CODESIGN))
-	    $(CODESIGN) -s "$(MACOSX_CODESIGN_IDENTITY)" $$@
+	    $(CODESIGN) $(CODESIGN_OPTIONS) $$@
           endif
         endif
   endif


### PR DESCRIPTION
When libcrypto.dylib or libssl.dylib are bundled in a jdk on OSX, they must also be signed.

* define CodesignFile in custom-spec.gmk for use in OpenJ9.gmk and CopyFiles.gmk.
* update code signing:
  - copy entitlements.plist from jdk11
  - also sign all shared libraries

Issue: eclipse/openj9#8389