### PR TITLE
Move rules from OpenJ9.gmk to goal-specific makefiles

### DIFF
--- a/closed/CopyToBuildJdk.gmk
+++ b/closed/CopyToBuildJdk.gmk
@@ -1,0 +1,173 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+all :
+
+.PHONY : all
+
+include $(SPEC)
+include $(SRC_ROOT)/make/common/MakeBase.gmk
+
+ifeq (windows,$(OPENJDK_TARGET_OS))
+  # set Visual Studio environment
+  EXPORT_MSVS_ENV_VARS := PATH="$(PATH)" INCLUDE="$(INCLUDE)" LIB="$(LIB)"
+  # set the output directory for shared libraries
+  OPENJ9_LIBS_DIR := $(JDK_OUTPUTDIR)/bin
+else
+  EXPORT_MSVS_ENV_VARS :=
+  OPENJ9_LIBS_DIR := $(JDK_OUTPUTDIR)/lib$(OPENJDK_TARGET_CPU_LIBDIR)
+endif # windows
+
+define openj9_copy_only
+	$(call install-file)
+endef
+
+define openj9_copy_and_sign
+	$(openj9_copy_only)
+	$(call CodesignFile,"$@")
+endef
+
+# openj9_copy_rule
+# ----------------
+# $1 - suffix of install action macro ('only' or 'and_sign')
+# $2 - source file path
+# $3 - target file path
+define openj9_copy_rule
+  all : $3
+  $3 : $2
+	$$(openj9_copy_$1)
+endef
+
+# openj9_copy_files
+# -----------------
+# $1 - suffix of install action macro ('only' or 'and_sign'; default is 'only')
+# $2 - sequence of file paths
+openj9_copy_files = \
+	$(eval $(call openj9_copy_rule,$(if $1,$(strip $1),only),$(word 1,$2),$(word 2,$2))) \
+	$(if $(word 2,$2),$(call openj9_copy_files,,$(wordlist 2,$(words $2),$2)))
+
+# openj9_copy_exes
+# ----------------
+# $1 = list of executable names without $(EXE_SUFFIX)
+openj9_copy_exes = \
+	$(foreach file, $1, \
+		$(call openj9_copy_files,and_sign, \
+			$(addsuffix /$(file)$(EXE_SUFFIX), \
+				$(OPENJ9_VM_BUILD_DIR) \
+				$(JDK_OUTPUTDIR)/bin)))
+
+# openj9_copy_shlibs
+# ------------------
+# $1 = list of shared library names without $(LIBRARY_PREFIX) or $(SHARED_LIBRARY_SUFFIX)
+openj9_copy_shlibs = \
+	$(foreach name, $1, \
+		$(call openj9_copy_files,and_sign, \
+			$(addsuffix /$(call SHARED_LIBRARY,$(name)), \
+				$(OPENJ9_VM_BUILD_DIR) \
+				$(OPENJ9_LIBS_DIR)/$(OPENJ9_LIBS_SUBDIR))))
+
+# jitserver
+
+ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
+$(call openj9_copy_exes, jitserver)
+endif
+
+# jsig
+
+$(call openj9_copy_files,and_sign, \
+	$(addsuffix $(call SHARED_LIBRARY,jsig), \
+		$(OPENJ9_VM_BUILD_DIR)/ \
+		$(addprefix $(OPENJ9_LIBS_DIR), / /j9vm/ /server/)))
+
+# redirector
+
+$(call openj9_copy_files,and_sign, \
+	$(addsuffix $(call SHARED_LIBRARY,jvm), \
+		$(OPENJ9_VM_BUILD_DIR)/redirector/ \
+		$(addprefix $(OPENJ9_LIBS_DIR), /j9vm/ /server/)))
+
+# regular shared libraries
+
+$(call openj9_copy_shlibs, \
+	cuda4j29 \
+	j9dmp29 \
+	j9jextract \
+	j9gc29 \
+	j9gcchk29 \
+	j9hookable29 \
+	j9jit29 \
+	j9jnichk29 \
+	j9jvmti29 \
+	j9prt29 \
+	j9shr29 \
+	j9thr29 \
+	j9trc29 \
+	j9vm29 \
+	j9vmchk29 \
+	j9vrb29 \
+	j9zlib29 \
+	jclse29 \
+	jvm \
+	management \
+	management_ext \
+	omrsig \
+	)
+
+ifeq (windows,$(OPENJDK_TARGET_OS)) # static libraries
+  $(call openj9_copy_files,, \
+	$(addsuffix /$(call STATIC_LIBRARY,jsig), \
+		$(OPENJ9_VM_BUILD_DIR)/lib \
+		$(JDK_OUTPUTDIR)/lib))
+
+  $(call openj9_copy_files,, \
+	$(OPENJ9_VM_BUILD_DIR)/redirector/$(call STATIC_LIBRARY,redirector_jvm) \
+	$(JDK_OUTPUTDIR)/lib/$(call STATIC_LIBRARY,jvm))
+endif # windows
+
+$(foreach file, \
+		$(SRC_ROOT)/closed/classlib.properties \
+		$(OPENJ9_VM_BUILD_DIR)/J9TraceFormat.dat \
+		$(OPENJ9_VM_BUILD_DIR)/OMRTraceFormat.dat, \
+	$(call openj9_copy_files,, $(file) $(JDK_OUTPUTDIR)/lib/$(notdir $(file))))
+
+$(foreach file, \
+		$(wildcard $(OPENJ9_VM_BUILD_DIR)/java*.properties) \
+		$(OPENJ9_VM_BUILD_DIR)/options.default, \
+	$(call openj9_copy_files,, \
+		$(file) $(OPENJ9_LIBS_DIR)/$(OPENJ9_LIBS_SUBDIR)/$(notdir $(file))))
+
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+  .PHONY : run-ddrgen
+
+  $(OPENJ9_VM_BUILD_DIR)/j9ddr.dat : run-ddrgen
+
+  run-ddrgen :
+    ifeq (true,$(OPENJ9_ENABLE_CMAKE))
+	  $(MAKE) -C $(OPENJ9_VM_BUILD_DIR) j9ddr
+    else # OPENJ9_ENABLE_CMAKE
+	  CC="$(CC)" CXX="$(CXX)" VERSION_MAJOR=8 $(EXPORT_MSVS_ENV_VARS) \
+		$(MAKE) -C $(OPENJ9_VM_BUILD_DIR)/ddr -f run_omrddrgen.mk
+    endif # OPENJ9_ENABLE_CMAKE
+
+  $(call openj9_copy_files,, \
+	$(addsuffix /j9ddr.dat, \
+		$(OPENJ9_VM_BUILD_DIR) \
+		$(OPENJ9_LIBS_DIR)/$(OPENJ9_LIBS_SUBDIR)))
+endif # OPENJ9_ENABLE_DDR

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -22,6 +22,7 @@
 ifeq (,$(wildcard $(SPEC)))
   $(error OpenJ9.gmk needs SPEC set to a proper spec.gmk)
 endif
+
 include $(SPEC)
 include $(SRC_ROOT)/make/common/MakeBase.gmk
 
@@ -51,10 +52,6 @@ ifeq (,$(OPENJ9OMR_SHA))
   $(error Could not determine OMR SHA)
 endif
 
-OPENJ9_NOTICE_FILE := openj9/longabout.html
-OPENJ9_NOTICE_FILE_RENAME := openj9-notices.html
-OPENJ9_OPENJDK_NOTICE_FILE := openj9-openjdk-notices
-
 # openjdk makeflags don't work with openj9/omr native compiles; override with number of CPUs which openj9 and omr need supplied
 override MAKEFLAGS := -j $(JOBS)
 
@@ -63,179 +60,19 @@ ifeq (windows,$(OPENJDK_TARGET_OS))
   FixPath = $(shell $(CYGPATH) -m $1)
   # set Visual Studio environment
   EXPORT_MSVS_ENV_VARS := PATH="$(PATH)" INCLUDE="$(INCLUDE)" LIB="$(LIB)"
-  # set the output directory for shared libraries
-  OPENJ9_LIBS_OUTPUT_DIR := bin
 else
   FixPath = $1
   EXPORT_MSVS_ENV_VARS :=
-  OPENJ9_LIBS_OUTPUT_DIR := lib$(OPENJDK_TARGET_CPU_LIBDIR)
 endif
 
 .PHONY : \
-	build-j9 \
+	build-j9vm \
 	build-openj9-tools \
-	clean-j9 \
-	clean-j9-dist \
-	clean-openj9-thirdparty-binaries \
 	generate-j9jcl-sources \
 	generate-j9-version-headers \
 	run-preprocessors-j9 \
 	stage-j9 \
-	stage_openj9_build_jdk \
 	#
-
-define copy_and_sign
-	$(call install-file)
-	$(call CodesignFile,"$@")
-endef
-
-ifeq (true,$(OPENJ9_ENABLE_JITSERVER))
-  # sign the jitserver executable as we copy it to bin
-  $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	MACRO := copy_and_sign, \
-	SRC := $(OPENJ9_VM_BUILD_DIR), \
-	DEST := $(JDK_OUTPUTDIR)/bin, \
-	FILES := jitserver$(EXE_SUFFIX) \
-	))
-
-  # copy the signed jitserver executable to jre/bin
-  $(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	MACRO := install-file, \
-	SRC := $(JDK_OUTPUTDIR)/bin, \
-	DEST := $(JDK_OUTPUTDIR)/jre/bin, \
-	FILES := jitserver$(EXE_SUFFIX) \
-	))
-endif # OPENJ9_ENABLE_JITSERVER
-
-# sign the redirector library as we copy it to j9vm
-$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	MACRO := copy_and_sign, \
-	SRC := $(OPENJ9_VM_BUILD_DIR)/redirector, \
-	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm, \
-	FILES := $(call SHARED_LIBRARY,jvm) \
-	))
-
-# copy the signed redirector library to server
-$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	MACRO := install-file, \
-	SRC := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/j9vm, \
-	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/server, \
-	FILES := $(call SHARED_LIBRARY,jvm) \
-	))
-
-# sign the jsig library as we copy it to lib
-$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	MACRO := copy_and_sign, \
-	SRC := $(OPENJ9_VM_BUILD_DIR), \
-	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR), \
-	FILES := $(call SHARED_LIBRARY,jsig) \
-	))
-
-# copy the signed jsig library to j9vm and server directories
-$(foreach subdir, j9vm server, \
-	$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-		MACRO := install-file, \
-		SRC := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR), \
-		DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(subdir), \
-		FILES := $(call SHARED_LIBRARY,jsig) \
-	)))
-
-# regular shared libraries
-
-$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	MACRO := copy_and_sign, \
-	SRC := $(OPENJ9_VM_BUILD_DIR), \
-	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR), \
-	FILES := $(patsubst %, $(call SHARED_LIBRARY,%), \
-		cuda4j29 \
-		j9dmp29 \
-		j9jextract \
-		j9gc29 \
-		j9gcchk29 \
-		j9hookable29 \
-		j9jit29 \
-		j9jnichk29 \
-		j9jvmti29 \
-		j9prt29 \
-		j9shr29 \
-		j9thr29 \
-		j9trc29 \
-		j9vm29 \
-		j9vmchk29 \
-		j9vrb29 \
-		j9zlib29 \
-		jclse29 \
-		jvm \
-		management \
-		management_ext \
-		omrsig) \
-	))
-
-ifeq (windows,$(OPENJDK_TARGET_OS))
-
-$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	MACRO := install-file, \
-	SRC := $(OPENJ9_VM_BUILD_DIR)/lib, \
-	DEST := $(JDK_OUTPUTDIR)/lib, \
-	FILES := $(call STATIC_LIBRARY,jsig) \
-	))
-
-$(JDK_OUTPUTDIR)/lib/$(call STATIC_LIBRARY,jvm) : $(OPENJ9_VM_BUILD_DIR)/redirector/$(call STATIC_LIBRARY,redirector_jvm)
-	$(install-file)
-
-OPENJ9_STAGED_FILES += $(JDK_OUTPUTDIR)/lib/$(call STATIC_LIBRARY,jvm)
-
-endif # windows
-
-$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	MACRO := install-file, \
-	SRC := $(SRC_ROOT)/closed, \
-	DEST := $(JDK_OUTPUTDIR)/lib, \
-	FILES := classlib.properties \
-	))
-
-$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	MACRO := install-file, \
-	SRC := $(OPENJ9_VM_BUILD_DIR), \
-	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR), \
-	FILES := \
-		$(notdir $(wildcard $(OUTPUT_ROOT)/vm/java*.properties)) \
-		options.default \
-	))
-
-$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	MACRO := install-file, \
-	SRC := $(OPENJ9_VM_BUILD_DIR), \
-	DEST := $(JDK_OUTPUTDIR)/lib, \
-	FILES := \
-		J9TraceFormat.dat \
-		OMRTraceFormat.dat \
-	))
-
-ifeq (true,$(OPENJ9_ENABLE_DDR))
-
-.PHONY : run-ddrgen
-
-$(OPENJ9_VM_BUILD_DIR)/j9ddr.dat : run-ddrgen
-
-run-ddrgen :
-ifeq (true,$(OPENJ9_ENABLE_CMAKE))
-	$(MAKE) -C $(OPENJ9_VM_BUILD_DIR) j9ddr
-else # OPENJ9_ENABLE_CMAKE
-	export CC="$(CC)" CXX="$(CXX)" VERSION_MAJOR=8 $(EXPORT_MSVS_ENV_VARS) \
-		&& $(MAKE) -C $(OPENJ9_VM_BUILD_DIR)/ddr -f run_omrddrgen.mk
-endif # OPENJ9_ENABLE_CMAKE
-
-$(eval $(call SetupCopyFiles,OPENJ9_STAGED_FILES, \
-	MACRO := install-file, \
-	SRC := $(OPENJ9_VM_BUILD_DIR), \
-	DEST := $(JDK_OUTPUTDIR)/$(OPENJ9_LIBS_OUTPUT_DIR)/$(OPENJ9_LIBS_SUBDIR), \
-	FILES := j9ddr.dat \
-	))
-
-endif # OPENJ9_ENABLE_DDR
-
-stage_openj9_build_jdk : $(OPENJ9_STAGED_FILES)
 
 # openj9_copy_tree
 # ----------------
@@ -254,73 +91,6 @@ define openj9_copy_tree_impl
 		| $(TAR) --extract --directory=$1 -m
 	@$(TOUCH) $1/$(OPENJ9_MARKER_FILE)
 endef
-
-OPENJ9_TEST_IMAGE_DIR := $(IMAGES_OUTPUTDIR)/test/openj9
-
-# openj9_test_image_rules
-# -----------------------
-# $1 = absolute library path
-define openj9_test_image_rules
-openj9_test_image : $(OPENJ9_TEST_IMAGE_DIR)/$(notdir $(strip $1))
-$(OPENJ9_TEST_IMAGE_DIR)/$(notdir $(strip $1)) : $(strip $1)
-	$$(copy_and_sign)
-endef
-
-$(foreach file, \
-	$(patsubst %, $(OPENJ9_VM_BUILD_DIR)/%$(EXE_SUFFIX), \
-		algotest \
-		bcvunit \
-		cfdump \
-		ctest \
-		dyntest \
-		gc_rwlocktest \
-		glaunch \
-		invtest \
-		jsigjnitest \
-		nativevmargs \
-		pltest \
-		propstest \
-		shrtest \
-		testjep178_dynamic \
-		testjep178_static \
-		thrstatetest \
-		vmLifecyleTests \
-		vmtest \
-		) \
-	$(patsubst %, $(OPENJ9_VM_BUILD_DIR)/$(call SHARED_LIBRARY,%), \
-		balloon29 \
-		bcuwhite \
-		bcvrelationships \
-		bcvwhite \
-		gptest \
-		hooktests \
-		j9aixbaddep \
-		j9ben \
-		j9lazyClassLoad \
-		j9thrnumanatives29 \
-		j9thrtestnatives29 \
-		j9unresolved \
-		j9vmtest \
-		jcoregen29 \
-		jlmagent29 \
-		jniargtests \
-		jvmtitest \
-		memorywatcher29 \
-		migration \
-		osmemory29 \
-		SharedClassesNativeAgent \
-		softmxtest \
-		testjvmtiA \
-		testjvmtiB \
-		testlibA \
-		testlibB \
-		vmruntimestateagent29 \
-		) \
-	$(patsubst %, $(OPENJ9_VM_BUILD_DIR)/lib%.jnilib, \
-		loadLibraryTest \
-		), \
-	$(if $(wildcard $(file)), \
-		$(eval $(call openj9_test_image_rules, $(file)))))
 
 # Comments for stage-j9
 # Currently there is a staged location where j9 is built.  This is due to a number of reasons:
@@ -588,17 +358,11 @@ endif # OPENJ9_ENABLE_CMAKE
 
 run-preprocessors-j9 : generate-j9-version-headers
 
-build-j9 : run-preprocessors-j9
+build-j9vm : run-preprocessors-j9
 	@$(ECHO) Compiling OpenJ9 in $(OPENJ9_VM_BUILD_DIR)
 	export OPENJ9_BUILD=true $(EXPORT_MSVS_ENV_VARS) $(CUSTOM_COMPILER_ENV_VARS) \
 		&& $(MAKE) -C $(OUTPUT_ROOT)/vm $(MAKEFLAGS) JAVA_VERSION=80 VERSION_MAJOR=8 all
 	@$(ECHO) OpenJ9 compile complete
-	@$(MKDIR) -p $(JDK_IMAGE_DIR)/
-	@$(MKDIR) -p $(JRE_IMAGE_DIR)/
-	@$(CP) -p $(SRC_ROOT)/$(OPENJ9_NOTICE_FILE) $(JDK_IMAGE_DIR)/$(OPENJ9_NOTICE_FILE_RENAME)
-	@$(CP) -p $(SRC_ROOT)/$(OPENJ9_NOTICE_FILE) $(JRE_IMAGE_DIR)/$(OPENJ9_NOTICE_FILE_RENAME)
-	@$(CP) -p $(SRC_ROOT)/$(OPENJ9_OPENJDK_NOTICE_FILE) $(JDK_IMAGE_DIR)/$(OPENJ9_OPENJDK_NOTICE_FILE)
-	@$(CP) -p $(SRC_ROOT)/$(OPENJ9_OPENJDK_NOTICE_FILE) $(JRE_IMAGE_DIR)/$(OPENJ9_OPENJDK_NOTICE_FILE)
 
 J9JCL_SOURCES_DONEFILE := $(JDK_OUTPUTDIR)/j9jcl_sources/j9jcl_sources.done
 
@@ -638,12 +402,3 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 	@$(TOUCH) $@
 
 generate-j9jcl-sources : $(J9JCL_SOURCES_DONEFILE)
-
-clean-j9 : clean-openj9-thirdparty-binaries
-	(cd $(OUTPUT_ROOT)/vm && $(MAKE) clean)
-
-clean-j9-dist : clean-openj9-thirdparty-binaries
-	$(RM) -fdr $(OUTPUT_ROOT)/vm
-
-clean-openj9-thirdparty-binaries :
-	$(RM) -f $(OPENJ9_STAGED_THIRDPARTY_BINARIES) $(patsubst %.jar,%.tar.gz,$(OPENJ9_STAGED_THIRDPARTY_BINARIES))

--- a/closed/TestImage.gmk
+++ b/closed/TestImage.gmk
@@ -1,0 +1,95 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+all :
+
+.PHONY : all
+
+include $(SPEC)
+include $(SRC_ROOT)/make/common/MakeBase.gmk
+
+OPENJ9_TEST_IMAGE_DIR := $(IMAGES_OUTPUTDIR)/test/openj9
+
+# openj9_test_image_rule
+# ----------------------
+# $1 - absolute library path
+define openj9_test_image_rule
+  all : $(OPENJ9_TEST_IMAGE_DIR)/$(notdir $(strip $1))
+
+  $(OPENJ9_TEST_IMAGE_DIR)/$(notdir $(strip $1)) : $(strip $1)
+	$$(call install-file)
+	$$(call CodesignFile,"$$@")
+endef
+
+$(foreach file, \
+	$(patsubst %, $(OPENJ9_VM_BUILD_DIR)/%$(EXE_SUFFIX), \
+		algotest \
+		bcvunit \
+		cfdump \
+		ctest \
+		dyntest \
+		gc_rwlocktest \
+		glaunch \
+		invtest \
+		jsigjnitest \
+		nativevmargs \
+		pltest \
+		propstest \
+		shrtest \
+		testjep178_dynamic \
+		testjep178_static \
+		thrstatetest \
+		vmLifecyleTests \
+		vmtest \
+		) \
+	$(patsubst %, $(OPENJ9_VM_BUILD_DIR)/$(call SHARED_LIBRARY,%), \
+		balloon29 \
+		bcuwhite \
+		bcvrelationships \
+		bcvwhite \
+		gptest \
+		hooktests \
+		j9aixbaddep \
+		j9ben \
+		j9lazyClassLoad \
+		j9thrnumanatives29 \
+		j9thrtestnatives29 \
+		j9unresolved \
+		j9vmtest \
+		jcoregen29 \
+		jlmagent29 \
+		jniargtests \
+		jvmtitest \
+		memorywatcher29 \
+		migration \
+		osmemory29 \
+		SharedClassesNativeAgent \
+		softmxtest \
+		testjvmtiA \
+		testjvmtiB \
+		testlibA \
+		testlibB \
+		vmruntimestateagent29 \
+		) \
+	$(patsubst %, $(OPENJ9_VM_BUILD_DIR)/lib%.jnilib, \
+		loadLibraryTest \
+		), \
+	$(if $(wildcard $(file)), \
+		$(eval $(call openj9_test_image_rule, $(file)))))

--- a/closed/make/Images.gmk
+++ b/closed/make/Images.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2020 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -54,6 +54,16 @@ jdk-image : openj9.ddr-jar
 
 endif # OPENJ9_ENABLE_DDR
 
-# ensure jre/jdk binary LICENSE file content is correctly sourced
+# include legal content
+
 $(addsuffix /LICENSE, $(JDK_IMAGE_DIR) $(JDK_IMAGE_DIR)/jre $(JRE_IMAGE_DIR)) : $(SRC_ROOT)/LICENSE
 	$(process-doc-file)
+
+$(addsuffix /openj9-notices.html, $(JDK_IMAGE_DIR) $(JRE_IMAGE_DIR)) : $(OPENJ9_TOPDIR)/longabout.html
+	$(call install-file)
+
+$(addsuffix /openj9-openjdk-notices, $(JDK_IMAGE_DIR) $(JRE_IMAGE_DIR)) : $(SRC_ROOT)/openj9-openjdk-notices
+	$(call install-file)
+
+JDK_DOC_TARGETS += $(addprefix $(JDK_IMAGE_DIR)/, openj9-notices.html openj9-openjdk-notices)
+JRE_DOC_TARGETS += $(addprefix $(JRE_IMAGE_DIR)/, openj9-notices.html openj9-openjdk-notices)

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -18,28 +18,26 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
+clean : clean-j9vm
+
 clean-j9vm :
 	$(call CleanComponent,vm)
 
 .PHONY : \
-	j9vm-build \
-	j9vm-compose-buildjvm \
+	build-j9vm \
+	clean-j9vm \
 	test-image \
 	test-image-openj9 \
 	#
 
-OPENJ9_MAKE := $(MAKE) -f $(SRC_ROOT)/closed/OpenJ9.gmk SPEC=$(SPEC)
+jdk : build-j9vm
 
-OPENSSL_MAKE := $(MAKE) -f $(SRC_ROOT)/closed/openssl.gmk SPEC=$(SPEC)
-
-openssl-build :
-	+$(OPENSSL_MAKE)
-
-j9vm-build : openssl-build
-	+$(OPENJ9_MAKE) build-j9
-
-j9vm-compose-buildjvm : j9vm-build
-	+$(OPENJ9_MAKE) stage_openj9_build_jdk
+build-j9vm : start-make
+  ifeq ($(BUILD_OPENSSL),yes)
+	+$(MAKE) -f $(SRC_ROOT)/closed/openssl.gmk SPEC=$(SPEC)
+  endif # BUILD_OPENSSL
+	+$(MAKE) -f $(SRC_ROOT)/closed/OpenJ9.gmk SPEC=$(SPEC) build-j9vm
+	+$(MAKE) -f $(SRC_ROOT)/closed/CopyToBuildJdk.gmk SPEC=$(SPEC)
 
 all : test-image
 
@@ -47,7 +45,7 @@ test-image : test-image-openj9
 
 # If not cross-compiling, capture 'java -version' output.
 test-image-openj9 : images
-	+$(OPENJ9_MAKE) openj9_test_image
+	+$(MAKE) -f $(SRC_ROOT)/closed/TestImage.gmk SPEC=$(SPEC)
 ifneq ($(COMPILE_TYPE), cross)
 	$(JRE_IMAGE_DIR)/bin/java -version 2>&1 | $(TEE) $(IMAGES_OUTPUTDIR)/test/openj9/java-version.txt
 endif

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2011, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2011, 2020 All Rights Reserved
 # ===========================================================================
 
 ### This is the main part of the Makefile, for the normal case with SPEC specifying a single existing spec.gmk file.
@@ -115,7 +115,7 @@ ifeq ($(BUILD_HOTSPOT),true)
 	@$(call TargetExit)
 endif
 
-jdk: langtools j9vm-compose-buildjvm corba jaxp jaxws jdk-only
+jdk: langtools corba jaxp jaxws jdk-only
 jdk-only: start-make
 	@$(call TargetEnter)
 	@($(CD) $(JDK_TOPDIR)/make && $(BUILD_LOG_WRAPPER) $(MAKE) $(MAKE_ARGS) -f BuildJdk.gmk $(JDK_TARGET))
@@ -198,7 +198,7 @@ $(OUTPUT_ROOT)/source_tips: FRC
 
 
 # Remove everything, except the output from configure.
-clean: clean-langtools clean-corba clean-jaxp clean-jaxws clean-j9vm clean-jdk clean-nashorn clean-images clean-overlay-images clean-bootcycle-build clean-docs clean-test
+clean: clean-langtools clean-corba clean-jaxp clean-jaxws clean-jdk clean-nashorn clean-images clean-overlay-images clean-bootcycle-build clean-docs clean-test
 	@($(CD) $(OUTPUT_ROOT) && $(RM) -r tmp source_tips build.log* build-trace*.log*)
 	@$(ECHO) Cleaned all build artifacts.
 


### PR DESCRIPTION
This is based on ideas in https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/265 but adjusted for jdk8.