### PR TITLE
Add debug-image target

### DIFF
--- a/closed/CopyToBuildJdk.gmk
+++ b/closed/CopyToBuildJdk.gmk
@@ -35,6 +35,83 @@ else
   OPENJ9_LIBS_DIR := $(JDK_OUTPUTDIR)/lib$(OPENJDK_TARGET_CPU_LIBDIR)
 endif # windows
 
+ifneq (true,$(ENABLE_DEBUG_SYMBOLS))
+  openj9_copy_debuginfos :=
+else
+
+  ifeq (macosx,$(OPENJDK_TARGET_OS))
+    DEBUGINFO_SRC_SUFFIX := .dSYM
+  else ifeq (windows,$(OPENJDK_TARGET_OS))
+    DEBUGINFO_SRC_SUFFIX := .pdb
+  else
+    DEBUGINFO_SRC_SUFFIX := .debuginfo
+  endif
+
+  ifeq (true,$(ZIP_DEBUGINFO_FILES))
+    DEBUGINFO_DST_SUFFIX := .diz
+  else
+    DEBUGINFO_DST_SUFFIX := $(DEBUGINFO_SRC_SUFFIX)
+  endif
+
+  # openj9_make_debuginfo_paths
+  # ---------------------------
+  # $1 - required suffix
+  # $2 - input paths
+  openj9_make_debuginfo_paths = \
+	$(if $(filter .dSYM, $1), \
+		$(addsuffix .dSYM, $2), \
+		$(foreach path, $2, $(path:$(suffix $(path))=$1)))
+
+  # openj9_copy_debuginfo_rule
+  # --------------------------
+  # $1 - source file path
+  # $2 - target file path
+  define openj9_copy_debuginfo_rule
+    all : $2
+    $2 : $1
+    ifneq (,$(and $(filter %$(DEBUGINFO_SRC_SUFFIX),$1),$(filter %.diz,$2)))
+		$(eval $(call MakeDir,$(dir $2)))
+		($(CD) $$(<D) && $(ZIPEXE) -Dqr $$@ $$(<F))
+    else
+		$$(call install-file)
+    endif
+  endef
+
+  # openj9_copy_debuginfo_helper
+  # ----------------------------
+  # $1 - sequence of file paths
+  openj9_copy_debuginfo_helper = \
+	$(eval $(call openj9_copy_debuginfo_rule,$(word 1,$1),$(word 2,$1))) \
+	$(if $(word 3,$1),$(call openj9_copy_debuginfo_helper,$(wordlist 2,$(words $1),$1)))
+
+  # openj9_copy_debuginfo_paths*
+  # ----------------------------
+  # $1 - source suffix
+  # $2 - sequence of file paths
+  ifeq (macosx/.dSYM,$(OPENJDK_TARGET_OS)/$(DEBUGINFO_DST_SUFFIX))
+    # When not zipping on MacOSX, there are multiple files to copy; openj9_copy_debuginfo_paths_list
+    # names the functions that produce the sequence for each file.
+    openj9_copy_debuginfo_paths_list = openj9_copy_debuginfo_paths_a openj9_copy_debuginfo_paths_b
+    openj9_copy_debuginfo_paths_a = $(foreach path, $2, $(path).dSYM/Contents/Info.plist)
+    openj9_copy_debuginfo_paths_b = $(foreach path, $2, $(path).dSYM/Contents/Resources/DWARF/$(notdir $(path)))
+  else
+    openj9_copy_debuginfo_paths_list = openj9_copy_debuginfo_paths
+    openj9_copy_debuginfo_paths = \
+		$(call openj9_make_debuginfo_paths,$(DEBUGINFO_SRC_SUFFIX),$(word 1,$2)) \
+		$(call openj9_make_debuginfo_paths,$(DEBUGINFO_DST_SUFFIX),$(wordlist 2,$(words $2),$2))
+  endif # macosx
+
+  # openj9_copy_debuginfos
+  # ----------------------
+  # $1 - source suffix
+  # $2 - sequence of file paths
+  openj9_copy_debuginfos = \
+	$(if $(wildcard $(call openj9_make_debuginfo_paths,$(DEBUGINFO_SRC_SUFFIX),$(word 1,$2))), \
+		$(foreach paths, $(openj9_copy_debuginfo_paths_list), \
+			$(call openj9_copy_debuginfo_helper, $(call $(paths),$1,$2))))
+
+endif # COPY_DEBUG_SYMBOLS
+
 define openj9_copy_only
 	$(call install-file)
 endef
@@ -61,14 +138,21 @@ endef
 # $2 - sequence of file paths
 openj9_copy_files = \
 	$(eval $(call openj9_copy_rule,$(if $1,$(strip $1),only),$(word 1,$2),$(word 2,$2))) \
-	$(if $(word 2,$2),$(call openj9_copy_files,,$(wordlist 2,$(words $2),$2)))
+	$(if $(word 3,$2),$(call openj9_copy_files,,$(wordlist 2,$(words $2),$2)))
+
+# openj9_copy_files_and_debuginfos
+# --------------------------------
+# $1 - sequence of file paths
+openj9_copy_files_and_debuginfos = \
+	$(call openj9_copy_files,and_sign,$1) \
+	$(call openj9_copy_debuginfos,$(suffix $(word 1,$1)),$1)
 
 # openj9_copy_exes
 # ----------------
 # $1 = list of executable names without $(EXE_SUFFIX)
 openj9_copy_exes = \
 	$(foreach file, $1, \
-		$(call openj9_copy_files,and_sign, \
+		$(call openj9_copy_files_and_debuginfos, \
 			$(addsuffix /$(file)$(EXE_SUFFIX), \
 				$(OPENJ9_VM_BUILD_DIR) \
 				$(JDK_OUTPUTDIR)/bin)))
@@ -78,7 +162,7 @@ openj9_copy_exes = \
 # $1 = list of shared library names without $(LIBRARY_PREFIX) or $(SHARED_LIBRARY_SUFFIX)
 openj9_copy_shlibs = \
 	$(foreach name, $1, \
-		$(call openj9_copy_files,and_sign, \
+		$(call openj9_copy_files_and_debuginfos, \
 			$(addsuffix /$(call SHARED_LIBRARY,$(name)), \
 				$(OPENJ9_VM_BUILD_DIR) \
 				$(OPENJ9_LIBS_DIR)/$(OPENJ9_LIBS_SUBDIR))))
@@ -91,14 +175,14 @@ endif
 
 # jsig
 
-$(call openj9_copy_files,and_sign, \
+$(call openj9_copy_files_and_debuginfos, \
 	$(addsuffix $(call SHARED_LIBRARY,jsig), \
 		$(OPENJ9_VM_BUILD_DIR)/ \
 		$(addprefix $(OPENJ9_LIBS_DIR), / /j9vm/ /server/)))
 
 # redirector
 
-$(call openj9_copy_files,and_sign, \
+$(call openj9_copy_files_and_debuginfos, \
 	$(addsuffix $(call SHARED_LIBRARY,jvm), \
 		$(OPENJ9_VM_BUILD_DIR)/redirector/ \
 		$(addprefix $(OPENJ9_LIBS_DIR), /j9vm/ /server/)))

--- a/closed/DebugImage.gmk
+++ b/closed/DebugImage.gmk
@@ -1,0 +1,71 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+all :
+
+.PHONY : all
+
+include $(SPEC)
+include $(TOPDIR)/make/common/MakeBase.gmk
+
+ifneq (true,$(ENABLE_DEBUG_SYMBOLS))
+  DEBUG_SYMBOL_SUFFIX :=
+else ifeq (true,$(ZIP_DEBUGINFO_FILES))
+  DEBUG_SYMBOL_SUFFIX := .diz
+else ifeq (macosx,$(OPENJDK_TARGET_OS))
+  DEBUG_SYMBOL_SUFFIX := .dSYM
+else ifeq (windows,$(OPENJDK_TARGET_OS))
+  DEBUG_SYMBOL_SUFFIX := .pdb
+else
+  DEBUG_SYMBOL_SUFFIX := .debuginfo
+endif
+
+ifneq (,$(DEBUG_SYMBOL_SUFFIX))
+
+DEBUG_IMAGE_DIR := $(IMAGES_OUTPUTDIR)/debug-image
+
+# openj9_copy_rule
+# ----------------
+# $1 - source file path
+# $2 - target file path
+define openj9_copy_rule
+  all : $2
+  $2 : $1
+	$$(call install-file)
+endef
+
+# openj9_copy_group - copy a file or a group of files into images/debug-image
+# -----------------
+# $1 - source file/folder
+# $2 - target folder
+openj9_copy_group = \
+	$(foreach path, $(call CacheFind, $1), \
+  		$(eval $(call openj9_copy_rule,$(path),$(strip $2)$(patsubst $(dir $1)%,%,$(path)))))
+
+DEBUGINFO_DIRS := $(addprefix $(JDK_OUTPUTDIR)/, bin lib)
+
+$(eval $(call FillCacheFind, $(DEBUGINFO_DIRS)))
+
+DEBUGINFO_FILES := $(filter %$(DEBUG_SYMBOL_SUFFIX), $(call CacheFind, $(DEBUGINFO_DIRS)))
+
+$(foreach file, $(DEBUGINFO_FILES), \
+	$(eval $(call openj9_copy_group,$(file),$(dir $(patsubst $(JDK_OUTPUTDIR)/%,$(DEBUG_IMAGE_DIR)/%,$(file))))))
+
+endif # DEBUG_SYMBOL_SUFFIX

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -26,6 +26,7 @@ clean-j9vm :
 .PHONY : \
 	build-j9vm \
 	clean-j9vm \
+	debug-image \
 	test-image \
 	test-image-openj9 \
 	#
@@ -34,10 +35,15 @@ jdk : build-j9vm
 
 build-j9vm : start-make
   ifeq ($(BUILD_OPENSSL),yes)
-	+$(MAKE) -f $(SRC_ROOT)/closed/openssl.gmk SPEC=$(SPEC)
+	@$(MAKE) $(MAKE_ARGS) -f $(SRC_ROOT)/closed/openssl.gmk
   endif # BUILD_OPENSSL
-	+$(MAKE) -f $(SRC_ROOT)/closed/OpenJ9.gmk SPEC=$(SPEC) build-j9vm
-	+$(MAKE) -f $(SRC_ROOT)/closed/CopyToBuildJdk.gmk SPEC=$(SPEC)
+	@$(MAKE) $(MAKE_ARGS) -f $(SRC_ROOT)/closed/OpenJ9.gmk build-j9vm
+	@$(MAKE) $(MAKE_ARGS) -f $(SRC_ROOT)/closed/CopyToBuildJdk.gmk
+
+all : debug-image
+
+debug-image : images
+	@$(MAKE) $(MAKE_ARGS) -f $(SRC_ROOT)/closed/DebugImage.gmk
 
 all : test-image
 
@@ -45,7 +51,7 @@ test-image : test-image-openj9
 
 # If not cross-compiling, capture 'java -version' output.
 test-image-openj9 : images
-	+$(MAKE) -f $(SRC_ROOT)/closed/TestImage.gmk SPEC=$(SPEC)
+	@$(MAKE) $(MAKE_ARGS) -f $(SRC_ROOT)/closed/TestImage.gmk
 ifneq ($(COMPILE_TYPE), cross)
 	$(JRE_IMAGE_DIR)/bin/java -version 2>&1 | $(TEE) $(IMAGES_OUTPUTDIR)/test/openj9/java-version.txt
 endif


### PR DESCRIPTION
* copy debuginfo files for openj9 shared libraries
* collect files (*.debuginfo, *.pdb, etc.) into images/debug-image

Note: that the default configure behavior is `--enable-zip-debug-info` which results in `*.diz` files being included in the debug image. To get uncompressed debug information files, use `--disable-zip-debug-info` (which doesn't work on Windows due to some missing rules in openjdk makefiles).