### PR TITLE
Set environment variable MALLOCOPTIONS=multiheap on AIX

### DIFF
--- a/jdk/src/solaris/bin/java_md_solinux.c
+++ b/jdk/src/solaris/bin/java_md_solinux.c
@@ -388,9 +388,9 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
                                            is asked for */
 #ifdef AIX
     const char *mallocOptionsName = "MALLOCOPTIONS";
-    const char *mallocOptionsValue = "multiheap,buckets";
+    const char *mallocOptionsValue = "multiheap";
     if (setenv(mallocOptionsName, mallocOptionsValue, 0) != 0) {
-        fprintf(stderr, "setenv('MALLOCOPTIONS=multiheap,buckets') failed: performance may be affected\n");
+        fprintf(stderr, "setenv('MALLOCOPTIONS=multiheap') failed: performance may be affected\n");
     }
 #endif
 #ifdef SETENV_REQUIRED


### PR DESCRIPTION
The previous setting `MALLOCOPTIONS=multiheap,buckets` caused
Issue https://github.com/eclipse/openj9/issues/8842

Signed-off-by: Peter Shipton <Peter_Shipton@ca.ibm.com>