### PR TITLE
Fix handling of reference repos

### DIFF
--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -34,7 +34,7 @@ usage() {
 	echo "  -omr-repo         the OpenJ9/omr repository url: https://github.com/eclipse/openj9-omr.git"
 	echo "                    or git@github.com:<namespace>/openj9-omr.git"
 	echo "  -omr-branch       the OpenJ9/omr git branch: openj9"
-	echo "  -omr-sha           a commit SHA for the omr repository"
+	echo "  -omr-sha          a commit SHA for the omr repository"
 	echo "  -omr-reference    a local repo to use as a clone reference"
 	echo "  -parallel         (boolean) if 'true' then the clone j9 repository commands run in parallel, default is false"
 	echo ""
@@ -130,8 +130,10 @@ for i in "${!default_j9repos[@]}" ; do
 	if [ ${branches[$i]+_} ] ; then
 		branch=${branches[$i]}
 	fi
-	if [ ${references[$i]+_} ] ; then
-		reference="--reference ${references[$i]}"
+	if [ -n "${references[$i]+_}" ] ; then
+		reference=" --reference ${references[$i]}"
+	else
+		reference=""
 	fi
 
 	if [ -d ${i} ] ; then
@@ -154,7 +156,7 @@ for i in "${!default_j9repos[@]}" ; do
 			git_url="${j9repos[$i]}"
 		fi
 
-		git_clone_command="${git} clone ${reference} --recursive -b ${branch} ${git_url} ${i}"
+		git_clone_command="${git} clone${reference} --recursive -b ${branch} ${git_url} ${i}"
 		commands[$i]=${git_clone_command}
 
 		echo

--- a/get_source.sh
+++ b/get_source.sh
@@ -27,7 +27,6 @@
 # ===========================================================================
 # (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
 # ===========================================================================
-#
 
 usage() {
 	echo "Usage: $0 [-h|--help] [... other j9 options] [-parallel=<true|false>] [--openssl-version=<openssl version to download>]"
@@ -46,7 +45,7 @@ usage() {
 	echo "  -omr-reference    a local repo to use as a clone reference"
 	echo "  -parallel         (boolean) if 'true' then the clone j9 repository commands run in parallel, default is false"
 	echo "  --openssl-version Specify the version of OpenSSL source to download"
-	echo " "
+	echo ""
 	exit 1
 }
 


### PR DESCRIPTION
Avoid unexpected reuse of reference repos: if `-openj9-reference=` or `-omr-reference=` are specified, but not both, the one reference may be used by both clones: This fixes that.

See also ibmruntimes/openj9-openjdk-jdk11#316.