### PR TITLE
Update source path for DDR stubs target

### DIFF
--- a/closed/make/DDR.gmk
+++ b/closed/make/DDR.gmk
@@ -161,7 +161,7 @@ $(eval $(call SetupJavaCompilation,BUILD_DDR_STUBS, \
 	SETUP := GENERATE_USINGJDKBYTECODE, \
 	BIN := $(DDR_STUBS_BIN), \
 	ADD_JAVAC_FLAGS := -cp $(JDK_OUTPUTDIR)/classes, \
-	SRC := $(OPENJ9_TOPDIR)/jcl/src/ibm.jzos/share/classes, \
+	SRC := $(OPENJ9_TOPDIR)/jcl/stubs/ibm.jzos/share/classes, \
 	EXCLUDE_FILES := module-info.java \
 	))
 	


### PR DESCRIPTION
Update path to ibm.jzos source files since openj9/jcl/src/ibm.jzos has
moved to openj9/jcl/stubs.

Signed-off-by: Violeta Sebe <vsebe@ca.ibm.com>