### PR TITLE
Don't define unused preprocessor macro 'com.ibm.oti.vm.library.version'

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -428,7 +428,6 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 			-srcRoot jcl/ \
 			-xml jpp_configuration.xml \
 			-dest "$(call FixPath,$(JPP_DEST))" \
-			-macro:define "com.ibm.oti.vm.library.version=29" \
 			-tag:define "$(JPP_TAGS)"
 	@$(ECHO) Generating J9JCL tools
 	@$(BOOT_JDK)/bin/java \
@@ -441,7 +440,6 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 			-srcRoot jcl/ \
 			-xml jpp_configuration.xml \
 			-dest "$(call FixPath,$(JPP_DEST))" \
-			-macro:define "com.ibm.oti.vm.library.version=29" \
 			-tag:define "$(JPP_TAGS)"
 	@$(MKDIR) -p $(@D)
 	@$(TOUCH) $@


### PR DESCRIPTION
Depends on eclipse/openj9#10888.