### PR TITLE
Undo change for OpenJ9

### DIFF
--- a/jdk/src/share/back/export/sys.h
+++ b/jdk/src/share/back/export/sys.h
@@ -23,12 +23,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
- * ===========================================================================
- */
-
 #ifndef JDWP_SYS_H
 #define JDWP_SYS_H
 
@@ -43,7 +37,7 @@
 
 /* Implemented in linker_md.c */
 
-void    dbgsysBuildLibName(char *, size_t, const char *, const char *);
+void    dbgsysBuildLibName(char *, int, const char *, const char *);
 void *  dbgsysLoadLibrary(const char *, char *err_buf, int err_buflen);
 void    dbgsysUnloadLibrary(void *);
 void *  dbgsysFindLibraryEntry(void *, const char *);


### PR DESCRIPTION
Also makes declaration of `dbgsysBuildLibName()` consistent with its definitions.