### PR TITLE
Add SOURCE version information in release file

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -32,6 +32,15 @@ clean-j9vm :
 	test-image-openj9 \
 	#
 
+# Override definition from MakeBase.gmk for OpenJ9.
+define GetSourceTips
+	$(PRINTF) "%s:%s\n" \
+		OpenJDK "$(shell git -C $(TOPDIR) rev-parse --short HEAD)" \
+		OpenJ9  "$(shell git -C $(OPENJ9_TOPDIR) rev-parse --short HEAD)" \
+		OMR     "$(shell git -C $(OPENJ9OMR_TOPDIR) rev-parse --short HEAD)" \
+		> $@
+endef
+
 jdk : build-j9vm
 
 build-j9vm : start-make


### PR DESCRIPTION
While working on ibmruntimes/openj9-openjdk-jdk#242, I noticed that the equivalent of https://github.com/ibmruntimes/openj9-openjdk-jdk11/blob/openj9/closed/custom/ReleaseFile.gmk#L24 was not happening for Java 8:
```
$ cat jdk8u265-b01-openj9-0.21.0/release
JAVA_VERSION="1.8.0_265"
OS_NAME="Linux"
OS_VERSION="2.6"
OS_ARCH="amd64"
SOURCE=""
```
This fixes that:
```
$ cat images/j2sdk-image/release 
JAVA_VERSION="1.8.0_272"
OS_NAME="Linux"
OS_VERSION="2.6"
OS_ARCH="amd64"
SOURCE="OpenJDK:b543cd386bd OpenJ9:c18472815f5 OMR:e2fac34fcb3"
```