### PR TITLE
Compute and display build version information

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -30,6 +30,11 @@ ifeq (,$(BUILD_ID))
   BUILD_ID := 000000
 endif
 
+OPENJDK_SHA := $(shell git -C $(TOPDIR) rev-parse --short HEAD)
+ifeq (,$(OPENJDK_SHA))
+  $(error Could not determine OpenJDK SHA)
+endif
+
 OPENJ9_SHA := $(shell git -C $(OPENJ9_TOPDIR) rev-parse --short HEAD)
 ifeq (,$(OPENJ9_SHA))
   $(error Could not determine OpenJ9 SHA)
@@ -391,7 +396,11 @@ else
 endif
 
 build-j9vm : run-preprocessors-j9
-	@$(ECHO) Compiling OpenJ9 in $(OPENJ9_VM_BUILD_DIR)
+	@$(ECHO) "Compiling OpenJ9 in $(OUTPUT_ROOT)/vm"
+	@$(ECHO) "  Source version info:"
+	@$(ECHO) "    openjdk - $(OPENJDK_SHA)"
+	@$(ECHO) "    openj9  - $(OPENJ9_SHA)"
+	@$(ECHO) "    omr     - $(OPENJ9OMR_SHA)"
 	+export OPENJ9_BUILD=true $(EXPORT_MSVS_ENV_VARS) $(CUSTOM_COMPILER_ENV_VARS) \
 		&& $(MAKE_VM) $(MAKE_ARGS) -C $(OUTPUT_ROOT)/vm JAVA_VERSION=80 VERSION_MAJOR=8 all
 	@$(ECHO) OpenJ9 compile complete

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4410,7 +4410,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1600276123
+DATE_WHEN_GENERATED=1603832230
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -368,10 +368,6 @@ AC_DEFUN([OPENJDK_VERSION_DETAILS],
   AC_SUBST(JDK_MOD_VERSION)
   AC_SUBST(JDK_FIX_VERSION)
 
-  OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
-
-  AC_SUBST(OPENJDK_SHA)
-
   # Outer [ ] to quote m4.
   [ USERNAME=`$ECHO "$USER" | $TR -d -c '[a-z][A-Z][0-9]'` ]
   AC_SUBST(USERNAME)

--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -58,7 +58,6 @@ OPENJ9_ENABLE_OPENJDK_METHODHANDLES := @OPENJ9_ENABLE_OPENJDK_METHODHANDLES@
 # for constructing version output
 COMPILER_VERSION_STRING := @COMPILER_VERSION_STRING@
 USERNAME                := @USERNAME@
-OPENJDK_SHA             := @OPENJDK_SHA@
 
 include $(SRC_ROOT)/closed/openjdk-tag.gmk
 

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -903,7 +903,6 @@ OPENJ9_CC
 OPENJ9_ENABLE_CMAKE
 CMAKE
 USERNAME
-OPENJDK_SHA
 JDK_FIX_VERSION
 JDK_MOD_VERSION
 OPENJ9_LIBS_SUBDIR
@@ -4547,7 +4546,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1600276123
+DATE_WHEN_GENERATED=1603832230
 
 ###############################################################################
 #
@@ -15266,10 +15265,6 @@ fi
   # Source the closed version numbers
   . $SRC_ROOT/jdk/make/closed/autoconf/openj9ext-version-numbers
 
-
-
-
-  OPENJDK_SHA=`git -C $SRC_ROOT rev-parse --short HEAD`
 
 
 


### PR DESCRIPTION
In support of ibmruntimes/openj9-openjdk-jdk#242:
* dynamically compute openjdk SHA in OpenJ9.gmk (instead of at configuration time)
* print git SHAs before compiling VM
* remove unused definition in custom-spec.gmk.in