### PR TITLE
Add check for OPENJDK_TARGET_CPU_BITS back into configure

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4410,7 +4410,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1605236068
+DATE_WHEN_GENERATED=1605496318
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -294,7 +294,7 @@ AC_DEFUN([OPENJ9_PLATFORM_SETUP],
     fi
     OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_mxdptrs"
     OPENJ9_LIBS_SUBDIR=default
-  elif test "x$with_noncompressedrefs" = xyes ; then
+  elif test "x$with_noncompressedrefs" = xyes -o "x$OPENJDK_TARGET_CPU_BITS" = x32; then
     OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}"
     OPENJ9_LIBS_SUBDIR=default
   else

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -4550,7 +4550,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1605236068
+DATE_WHEN_GENERATED=1605496318
 
 ###############################################################################
 #
@@ -15235,7 +15235,7 @@ fi
     fi
     OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_mxdptrs"
     OPENJ9_LIBS_SUBDIR=default
-  elif test "x$with_noncompressedrefs" = xyes ; then
+  elif test "x$with_noncompressedrefs" = xyes -o "x$OPENJDK_TARGET_CPU_BITS" = x32; then
     OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}"
     OPENJ9_LIBS_SUBDIR=default
   else


### PR DESCRIPTION
In the changes from https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/458, a check for `"x$OPENJDK_TARGET_CPU_BITS" = x32` was mistakenly removed. This resulted in the build getting generated in the `compressedrefs` directory, instead of the `default` directory, causing the tests in https://github.com/eclipse/openj9/issues/11187 to fail. Adding this check back in should fix https://github.com/eclipse/openj9/issues/11187.