### PR TITLE
Remove build redundancies relating to msvcp.dll

### DIFF
--- a/closed/make/CopyFiles.gmk
+++ b/closed/make/CopyFiles.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
 # ===========================================================================
 # 
 # This code is free software; you can redistribute it and/or modify it
@@ -24,18 +24,6 @@ $(JDK_OUTPUTDIR)/classes/com/ibm/oti/util/ExternalMessages.properties: $(JDK_OUT
 	$(call install-file)
 
 COPY_FILES += $(JDK_OUTPUTDIR)/classes/com/ibm/oti/util/ExternalMessages.properties
-
-# Copy msvcpXX.dll on windows
-
-ifeq ($(OPENJDK_TARGET_OS), windows)
-  MSVCP_TARGET := $(JDK_OUTPUTDIR)/bin/$(notdir $(MSVCP_DLL))
-  # Chmod to avoid permission issues if bundles are unpacked on unix platforms.
-  $(MSVCP_TARGET): $(MSVCP_DLL)
-	$(call install-file)
-	$(CHMOD) a+rx $@
-
-  COPY_FILES += $(MSVCP_TARGET)
-endif
 
 # Copy ibmjvmti.h
 $(JDK_OUTPUTDIR)/include/ibmjvmti.h: $(SRC_ROOT)/openj9/runtime/include/ibmjvmti.h

--- a/closed/make/Images.gmk
+++ b/closed/make/Images.gmk
@@ -18,23 +18,6 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
-ifeq ($(OPENJDK_TARGET_OS), windows)
-  MSVCP_BIN_LIST := $(call CacheFind, $(JDK_OUTPUTDIR)/bin)
-  MSVCP_BIN_LIST := $(filter %$(notdir $(MSVCP_DLL)), $(MSVCP_BIN_LIST))
-  $(foreach f,$(MSVCP_BIN_LIST), \
-    $(eval $(call AddFileToCopy,$(JDK_OUTPUTDIR),$(JDK_IMAGE_DIR),$f,JDK_BIN_TARGETS)))
-
-  MSVCP_PATTERN := %$(notdir $(MSVCP_DLL))
-  ifneq ($(POST_STRIP_CMD), )
-    JRE_STRIP_LIST := $(filter-out $(MSVCP_PATTERN), $(JRE_STRIP_LIST))
-    JDKJRE_STRIP_LIST := $(filter-out $(MSVCP_PATTERN), $(JDKJRE_STRIP_LIST))
-    JDK_BIN_STRIP_LIST := $(filter-out $(MSVCP_PATTERN), $(JDK_BIN_STRIP_LIST))
-    JRE_OVERLAY_STRIP_LIST := $(filter-out $(MSVCP_PATTERN), $(JRE_OVERLAY_STRIP_LIST))
-    JDKJRE_OVERLAY_STRIP_LIST := $(filter-out $(MSVCP_PATTERN), $(JDKJRE_OVERLAY_STRIP_LIST))
-    JDK_OVERLAY_BIN_STRIP_LIST := $(filter-out $(MSVCP_PATTERN), $(JDK_OVERLAY_BIN_STRIP_LIST))
-  endif
-endif
-
 # only include jextract in jre/bin
 NOT_JDK_BIN_FILES  := jextract$(EXE_SUFFIX)
 JDK_BIN_STRIP_LIST := $(filter-out $(addprefix %, $(addsuffix .stripped, $(NOT_JDK_BIN_FILES))), $(JDK_BIN_STRIP_LIST))

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4410,7 +4410,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1605496318
+DATE_WHEN_GENERATED=1605549617
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -48,10 +48,7 @@ AC_DEFUN_ONCE([CUSTOM_EARLY_HOOK],
   if test "x$OPENJDK_TARGET_OS" = xwindows ; then
     BASIC_SETUP_OUTPUT_DIR
     TOOLCHAIN_SETUP_VISUAL_STUDIO_ENV
-    TOOLCHAIN_SETUP_MSVCP_DLL
   fi
-
-  AC_SUBST(MSVCP_DLL)
 
   OPENJ9_THIRD_PARTY_REQUIREMENTS
   OPENJ9_CHECK_NASM_VERSION
@@ -511,88 +508,6 @@ AC_DEFUN([TOOLCHAIN_CHECK_POSSIBLE_MSVCP_DLL],
       AC_MSG_NOTICE([The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE])
     fi
   fi
-])
-
-AC_DEFUN([TOOLCHAIN_SETUP_MSVCP_DLL],
-[
-  AC_ARG_WITH(msvcp-dll, [AS_HELP_STRING([--with-msvcp-dll],
-      [copy this msvcp120.dll into the built JDK (Windows only) @<:@probed@:>@])])
-
-  if test "x$with_msvcp_dll" != x ; then
-    # If given explicitly by user, do not probe. If not present, fail directly.
-    TOOLCHAIN_CHECK_POSSIBLE_MSVCP_DLL([$with_msvcp_dll], [--with-msvcp-dll])
-    if test "x$MSVCP_DLL" = x ; then
-      AC_MSG_ERROR([Could not find a proper msvcp120.dll as specified by --with-msvcp-dll])
-    fi
-  fi
-
-  if test "x$MSVCP_DLL" = x ; then
-    # Probe: Using well-known location from Visual Studio 12.0
-    if test "x$VCINSTALLDIR" != x ; then
-      CYGWIN_VC_INSTALL_DIR="$VCINSTALLDIR"
-      BASIC_WINDOWS_REWRITE_AS_UNIX_PATH(CYGWIN_VC_INSTALL_DIR)
-      if test "x$OPENJDK_TARGET_CPU_BITS" = x64 ; then
-        POSSIBLE_MSVCP_DLL="$CYGWIN_VC_INSTALL_DIR/redist/x64/Microsoft.VC120.CRT/msvcp120.dll"
-      else
-        POSSIBLE_MSVCP_DLL="$CYGWIN_VC_INSTALL_DIR/redist/x86/Microsoft.VC120.CRT/msvcp120.dll"
-      fi
-      TOOLCHAIN_CHECK_POSSIBLE_MSVCP_DLL([$POSSIBLE_MSVCP_DLL], [well-known location in VCINSTALLDIR])
-    fi
-  fi
-
-  if test "x$MSVCP_DLL" = x ; then
-    # Probe: Check in the Boot JDK directory.
-    POSSIBLE_MSVCP_DLL="$BOOT_JDK/bin/msvcp120.dll"
-    TOOLCHAIN_CHECK_POSSIBLE_MSVCP_DLL([$POSSIBLE_MSVCP_DLL], [well-known location in Boot JDK])
-  fi
-
-  if test "x$MSVCP_DLL" = x ; then
-    # Probe: Look in the Windows system32 directory
-    CYGWIN_SYSTEMROOT="$SYSTEMROOT"
-    BASIC_WINDOWS_REWRITE_AS_UNIX_PATH(CYGWIN_SYSTEMROOT)
-    POSSIBLE_MSVCP_DLL="$CYGWIN_SYSTEMROOT/system32/msvcp120.dll"
-    TOOLCHAIN_CHECK_POSSIBLE_MSVCP_DLL([$POSSIBLE_MSVCP_DLL], [well-known location in SYSTEMROOT])
-  fi
-
-  if test "x$MSVCP_DLL" = x ; then
-    # Probe: If Visual Studio Express is installed, there is usually one with the debugger
-    if test "x$VS120COMNTOOLS" != x ; then
-      CYGWIN_VS_TOOLS_DIR="$VS120COMNTOOLS/.."
-      BASIC_WINDOWS_REWRITE_AS_UNIX_PATH(CYGWIN_VS_TOOLS_DIR)
-      if test "x$OPENJDK_TARGET_CPU_BITS" = x64 ; then
-        POSSIBLE_MSVCP_DLL=`$FIND "$CYGWIN_VS_TOOLS_DIR" -name msvcp120.dll | $GREP -i /x64/ | $HEAD --lines 1`
-      else
-        POSSIBLE_MSVCP_DLL=`$FIND "$CYGWIN_VS_TOOLS_DIR" -name msvcp120.dll | $GREP -i /x86/ | $HEAD --lines 1`
-      fi
-      TOOLCHAIN_CHECK_POSSIBLE_MSVCP_DLL([$POSSIBLE_MSVCP_DLL], [search of VS120COMNTOOLS])
-    fi
-  fi
-
-  if test "x$MSVCP_DLL" = x ; then
-    # Probe: Search wildly in the VCINSTALLDIR. We've probably lost by now.
-    # (This was the original behaviour ; kept since it might turn up something)
-    if test "x$CYGWIN_VC_INSTALL_DIR" != x ; then
-      if test "x$OPENJDK_TARGET_CPU_BITS" = x64 ; then
-        POSSIBLE_MSVCP_DLL=`$FIND "$CYGWIN_VC_INSTALL_DIR" -name msvcp120.dll | $GREP x64 | $HEAD --lines 1`
-      else
-        POSSIBLE_MSVCP_DLL=`$FIND "$CYGWIN_VC_INSTALL_DIR" -name msvcp120.dll | $GREP x86 | $GREP -v ia64 | $GREP -v x64 | $HEAD --lines 1`
-        if test "x$POSSIBLE_MSVCP_DLL" = x ; then
-          # We're grasping at straws now...
-          POSSIBLE_MSVCP_DLL=`$FIND "$CYGWIN_VC_INSTALL_DIR" -name msvcp120.dll | $HEAD --lines 1`
-        fi
-      fi
-
-      TOOLCHAIN_CHECK_POSSIBLE_MSVCP_DLL([$POSSIBLE_MSVCP_DLL], [search of VCINSTALLDIR])
-    fi
-  fi
-
-  if test "x$MSVCP_DLL" = x ; then
-    AC_MSG_CHECKING([for msvcp120.dll])
-    AC_MSG_RESULT([no])
-    AC_MSG_ERROR([Could not find msvcp120.dll. Please specify using --with-msvcp-dll.])
-  fi
-
-  BASIC_FIXUP_PATH(MSVCP_DLL)
 ])
 
 AC_DEFUN([CONFIGURE_OPENSSL],

--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -89,9 +89,6 @@ OMR_MIXED_REFERENCES_MODE := @OMR_MIXED_REFERENCES_MODE@
 export ac_cv_prog_CC    := @CC@
 export ac_cv_prog_CXX   := @CXX@
 
-# Windows
-MSVCP_DLL               := @MSVCP_DLL@
-
 COPY_JVM_CFG_FILE       := true
 
 ifeq ($(OPENJDK_TARGET_OS), macosx)

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -649,6 +649,7 @@ ENABLE_INTREE_EC
 SALIB_NAME
 HOTSPOT_MAKE_ARGS
 UCRT_DLL_DIR
+MSVCP_DLL
 MSVCR_DLL
 LIBCXX
 LLVM_LIBS
@@ -883,7 +884,6 @@ PKGHANDLER
 DEVKIT_LIB_DIR
 NASM
 FREEMARKER_JAR
-MSVCP_DLL
 VS_LIB
 VS_INCLUDE
 VS_PATH
@@ -1090,7 +1090,6 @@ enable_jitserver
 enable_openjdk_methodhandles
 with_conf_name
 with_toolchain_version
-with_msvcp_dll
 with_freemarker_jar
 with_devkit
 with_sys_root
@@ -1158,6 +1157,7 @@ with_giflib
 with_zlib
 with_stdc__lib
 with_msvcr_dll
+with_msvcp_dll
 with_ucrt_dll_dir
 with_dxsdk
 with_dxsdk_lib
@@ -1966,8 +1966,6 @@ Optional Packages:
                           the version of the toolchain to look for, use
                           '--help' to show possible values [platform
                           dependent]
-  --with-msvcp-dll        copy this msvcp120.dll into the built JDK (Windows
-                          only) [probed]
   --with-freemarker-jar   path to freemarker.jar (used to build OpenJ9 build
                           tools)
   --with-devkit           use this devkit for compilers, tools and resources
@@ -4538,8 +4536,6 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 
-
-
 # Create a tool wrapper for use by cmake.
 # Consists of a shell script which wraps commands with an invocation of fixpath.
 # OPENJ9_GENERATE_TOOL_WRAPER(<name_of_wrapper>, <command_to_call>)
@@ -4550,7 +4546,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1605496318
+DATE_WHEN_GENERATED=1605549617
 
 ###############################################################################
 #
@@ -17242,429 +17238,7 @@ $as_echo "$as_me: or run \"bash.exe -l\" from a VS command prompt and then run c
     as_fn_error $? "Cannot continue" "$LINENO" 5
   fi
 
-
-
-# Check whether --with-msvcp-dll was given.
-if test "${with_msvcp_dll+set}" = set; then :
-  withval=$with_msvcp_dll;
-fi
-
-
-  if test "x$with_msvcp_dll" != x ; then
-    # If given explicitly by user, do not probe. If not present, fail directly.
-
-  POSSIBLE_MSVCP_DLL="$with_msvcp_dll"
-  METHOD="--with-msvcp-dll"
-  if test -e "$POSSIBLE_MSVCP_DLL" ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: Found msvcp120.dll at $POSSIBLE_MSVCP_DLL using $METHOD" >&5
-$as_echo "$as_me: Found msvcp120.dll at $POSSIBLE_MSVCP_DLL using $METHOD" >&6;}
-
-    # Need to check if the found msvcp is correct architecture
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking found msvcp120.dll architecture" >&5
-$as_echo_n "checking found msvcp120.dll architecture... " >&6; }
-    MSVCP_DLL_FILETYPE=`$FILE -b "$POSSIBLE_MSVCP_DLL"`
-    if test "x$OPENJDK_TARGET_CPU_BITS" = x32 ; then
-      CORRECT_MSVCP_ARCH=386
-    else
-      CORRECT_MSVCP_ARCH=x86-64
-    fi
-    if $ECHO "$MSVCP_DLL_FILETYPE" | $GREP $CORRECT_MSVCP_ARCH 2>&1 > /dev/null ; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-$as_echo "ok" >&6; }
-      MSVCP_DLL="$POSSIBLE_MSVCP_DLL"
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for msvcp120.dll" >&5
-$as_echo_n "checking for msvcp120.dll... " >&6; }
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MSVCP_DLL" >&5
-$as_echo "$MSVCP_DLL" >&6; }
-    else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: incorrect, ignoring" >&5
-$as_echo "incorrect, ignoring" >&6; }
-      { $as_echo "$as_me:${as_lineno-$LINENO}: The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE" >&5
-$as_echo "$as_me: The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE" >&6;}
-    fi
   fi
-
-    if test "x$MSVCP_DLL" = x ; then
-      as_fn_error $? "Could not find a proper msvcp120.dll as specified by --with-msvcp-dll" "$LINENO" 5
-    fi
-  fi
-
-  if test "x$MSVCP_DLL" = x ; then
-    # Probe: Using well-known location from Visual Studio 12.0
-    if test "x$VCINSTALLDIR" != x ; then
-      CYGWIN_VC_INSTALL_DIR="$VCINSTALLDIR"
-
-  windows_path="$CYGWIN_VC_INSTALL_DIR"
-  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.cygwin"; then
-    unix_path=`$CYGPATH -u "$windows_path"`
-    CYGWIN_VC_INSTALL_DIR="$unix_path"
-  elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.msys"; then
-    unix_path=`$ECHO "$windows_path" | $SED -e 's,^\\(.\\):,/\\1,g' -e 's,\\\\,/,g'`
-    CYGWIN_VC_INSTALL_DIR="$unix_path"
-  fi
-
-      if test "x$OPENJDK_TARGET_CPU_BITS" = x64 ; then
-        POSSIBLE_MSVCP_DLL="$CYGWIN_VC_INSTALL_DIR/redist/x64/Microsoft.VC120.CRT/msvcp120.dll"
-      else
-        POSSIBLE_MSVCP_DLL="$CYGWIN_VC_INSTALL_DIR/redist/x86/Microsoft.VC120.CRT/msvcp120.dll"
-      fi
-
-  POSSIBLE_MSVCP_DLL="$POSSIBLE_MSVCP_DLL"
-  METHOD="well-known location in VCINSTALLDIR"
-  if test -e "$POSSIBLE_MSVCP_DLL" ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: Found msvcp120.dll at $POSSIBLE_MSVCP_DLL using $METHOD" >&5
-$as_echo "$as_me: Found msvcp120.dll at $POSSIBLE_MSVCP_DLL using $METHOD" >&6;}
-
-    # Need to check if the found msvcp is correct architecture
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking found msvcp120.dll architecture" >&5
-$as_echo_n "checking found msvcp120.dll architecture... " >&6; }
-    MSVCP_DLL_FILETYPE=`$FILE -b "$POSSIBLE_MSVCP_DLL"`
-    if test "x$OPENJDK_TARGET_CPU_BITS" = x32 ; then
-      CORRECT_MSVCP_ARCH=386
-    else
-      CORRECT_MSVCP_ARCH=x86-64
-    fi
-    if $ECHO "$MSVCP_DLL_FILETYPE" | $GREP $CORRECT_MSVCP_ARCH 2>&1 > /dev/null ; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-$as_echo "ok" >&6; }
-      MSVCP_DLL="$POSSIBLE_MSVCP_DLL"
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for msvcp120.dll" >&5
-$as_echo_n "checking for msvcp120.dll... " >&6; }
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MSVCP_DLL" >&5
-$as_echo "$MSVCP_DLL" >&6; }
-    else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: incorrect, ignoring" >&5
-$as_echo "incorrect, ignoring" >&6; }
-      { $as_echo "$as_me:${as_lineno-$LINENO}: The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE" >&5
-$as_echo "$as_me: The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE" >&6;}
-    fi
-  fi
-
-    fi
-  fi
-
-  if test "x$MSVCP_DLL" = x ; then
-    # Probe: Check in the Boot JDK directory.
-    POSSIBLE_MSVCP_DLL="$BOOT_JDK/bin/msvcp120.dll"
-
-  POSSIBLE_MSVCP_DLL="$POSSIBLE_MSVCP_DLL"
-  METHOD="well-known location in Boot JDK"
-  if test -e "$POSSIBLE_MSVCP_DLL" ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: Found msvcp120.dll at $POSSIBLE_MSVCP_DLL using $METHOD" >&5
-$as_echo "$as_me: Found msvcp120.dll at $POSSIBLE_MSVCP_DLL using $METHOD" >&6;}
-
-    # Need to check if the found msvcp is correct architecture
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking found msvcp120.dll architecture" >&5
-$as_echo_n "checking found msvcp120.dll architecture... " >&6; }
-    MSVCP_DLL_FILETYPE=`$FILE -b "$POSSIBLE_MSVCP_DLL"`
-    if test "x$OPENJDK_TARGET_CPU_BITS" = x32 ; then
-      CORRECT_MSVCP_ARCH=386
-    else
-      CORRECT_MSVCP_ARCH=x86-64
-    fi
-    if $ECHO "$MSVCP_DLL_FILETYPE" | $GREP $CORRECT_MSVCP_ARCH 2>&1 > /dev/null ; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-$as_echo "ok" >&6; }
-      MSVCP_DLL="$POSSIBLE_MSVCP_DLL"
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for msvcp120.dll" >&5
-$as_echo_n "checking for msvcp120.dll... " >&6; }
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MSVCP_DLL" >&5
-$as_echo "$MSVCP_DLL" >&6; }
-    else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: incorrect, ignoring" >&5
-$as_echo "incorrect, ignoring" >&6; }
-      { $as_echo "$as_me:${as_lineno-$LINENO}: The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE" >&5
-$as_echo "$as_me: The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE" >&6;}
-    fi
-  fi
-
-  fi
-
-  if test "x$MSVCP_DLL" = x ; then
-    # Probe: Look in the Windows system32 directory
-    CYGWIN_SYSTEMROOT="$SYSTEMROOT"
-
-  windows_path="$CYGWIN_SYSTEMROOT"
-  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.cygwin"; then
-    unix_path=`$CYGPATH -u "$windows_path"`
-    CYGWIN_SYSTEMROOT="$unix_path"
-  elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.msys"; then
-    unix_path=`$ECHO "$windows_path" | $SED -e 's,^\\(.\\):,/\\1,g' -e 's,\\\\,/,g'`
-    CYGWIN_SYSTEMROOT="$unix_path"
-  fi
-
-    POSSIBLE_MSVCP_DLL="$CYGWIN_SYSTEMROOT/system32/msvcp120.dll"
-
-  POSSIBLE_MSVCP_DLL="$POSSIBLE_MSVCP_DLL"
-  METHOD="well-known location in SYSTEMROOT"
-  if test -e "$POSSIBLE_MSVCP_DLL" ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: Found msvcp120.dll at $POSSIBLE_MSVCP_DLL using $METHOD" >&5
-$as_echo "$as_me: Found msvcp120.dll at $POSSIBLE_MSVCP_DLL using $METHOD" >&6;}
-
-    # Need to check if the found msvcp is correct architecture
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking found msvcp120.dll architecture" >&5
-$as_echo_n "checking found msvcp120.dll architecture... " >&6; }
-    MSVCP_DLL_FILETYPE=`$FILE -b "$POSSIBLE_MSVCP_DLL"`
-    if test "x$OPENJDK_TARGET_CPU_BITS" = x32 ; then
-      CORRECT_MSVCP_ARCH=386
-    else
-      CORRECT_MSVCP_ARCH=x86-64
-    fi
-    if $ECHO "$MSVCP_DLL_FILETYPE" | $GREP $CORRECT_MSVCP_ARCH 2>&1 > /dev/null ; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-$as_echo "ok" >&6; }
-      MSVCP_DLL="$POSSIBLE_MSVCP_DLL"
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for msvcp120.dll" >&5
-$as_echo_n "checking for msvcp120.dll... " >&6; }
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MSVCP_DLL" >&5
-$as_echo "$MSVCP_DLL" >&6; }
-    else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: incorrect, ignoring" >&5
-$as_echo "incorrect, ignoring" >&6; }
-      { $as_echo "$as_me:${as_lineno-$LINENO}: The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE" >&5
-$as_echo "$as_me: The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE" >&6;}
-    fi
-  fi
-
-  fi
-
-  if test "x$MSVCP_DLL" = x ; then
-    # Probe: If Visual Studio Express is installed, there is usually one with the debugger
-    if test "x$VS120COMNTOOLS" != x ; then
-      CYGWIN_VS_TOOLS_DIR="$VS120COMNTOOLS/.."
-
-  windows_path="$CYGWIN_VS_TOOLS_DIR"
-  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.cygwin"; then
-    unix_path=`$CYGPATH -u "$windows_path"`
-    CYGWIN_VS_TOOLS_DIR="$unix_path"
-  elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.msys"; then
-    unix_path=`$ECHO "$windows_path" | $SED -e 's,^\\(.\\):,/\\1,g' -e 's,\\\\,/,g'`
-    CYGWIN_VS_TOOLS_DIR="$unix_path"
-  fi
-
-      if test "x$OPENJDK_TARGET_CPU_BITS" = x64 ; then
-        POSSIBLE_MSVCP_DLL=`$FIND "$CYGWIN_VS_TOOLS_DIR" -name msvcp120.dll | $GREP -i /x64/ | $HEAD --lines 1`
-      else
-        POSSIBLE_MSVCP_DLL=`$FIND "$CYGWIN_VS_TOOLS_DIR" -name msvcp120.dll | $GREP -i /x86/ | $HEAD --lines 1`
-      fi
-
-  POSSIBLE_MSVCP_DLL="$POSSIBLE_MSVCP_DLL"
-  METHOD="search of VS120COMNTOOLS"
-  if test -e "$POSSIBLE_MSVCP_DLL" ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: Found msvcp120.dll at $POSSIBLE_MSVCP_DLL using $METHOD" >&5
-$as_echo "$as_me: Found msvcp120.dll at $POSSIBLE_MSVCP_DLL using $METHOD" >&6;}
-
-    # Need to check if the found msvcp is correct architecture
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking found msvcp120.dll architecture" >&5
-$as_echo_n "checking found msvcp120.dll architecture... " >&6; }
-    MSVCP_DLL_FILETYPE=`$FILE -b "$POSSIBLE_MSVCP_DLL"`
-    if test "x$OPENJDK_TARGET_CPU_BITS" = x32 ; then
-      CORRECT_MSVCP_ARCH=386
-    else
-      CORRECT_MSVCP_ARCH=x86-64
-    fi
-    if $ECHO "$MSVCP_DLL_FILETYPE" | $GREP $CORRECT_MSVCP_ARCH 2>&1 > /dev/null ; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-$as_echo "ok" >&6; }
-      MSVCP_DLL="$POSSIBLE_MSVCP_DLL"
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for msvcp120.dll" >&5
-$as_echo_n "checking for msvcp120.dll... " >&6; }
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MSVCP_DLL" >&5
-$as_echo "$MSVCP_DLL" >&6; }
-    else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: incorrect, ignoring" >&5
-$as_echo "incorrect, ignoring" >&6; }
-      { $as_echo "$as_me:${as_lineno-$LINENO}: The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE" >&5
-$as_echo "$as_me: The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE" >&6;}
-    fi
-  fi
-
-    fi
-  fi
-
-  if test "x$MSVCP_DLL" = x ; then
-    # Probe: Search wildly in the VCINSTALLDIR. We've probably lost by now.
-    # (This was the original behaviour ; kept since it might turn up something)
-    if test "x$CYGWIN_VC_INSTALL_DIR" != x ; then
-      if test "x$OPENJDK_TARGET_CPU_BITS" = x64 ; then
-        POSSIBLE_MSVCP_DLL=`$FIND "$CYGWIN_VC_INSTALL_DIR" -name msvcp120.dll | $GREP x64 | $HEAD --lines 1`
-      else
-        POSSIBLE_MSVCP_DLL=`$FIND "$CYGWIN_VC_INSTALL_DIR" -name msvcp120.dll | $GREP x86 | $GREP -v ia64 | $GREP -v x64 | $HEAD --lines 1`
-        if test "x$POSSIBLE_MSVCP_DLL" = x ; then
-          # We're grasping at straws now...
-          POSSIBLE_MSVCP_DLL=`$FIND "$CYGWIN_VC_INSTALL_DIR" -name msvcp120.dll | $HEAD --lines 1`
-        fi
-      fi
-
-
-  POSSIBLE_MSVCP_DLL="$POSSIBLE_MSVCP_DLL"
-  METHOD="search of VCINSTALLDIR"
-  if test -e "$POSSIBLE_MSVCP_DLL" ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: Found msvcp120.dll at $POSSIBLE_MSVCP_DLL using $METHOD" >&5
-$as_echo "$as_me: Found msvcp120.dll at $POSSIBLE_MSVCP_DLL using $METHOD" >&6;}
-
-    # Need to check if the found msvcp is correct architecture
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking found msvcp120.dll architecture" >&5
-$as_echo_n "checking found msvcp120.dll architecture... " >&6; }
-    MSVCP_DLL_FILETYPE=`$FILE -b "$POSSIBLE_MSVCP_DLL"`
-    if test "x$OPENJDK_TARGET_CPU_BITS" = x32 ; then
-      CORRECT_MSVCP_ARCH=386
-    else
-      CORRECT_MSVCP_ARCH=x86-64
-    fi
-    if $ECHO "$MSVCP_DLL_FILETYPE" | $GREP $CORRECT_MSVCP_ARCH 2>&1 > /dev/null ; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-$as_echo "ok" >&6; }
-      MSVCP_DLL="$POSSIBLE_MSVCP_DLL"
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for msvcp120.dll" >&5
-$as_echo_n "checking for msvcp120.dll... " >&6; }
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MSVCP_DLL" >&5
-$as_echo "$MSVCP_DLL" >&6; }
-    else
-      { $as_echo "$as_me:${as_lineno-$LINENO}: result: incorrect, ignoring" >&5
-$as_echo "incorrect, ignoring" >&6; }
-      { $as_echo "$as_me:${as_lineno-$LINENO}: The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE" >&5
-$as_echo "$as_me: The file type of the located msvcp120.dll is $MSVCP_DLL_FILETYPE" >&6;}
-    fi
-  fi
-
-    fi
-  fi
-
-  if test "x$MSVCP_DLL" = x ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for msvcp120.dll" >&5
-$as_echo_n "checking for msvcp120.dll... " >&6; }
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-    as_fn_error $? "Could not find msvcp120.dll. Please specify using --with-msvcp-dll." "$LINENO" 5
-  fi
-
-
-  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.cygwin"; then
-
-  # Input might be given as Windows format, start by converting to
-  # unix format.
-  path="$MSVCP_DLL"
-  new_path=`$CYGPATH -u "$path"`
-
-  # Cygwin tries to hide some aspects of the Windows file system, such that binaries are
-  # named .exe but called without that suffix. Therefore, "foo" and "foo.exe" are considered
-  # the same file, most of the time (as in "test -f"). But not when running cygpath -s, then
-  # "foo.exe" is OK but "foo" is an error.
-  #
-  # This test is therefore slightly more accurate than "test -f" to check for file precense.
-  # It is also a way to make sure we got the proper file name for the real test later on.
-  test_shortpath=`$CYGPATH -s -m "$new_path" 2> /dev/null`
-  if test "x$test_shortpath" = x; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: The path of MSVCP_DLL, which resolves as \"$path\", is invalid." >&5
-$as_echo "$as_me: The path of MSVCP_DLL, which resolves as \"$path\", is invalid." >&6;}
-    as_fn_error $? "Cannot locate the the path of MSVCP_DLL" "$LINENO" 5
-  fi
-
-  # Call helper function which possibly converts this using DOS-style short mode.
-  # If so, the updated path is stored in $new_path.
-
-  input_path="$new_path"
-  # Check if we need to convert this using DOS-style short mode. If the path
-  # contains just simple characters, use it. Otherwise (spaces, weird characters),
-  # take no chances and rewrite it.
-  # Note: m4 eats our [], so we need to use [ and ] instead.
-  has_forbidden_chars=`$ECHO "$input_path" | $GREP [^-._/a-zA-Z0-9]`
-  if test "x$has_forbidden_chars" != x; then
-    # Now convert it to mixed DOS-style, short mode (no spaces, and / instead of \)
-    shortmode_path=`$CYGPATH -s -m -a "$input_path"`
-    path_after_shortmode=`$CYGPATH -u "$shortmode_path"`
-    if test "x$path_after_shortmode" != "x$input_to_shortpath"; then
-      # Going to short mode and back again did indeed matter. Since short mode is
-      # case insensitive, let's make it lowercase to improve readability.
-      shortmode_path=`$ECHO "$shortmode_path" | $TR 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz'`
-      # Now convert it back to Unix-style (cygpath)
-      input_path=`$CYGPATH -u "$shortmode_path"`
-      new_path="$input_path"
-    fi
-  fi
-
-  test_cygdrive_prefix=`$ECHO $input_path | $GREP ^/cygdrive/`
-  if test "x$test_cygdrive_prefix" = x; then
-    # As a simple fix, exclude /usr/bin since it's not a real path.
-    if test "x`$ECHO $new_path | $GREP ^/usr/bin/`" = x; then
-      # The path is in a Cygwin special directory (e.g. /home). We need this converted to
-      # a path prefixed by /cygdrive for fixpath to work.
-      new_path="$CYGWIN_ROOT_PATH$input_path"
-    fi
-  fi
-
-
-  if test "x$path" != "x$new_path"; then
-    MSVCP_DLL="$new_path"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: Rewriting MSVCP_DLL to \"$new_path\"" >&5
-$as_echo "$as_me: Rewriting MSVCP_DLL to \"$new_path\"" >&6;}
-  fi
-
-  elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.msys"; then
-
-  path="$MSVCP_DLL"
-  has_colon=`$ECHO $path | $GREP ^.:`
-  new_path="$path"
-  if test "x$has_colon" = x; then
-    # Not in mixed or Windows style, start by that.
-    new_path=`cmd //c echo $path`
-  fi
-
-
-  input_path="$new_path"
-  # Check if we need to convert this using DOS-style short mode. If the path
-  # contains just simple characters, use it. Otherwise (spaces, weird characters),
-  # take no chances and rewrite it.
-  # Note: m4 eats our [], so we need to use [ and ] instead.
-  has_forbidden_chars=`$ECHO "$input_path" | $GREP [^-_/:a-zA-Z0-9]`
-  if test "x$has_forbidden_chars" != x; then
-    # Now convert it to mixed DOS-style, short mode (no spaces, and / instead of \)
-    new_path=`cmd /c "for %A in (\"$input_path\") do @echo %~sA"|$TR \\\\\\\\ / | $TR 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz'`
-  fi
-
-
-  windows_path="$new_path"
-  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.cygwin"; then
-    unix_path=`$CYGPATH -u "$windows_path"`
-    new_path="$unix_path"
-  elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.msys"; then
-    unix_path=`$ECHO "$windows_path" | $SED -e 's,^\\(.\\):,/\\1,g' -e 's,\\\\,/,g'`
-    new_path="$unix_path"
-  fi
-
-  if test "x$path" != "x$new_path"; then
-    MSVCP_DLL="$new_path"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: Rewriting MSVCP_DLL to \"$new_path\"" >&5
-$as_echo "$as_me: Rewriting MSVCP_DLL to \"$new_path\"" >&6;}
-  fi
-
-  # Save the first 10 bytes of this path to the storage, so fixpath can work.
-  all_fixpath_prefixes=("${all_fixpath_prefixes[@]}" "${new_path:0:10}")
-
-  else
-    # We're on a posix platform. Hooray! :)
-    path="$MSVCP_DLL"
-    has_space=`$ECHO "$path" | $GREP " "`
-    if test "x$has_space" != x; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: The path of MSVCP_DLL, which resolves as \"$path\", is invalid." >&5
-$as_echo "$as_me: The path of MSVCP_DLL, which resolves as \"$path\", is invalid." >&6;}
-      as_fn_error $? "Spaces are not allowed in this path." "$LINENO" 5
-    fi
-
-    # Use eval to expand a potential ~
-    eval path="$path"
-    if test ! -f "$path" && test ! -d "$path"; then
-      as_fn_error $? "The path of MSVCP_DLL, which resolves as \"$path\", is not found." "$LINENO" 5
-    fi
-
-    MSVCP_DLL="`cd "$path"; $THEPWDCMD -L`"
-  fi
-
-
-  fi
-
-
 
 
   # check 3rd party library requirement for UMA


### PR DESCRIPTION
#73 added `msvcpXXX.dll` in several places, including `bin` and `jre/bin` unlike a Hotspot JDK which only includes the latter.

This removes the duplicate code which finds the proper version of `msvcpXXX.dll` and places it in the desired places in a jdk or a jre image.