### PR TITLE
Suppress use of broken make rules inherited from openjdk

### DIFF
--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -269,7 +269,7 @@ endif
 $(JDK_OUTPUTDIR)/bin$(OUTPUT_SUBDIR)/java$(DEBUGINFO_EXT): $(BUILD_LAUNCHER_java)
 	$(MKDIR) -p $(@D)
 	$(RM) $@
-	$(CP) -R $(JDK_OUTPUTDIR)/objs/java_objs$(OUTPUT_SUBDIR)/java$(DEBUGINFO_EXT) $@
+	$(CP) $(JDK_OUTPUTDIR)/objs/java_objs$(OUTPUT_SUBDIR)/java$(DEBUGINFO_EXT) $@
 
 BUILD_LAUNCHERS += $(JDK_OUTPUTDIR)/bin$(OUTPUT_SUBDIR)/java$(EXE_SUFFIX)
 ifeq ($(ENABLE_DEBUG_SYMBOLS), true)
@@ -281,6 +281,8 @@ ifeq ($(ENABLE_DEBUG_SYMBOLS), true)
 endif
 
 ifeq ($(OPENJDK_TARGET_OS):$(ENABLE_DEBUG_SYMBOLS), macosx:true)
+  # Remove java.dSYM from BUILD_LAUNCHERS in favour of the following, avoiding the broken rule above.
+  BUILD_LAUNCHERS := $(filter-out $(JDK_OUTPUTDIR)/bin$(OUTPUT_SUBDIR)/java$(DEBUGINFO_EXT), $(BUILD_LAUNCHERS))
   # Because the java launcher is built in a non-standard directory,
   # we need to copy debug information so it can be included in a debug image.
   $(JDK_OUTPUTDIR)/bin$(OUTPUT_SUBDIR)/java.dSYM/Contents/Info.plist : $(BUILD_LAUNCHER_java)
@@ -648,7 +650,9 @@ $(JDK_OUTPUTDIR)/bin$(OUTPUT_SUBDIR)/unpack200$(DEBUGINFO_EXT): $(BUILD_UNPACKEX
 	$(call install-file)
 
 BUILD_LAUNCHERS += $(JDK_OUTPUTDIR)/bin$(OUTPUT_SUBDIR)/unpack200$(EXE_SUFFIX)
-ifeq ($(ENABLE_DEBUG_SYMBOLS), true)
+ifeq ($(OPENJDK_TARGET_OS), macosx)
+  # Avoid using the broken rule above and do without unpack200.dSYM.
+else ifeq ($(ENABLE_DEBUG_SYMBOLS), true)
   ifneq ($(POST_STRIP_CMD), )
     ifneq ($(STRIP_POLICY), no_strip)
       BUILD_LAUNCHERS += $(JDK_OUTPUTDIR)/bin$(OUTPUT_SUBDIR)/unpack200$(DEBUGINFO_EXT)


### PR DESCRIPTION
* the rule to produce `java.dSYM` is broken: the target is expected to be a folder (without `-R`, `rm` & `cp` won't do what's necessary) and we already have rules to produce the files within that folder
* the rule to produce `unpack200.dSYM` is also broken: it copies a file rather than the debug info files one would expect

Fixes: eclipse/openj9#11244.