### PR TITLE
Move definition of J9JCL_SOURCES_DIR to custom-spec.gmk

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -411,12 +411,12 @@ build-j9vm : run-preprocessors-j9
 		&& $(MAKE_VM) $(MAKE_ARGS) -C $(OUTPUT_ROOT)/vm JAVA_VERSION=80 VERSION_MAJOR=8 all
 	@$(ECHO) OpenJ9 compile complete
 
-J9JCL_SOURCES_DONEFILE := $(JDK_OUTPUTDIR)/j9jcl_sources/j9jcl_sources.done
+J9JCL_SOURCES_DONEFILE := $(J9JCL_SOURCES_DIR)/j9jcl.done
 
 recur_wildcard = $(foreach dir,$(wildcard $1/*),$(call recur_wildcard,$(dir),$2) $(filter $(subst *,%,$2),$(dir)))
 AllJclSource   = $(call recur_wildcard,$(OPENJ9_TOPDIR)/jcl/src,*.java)
 
-JPP_DEST := $(JDK_OUTPUTDIR)/j9jcl_sources/jdk/src/share/classes
+JPP_DEST := $(J9JCL_SOURCES_DIR)/jdk/src/share/classes
 JPP_JAR  := $(J9TOOLS_DIR)/jpp.jar
 JPP_TAGS := PLATFORM-$(OPENJ9_PLATFORM_CODE)
 

--- a/closed/make/CopyFiles.gmk
+++ b/closed/make/CopyFiles.gmk
@@ -20,7 +20,7 @@
 # 
 # ===========================================================================
 
-$(JDK_OUTPUTDIR)/classes/com/ibm/oti/util/ExternalMessages.properties: $(JDK_OUTPUTDIR)/j9jcl_sources/jdk/src/share/classes/com/ibm/oti/util/ExternalMessages.properties
+$(JDK_OUTPUTDIR)/classes/com/ibm/oti/util/ExternalMessages.properties: $(J9JCL_SOURCES_DIR)/jdk/src/share/classes/com/ibm/oti/util/ExternalMessages.properties
 	$(call install-file)
 
 COPY_FILES += $(JDK_OUTPUTDIR)/classes/com/ibm/oti/util/ExternalMessages.properties

--- a/closed/make/Javadoc.gmk
+++ b/closed/make/Javadoc.gmk
@@ -43,7 +43,7 @@ PLATFORM2COREAPI := ../api
 
 #############################################################################
 # Source files for openj9 extensions javadoc
-OPENJ9_DOCS_SRCDIR := $(JDK_OUTPUTDIR)/j9jcl_sources/jdk/src/share/classes
+OPENJ9_DOCS_SRCDIR := $(J9JCL_SOURCES_DIR)/jdk/src/share/classes
 
 #############################################################################
 # Update macros which hold a list of the source directories.
@@ -511,7 +511,7 @@ $(OPENJ9_MGMT_PACKAGES_FILE) : $(DIRECTORY_CACHE) $(call PackageDependencies,$(A
 # When pages are being generated openj9 extensions (under the docs/platform
 # directory), the correct footer is specified directly in the javadoc command.
 #
-# The OpenJ9 classes are built from the j9jcl_sources and closed/src
+# The OpenJ9 classes are built from the $(J9JCL_SOURCES_DIR) and closed/src
 # directories.
 # The packages are beneath directories called /share/classes (or /unix/classes,
 # /windows/classes etc.) which do not appear in the javadoc tree structure.
@@ -563,7 +563,7 @@ OPENJ9_JAVADOC_SCRIPT_BODY = \
 
 $(OPENJ9_JAVADOC_MARKER) : $(COREAPI_DOCSDIR)/index.html $(OPENJ9_MGMT_INDEXALL_FILE)
 	$(ECHO) '$(OPENJ9_JAVADOC_SCRIPT_BODY)' >$(OPENJ9_JAVADOC_SCRIPT)
-	$(CD) $(JDK_OUTPUTDIR)/j9jcl_sources/jdk/src ; \
+	$(CD) $(J9JCL_SOURCES_DIR)/jdk/src ; \
 		$(FIND) . -type f -name '*.java' \
 			| $(SED) -e 's|/[^/]\+/classes/|/|' -e 's|\.java$$|.html|' \
 			| $(XARGS) $(BASH) $(OPENJ9_JAVADOC_SCRIPT)

--- a/jdk/make/CreateJars.gmk
+++ b/jdk/make/CreateJars.gmk
@@ -23,9 +23,8 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
 # ===========================================================================
-#
 
 include $(SPEC)
 include MakeBase.gmk
@@ -646,7 +645,7 @@ SRC_ZIP_SRCS += $(JDK_OUTPUTDIR)/gendocsrc_rmic
 ifndef OPENJDK
   SRC_ZIP_SRCS += $(JDK_TOPDIR)/src/closed/share/classes
 endif
-SRC_ZIP_SRCS += $(JDK_OUTPUTDIR)/j9jcl_sources/jdk/src/share/classes
+SRC_ZIP_SRCS += $(J9JCL_SOURCES_DIR)/jdk/src/share/classes
 SRC_ZIP_SRCS += $(SRC_ROOT)/closed/adds/jdk/src/share/classes
 
 # Need to copy launcher src files into desired directory structure

--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -128,3 +128,5 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 else
   OPENJ9_VM_BUILD_DIR = $(OUTPUT_ROOT)/vm
 endif
+
+J9JCL_SOURCES_DIR := $(JDK_OUTPUTDIR)/j9jcl

--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2011, 2018 All Rights Reserved
+# (c) Copyright IBM Corp. 2011, 2020 All Rights Reserved
 # ===========================================================================
 
 # This makefile is much simpler now that it can use the smart javac wrapper
@@ -409,14 +409,14 @@ define SetupJavaCompilation
   # Find all files in the source trees.
  
   # Add J9 generated source overrides
-  J9_OVERRIDE_SRC_ROOT := $$(JDK_OUTPUTDIR)/j9jcl_sources
+  J9_OVERRIDE_SRC_ROOT := $$(J9JCL_SOURCES_DIR)
   $1_SRC += $$(wildcard $$(subst $$(SRC_ROOT),$$(J9_OVERRIDE_SRC_ROOT),$$($1_SRC)))
 
   $1_ALL_SRCS += $$(filter-out $(OVR_SRCS),$$(call CacheFind,$$($1_SRC)))
 
   # Filter out SRC_ROOT equivalents of J9 generated source overrides
-  AllJ9JclSource   = $$(call recur_wildcard,$$(J9_OVERRIDE_SRC_ROOT),*.java)
-  J9_OVR_SRCS:=$$(subst $$(J9_OVERRIDE_SRC_ROOT),$$(SRC_ROOT),$$(AllJ9JclSource))
+  AllJ9JclSource = $$(call recur_wildcard,$$(J9_OVERRIDE_SRC_ROOT),*.java)
+  J9_OVR_SRCS := $$(subst $$(J9_OVERRIDE_SRC_ROOT),$$(SRC_ROOT),$$(AllJ9JclSource))
   $1_ALL_SRCS := $$(filter-out $$(J9_OVR_SRCS),$$($1_ALL_SRCS))
 
   # Extract the java files.


### PR DESCRIPTION
Replace multiple occurrences of `$(JDK_OUTPUTDIR)/j9jcl_sources` with `$(J9JCL_SOURCES_DIR)`.