### PR TITLE
Add accelerated zlibNX to LIBPATH for AIX P9 or newer systems and set system zlib as default on AIX

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4031,6 +4031,10 @@ fi
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# ===========================================================================
+
 
 
 
@@ -4410,7 +4414,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1605656592
+DATE_WHEN_GENERATED=1611600888
 
 ###############################################################################
 #
@@ -48442,9 +48446,9 @@ fi
 $as_echo_n "checking for which zlib to use... " >&6; }
 
   DEFAULT_ZLIB=bundled
-  if test "x$OPENJDK_TARGET_OS" = xmacosx; then
+  if test "x$OPENJDK_TARGET_OS" = xmacosx -o "x$OPENJDK_TARGET_OS" = xaix; then
     #
-    # On macosx default is system...on others default is
+    # On macosx and aix default is system...on others default is
     #
     DEFAULT_ZLIB=system
   fi

--- a/common/autoconf/libraries.m4
+++ b/common/autoconf/libraries.m4
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# ===========================================================================
+
 AC_DEFUN_ONCE([LIB_SETUP_INIT],
 [
 
@@ -833,9 +837,9 @@ AC_DEFUN_ONCE([LIB_SETUP_MISC_LIBS],
   AC_MSG_CHECKING([for which zlib to use])
 
   DEFAULT_ZLIB=bundled
-  if test "x$OPENJDK_TARGET_OS" = xmacosx; then
+  if test "x$OPENJDK_TARGET_OS" = xmacosx -o "x$OPENJDK_TARGET_OS" = xaix; then
     #
-    # On macosx default is system...on others default is
+    # On macosx and aix default is system...on others default is
     #
     DEFAULT_ZLIB=system
   fi

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -4110,6 +4110,10 @@ fi
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# ===========================================================================
+
 
 
 
@@ -4546,7 +4550,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1605656592
+DATE_WHEN_GENERATED=1611600888
 
 ###############################################################################
 #
@@ -50956,9 +50960,9 @@ fi
 $as_echo_n "checking for which zlib to use... " >&6; }
 
   DEFAULT_ZLIB=bundled
-  if test "x$OPENJDK_TARGET_OS" = xmacosx; then
+  if test "x$OPENJDK_TARGET_OS" = xmacosx -o "x$OPENJDK_TARGET_OS" = xaix; then
     #
-    # On macosx default is system...on others default is
+    # On macosx and aix default is system...on others default is
     #
     DEFAULT_ZLIB=system
   fi

--- a/jdk/src/solaris/bin/java_md_solinux.h
+++ b/jdk/src/solaris/bin/java_md_solinux.h
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * ===========================================================================
+ */
+
 #ifndef JAVA_MD_SOLINUX_H
 #define JAVA_MD_SOLINUX_H
 
@@ -59,5 +65,30 @@ static const char *user_dir     = "/java";
 #else
 #include <pthread.h>
 #endif
+
+#ifdef AIX
+#define ZLIBNX_PATH "/usr/opt/zlibNX/lib"
+
+#ifndef POWER_9
+#define POWER_9 0x20000 /* 9 class CPU */
+#endif
+
+#ifndef POWER_10
+#define POWER_10 0x40000 /* 10 class CPU */
+#endif
+
+#define power_9_andup() ((POWER_9  == _system_configuration.implementation) \
+                        || (POWER_10 == _system_configuration.implementation))
+
+#ifndef SC_NX_CAP
+#define SC_NX_CAP 60
+#endif
+
+#ifndef NX_GZIP_PRESENT
+#define NX_GZIP_PRESENT 0x00000001
+#endif
+
+#define power_nx_gzip() (0 != ((long)getsystemcfg(SC_NX_CAP) & NX_GZIP_PRESENT))
+#endif /* AIX */
 
 #endif /* JAVA_MD_SOLINUX_H */


### PR DESCRIPTION
`zlibNX` is an accelerated replacement for `zlib`, it make use of the NX accelerator in P9 and newer systems.
This PR enable the use of `zlibNX` for AIX systems by adding it to the `LIBPATH` if the system is P9 or newer and has the NX accelerator enabled.

This PR also sets system zlib as default instead of bundled zlib on AIX systems to allow `zlibNX`

Signed-off-by: Abdulrahman Alattas <rmnattas@gmail.com>