### PR TITLE
Enable cmake by default on linux, AIX and mac platforms

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4414,7 +4414,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1611600888
+DATE_WHEN_GENERATED=1611961122
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -61,26 +61,37 @@ AC_DEFUN([OPENJ9_CONFIGURE_CMAKE],
       if test "x$with_cmake" = xyes -o "x$with_cmake" = x ; then
         with_cmake=cmake
       fi
-      if test "x$with_cmake" != xno ; then
-        if AS_EXECUTABLE_P(["$with_cmake"]) ; then
-          CMAKE="$with_cmake"
-        else
-          BASIC_REQUIRE_PROGS([CMAKE], [$with_cmake])
-        fi
-        with_cmake=yes
-      fi
     ],
-    [with_cmake=no])
-  if test "$with_cmake" = yes ; then
-    OPENJ9_ENABLE_CMAKE=true
-  else
+    [
+      case "$OPENJ9_PLATFORM_CODE" in
+        ap64|oa64|xa64|xl64|xr64|xz64)
+          if test "x$COMPILE_TYPE" != xcross ; then
+            with_cmake=cmake
+          else
+            with_cmake=no
+          fi
+          ;;
+        *)
+          with_cmake=no
+          ;;
+      esac
+    ])
+  # at this point with_cmake should either be no, or the name of the cmake command
+  if test "x$with_cmake" = xno ; then
     OPENJ9_ENABLE_CMAKE=false
-
     # Currently, mixedrefs mode is only available with CMake enabled
     if test "x$OMR_MIXED_REFERENCES_MODE" != xoff ; then
       AC_MSG_ERROR([[--with-mixedrefs=[static|dynamic] requires --with-cmake]])
     fi
+  else
+    OPENJ9_ENABLE_CMAKE=true
+    if AS_EXECUTABLE_P(["$with_cmake"]) ; then
+      CMAKE="$with_cmake"
+    else
+      BASIC_REQUIRE_PROGS([CMAKE], [$with_cmake])
+    fi
   fi
+
   AC_SUBST(OPENJ9_ENABLE_CMAKE)
 ])
 

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -4491,7 +4491,7 @@ VS_SDK_PLATFORM_NAME_2017=
 # definitions. It is replaced with custom functionality when building
 # custom sources.
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -4550,7 +4550,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1611600888
+DATE_WHEN_GENERATED=1611961122
 
 ###############################################################################
 #
@@ -15301,10 +15301,36 @@ if test "${with_cmake+set}" = set; then :
       if test "x$with_cmake" = xyes -o "x$with_cmake" = x ; then
         with_cmake=cmake
       fi
-      if test "x$with_cmake" != xno ; then
-        if as_fn_executable_p "$with_cmake" ; then
-          CMAKE="$with_cmake"
-        else
+
+else
+
+      case "$OPENJ9_PLATFORM_CODE" in
+        ap64|oa64|xa64|xl64|xr64|xz64)
+          if test "x$COMPILE_TYPE" != xcross ; then
+            with_cmake=cmake
+          else
+            with_cmake=no
+          fi
+          ;;
+        *)
+          with_cmake=no
+          ;;
+      esac
+
+fi
+
+  # at this point with_cmake should either be no, or the name of the cmake command
+  if test "x$with_cmake" = xno ; then
+    OPENJ9_ENABLE_CMAKE=false
+    # Currently, mixedrefs mode is only available with CMake enabled
+    if test "x$OMR_MIXED_REFERENCES_MODE" != xoff ; then
+      as_fn_error $? "--with-mixedrefs=[static|dynamic] requires --with-cmake" "$LINENO" 5
+    fi
+  else
+    OPENJ9_ENABLE_CMAKE=true
+    if as_fn_executable_p "$with_cmake" ; then
+      CMAKE="$with_cmake"
+    else
 
 
 
@@ -15498,24 +15524,9 @@ $as_echo "$tool_specified" >&6; }
   fi
 
 
-        fi
-        with_cmake=yes
-      fi
-
-else
-  with_cmake=no
-fi
-
-  if test "$with_cmake" = yes ; then
-    OPENJ9_ENABLE_CMAKE=true
-  else
-    OPENJ9_ENABLE_CMAKE=false
-
-    # Currently, mixedrefs mode is only available with CMake enabled
-    if test "x$OMR_MIXED_REFERENCES_MODE" != xoff ; then
-      as_fn_error $? "--with-mixedrefs=[static|dynamic] requires --with-cmake" "$LINENO" 5
     fi
   fi
+
 
 
 


### PR DESCRIPTION
Pre-testing to enable cmake. 
https://ci.eclipse.org/openj9/job/Pipeline-Build-Test-All/1168/ - only known intermittent failures.