### PR TITLE
Default jdk8 to build mixedrefs, unless cross compiling

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4414,7 +4414,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1613493478
+DATE_WHEN_GENERATED=1613592276
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -295,23 +295,25 @@ AC_DEFUN([OPENJ9_PLATFORM_SETUP],
   # Default OPENJ9_BUILD_OS=OPENJDK_BUILD_OS, but override with OpenJ9 equivalent as appropriate
   OPENJ9_BUILD_OS="${OPENJDK_BUILD_OS}"
 
-  OMR_MIXED_REFERENCES_MODE=off
-  if test "x$with_mixedrefs" != x -a "x$with_mixedrefs" != xno; then
-    if test "x$with_mixedrefs" = xyes -o "x$with_mixedrefs" = xstatic; then
+  if test "x$with_noncompressedrefs" = xyes -o "x$OPENJDK_TARGET_CPU_BITS" = x32 -o "x$with_mixedrefs" = xno -o "x$COMPILE_TYPE" = xcross ; then
+    OMR_MIXED_REFERENCES_MODE=off
+    if test "x$with_noncompressedrefs" = xyes -o "x$OPENJDK_TARGET_CPU_BITS" = x32 ; then
+      OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}"
+      OPENJ9_LIBS_SUBDIR=default
+    else
+      OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_cmprssptrs"
+      OPENJ9_LIBS_SUBDIR=compressedrefs
+    fi
+  else
+    if test "x$with_mixedrefs" = x -o "x$with_mixedrefs" = xyes -o "x$with_mixedrefs" = xstatic ; then
       OMR_MIXED_REFERENCES_MODE=static
-    elif test "x$with_mixedrefs" = xdynamic; then
+    elif test "x$with_mixedrefs" = xdynamic ; then
       OMR_MIXED_REFERENCES_MODE=dynamic
     else
       AC_MSG_ERROR([OpenJ9 supports --with-mixedrefs=static and --with-mixedrefs=dynamic])
     fi
     OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_mxdptrs"
     OPENJ9_LIBS_SUBDIR=default
-  elif test "x$with_noncompressedrefs" = xyes -o "x$OPENJDK_TARGET_CPU_BITS" = x32; then
-    OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}"
-    OPENJ9_LIBS_SUBDIR=default
-  else
-    OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_cmprssptrs"
-    OPENJ9_LIBS_SUBDIR=compressedrefs
   fi
 
   if test "x$OPENJ9_CPU" = xx86-64 ; then

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -4554,7 +4554,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1613493478
+DATE_WHEN_GENERATED=1613592276
 
 ###############################################################################
 #
@@ -15225,23 +15225,25 @@ fi
   # Default OPENJ9_BUILD_OS=OPENJDK_BUILD_OS, but override with OpenJ9 equivalent as appropriate
   OPENJ9_BUILD_OS="${OPENJDK_BUILD_OS}"
 
-  OMR_MIXED_REFERENCES_MODE=off
-  if test "x$with_mixedrefs" != x -a "x$with_mixedrefs" != xno; then
-    if test "x$with_mixedrefs" = xyes -o "x$with_mixedrefs" = xstatic; then
+  if test "x$with_noncompressedrefs" = xyes -o "x$OPENJDK_TARGET_CPU_BITS" = x32 -o "x$with_mixedrefs" = xno -o "x$COMPILE_TYPE" = xcross ; then
+    OMR_MIXED_REFERENCES_MODE=off
+    if test "x$with_noncompressedrefs" = xyes -o "x$OPENJDK_TARGET_CPU_BITS" = x32 ; then
+      OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}"
+      OPENJ9_LIBS_SUBDIR=default
+    else
+      OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_cmprssptrs"
+      OPENJ9_LIBS_SUBDIR=compressedrefs
+    fi
+  else
+    if test "x$with_mixedrefs" = x -o "x$with_mixedrefs" = xyes -o "x$with_mixedrefs" = xstatic ; then
       OMR_MIXED_REFERENCES_MODE=static
-    elif test "x$with_mixedrefs" = xdynamic; then
+    elif test "x$with_mixedrefs" = xdynamic ; then
       OMR_MIXED_REFERENCES_MODE=dynamic
     else
       as_fn_error $? "OpenJ9 supports --with-mixedrefs=static and --with-mixedrefs=dynamic" "$LINENO" 5
     fi
     OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_mxdptrs"
     OPENJ9_LIBS_SUBDIR=default
-  elif test "x$with_noncompressedrefs" = xyes -o "x$OPENJDK_TARGET_CPU_BITS" = x32; then
-    OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}"
-    OPENJ9_LIBS_SUBDIR=default
-  else
-    OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_cmprssptrs"
-    OPENJ9_LIBS_SUBDIR=compressedrefs
   fi
 
   if test "x$OPENJ9_CPU" = xx86-64 ; then


### PR DESCRIPTION
See https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/382