### PR TITLE
Switch to build with cmake by default for Windows 64-bit

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4414,7 +4414,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1613064460
+DATE_WHEN_GENERATED=1613485990
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -64,7 +64,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CMAKE],
     ],
     [
       case "$OPENJ9_PLATFORM_CODE" in
-        ap64|oa64|xa64|xl64|xr64|xz64)
+        ap64|oa64|wa64|xa64|xl64|xr64|xz64)
           if test "x$COMPILE_TYPE" != xcross ; then
             with_cmake=cmake
           else

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -4554,7 +4554,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1613064460
+DATE_WHEN_GENERATED=1613485990
 
 ###############################################################################
 #
@@ -15306,7 +15306,7 @@ if test "${with_cmake+set}" = set; then :
 else
 
       case "$OPENJ9_PLATFORM_CODE" in
-        ap64|oa64|xa64|xl64|xr64|xz64)
+        ap64|oa64|wa64|xa64|xl64|xr64|xz64)
           if test "x$COMPILE_TYPE" != xcross ; then
             with_cmake=cmake
           else


### PR DESCRIPTION
With the merge of https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/477, cmake is supported for Windows 64-bit.

The nightly build last night was successful (build and testing) with cmake (and mixedrefs).
https://ci.eclipse.org/openj9/job/Pipeline_Build_Test_JDK8_x86-64_windows_mixed/1/