### PR TITLE
Reduce unnecessary differences relative to openjdk

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4414,7 +4414,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1613592276
+DATE_WHEN_GENERATED=1614026434
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -450,6 +450,9 @@ AC_DEFUN([OPENJ9_THIRD_PARTY_REQUIREMENTS],
 
 AC_DEFUN_ONCE([CUSTOM_LATE_HOOK],
 [
+  # You're here because you want OpenJ9, not some other implementation.
+  BUILD_HOTSPOT=false
+
   CONFIGURE_OPENSSL
 
   COMPILER=$CXX

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -4554,7 +4554,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1613592276
+DATE_WHEN_GENERATED=1614026434
 
 ###############################################################################
 #
@@ -55639,6 +55639,9 @@ $as_echo "$OUTPUT_DIR_IS_LOCAL" >&6; }
 
 
 # At the end, call the custom hook. (Dummy macro if no custom sources available)
+
+  # You're here because you want OpenJ9, not some other implementation.
+  BUILD_HOTSPOT=false
 
 
 

--- a/jdk/make/lib/SoundLibraries.gmk
+++ b/jdk/make/lib/SoundLibraries.gmk
@@ -1,3 +1,4 @@
+#
 # Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
@@ -23,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2011, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2011, 2021 All Rights Reserved
 # ===========================================================================
 
 LIBJSOUND_SRC_DIRS := \
@@ -140,21 +141,20 @@ else
   endif
 
   ifeq ($(OPENJDK_TARGET_CPU), ppc64)
-    LIBJSOUND_CFLAGS += -DX_ARCH=X_PPC64
+       LIBJSOUND_CFLAGS += -DX_ARCH=X_PPC64
   endif
 
   ifeq ($(OPENJDK_TARGET_CPU), ppc64le)
-    LIBJSOUND_CFLAGS += -DX_ARCH=X_PPC64LE
-  endif
-
-  ifeq ($(OPENJDK_TARGET_CPU), s390x)
-    LIBJSOUND_CFLAGS += -DX_ARCH=X_S390X
+       LIBJSOUND_CFLAGS += -DX_ARCH=X_PPC64LE
   endif
 
   ifeq ($(OPENJDK_TARGET_CPU), aarch64)
     LIBJSOUND_CFLAGS += -DX_ARCH=X_AARCH64
   endif
 
+  ifeq ($(OPENJDK_TARGET_CPU), s390x)
+    LIBJSOUND_CFLAGS += -DX_ARCH=X_S390X
+  endif
 endif
 
 LIBJSOUND_CFLAGS += -DEXTRA_SOUND_JNI_LIBS='"$(EXTRA_SOUND_JNI_LIBS)"'

--- a/jdk/src/macosx/native/sun/font/CCharToGlyphMapper.m
+++ b/jdk/src/macosx/native/sun/font/CCharToGlyphMapper.m
@@ -23,10 +23,6 @@
  * questions.
  */
 
-/*
- * This file is backported from OpenJDK11
- */
-
 #import <JavaNativeFoundation/JavaNativeFoundation.h>
 
 #import "AWTFont.h"
@@ -111,10 +107,9 @@ JNF_COCOA_ENTER(env);
         AllocateGlyphBuffer(env, awtFont, count,
                            (UniChar *)unicodesAsChars, glyphs);
 
-        (*env)->ReleasePrimitiveArrayCritical(env, unicodes,
-                                              unicodesAsChars, JNI_ABORT);
+    (*env)->ReleasePrimitiveArrayCritical(env, unicodes,
+                                          unicodesAsChars, JNI_ABORT);
     }
 
 JNF_COCOA_EXIT(env);
 }
-

--- a/jdk/src/macosx/native/sun/osxapp/ThreadUtilities.m
+++ b/jdk/src/macosx/native/sun/osxapp/ThreadUtilities.m
@@ -36,7 +36,7 @@ static JNIEnv *appKitEnv = NULL;
 static jobject appkitThreadGroup = NULL;
 static BOOL awtEmbedded = NO;
 
-static inline void attachCurrentThread(void** env) {
+inline void attachCurrentThread(void** env) {
     if ([NSThread isMainThread]) {
         JavaVMAttachArgs args;
         args.version = JNI_VERSION_1_4;

--- a/jdk/src/share/native/com/sun/media/sound/SoundDefs.h
+++ b/jdk/src/share/native/com/sun/media/sound/SoundDefs.h
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+ * (c) Copyright IBM Corp. 2020, 2021 All Rights Reserved
  * ===========================================================================
  */
 
@@ -50,8 +50,8 @@
 #define X_PPC           8
 #define X_PPC64         9
 #define X_PPC64LE      10
-#define X_S390X        11
-#define X_AARCH64      12
+#define X_AARCH64      11
+#define X_S390X        12
 
 // **********************************
 // Make sure you set X_PLATFORM and X_ARCH defines correctly.

--- a/jdk/src/solaris/bin/aarch64/jvm.cfg
+++ b/jdk/src/solaris/bin/aarch64/jvm.cfg
@@ -20,9 +20,11 @@
 # Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
 # or visit www.oracle.com if you need additional information or have any
 # questions.
+#
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2021 All Rights Reserved
 # ===========================================================================
+# 
 # List of JVMs that can be used as an option to java, javac, etc.
 # Order is important -- first in this list is the default JVM.
 # NOTE that this both this file and its format are UNSUPPORTED and

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -23,10 +23,6 @@
 # questions.
 #
 
-# ===========================================================================
-# (c) Copyright IBM Corp. 2011, 2020 All Rights Reserved
-# ===========================================================================
-
 ### This is the main part of the Makefile, for the normal case with SPEC specifying a single existing spec.gmk file.
 
 # Now load the spec
@@ -115,7 +111,7 @@ ifeq ($(BUILD_HOTSPOT),true)
 	@$(call TargetExit)
 endif
 
-jdk: langtools corba jaxp jaxws jdk-only
+jdk: langtools hotspot corba jaxp jaxws jdk-only
 jdk-only: start-make
 	@$(call TargetEnter)
 	@($(CD) $(JDK_TOPDIR)/make && $(BUILD_LOG_WRAPPER) $(MAKE) $(MAKE_ARGS) -f BuildJdk.gmk $(JDK_TARGET))
@@ -147,7 +143,7 @@ overlay-images-only: start-make
 	@($(CD) $(JDK_TOPDIR)/make && $(BUILD_LOG_WRAPPER) $(MAKE) $(MAKE_ARGS) -f BuildJdk.gmk overlay-images)
 	@$(call TargetExit)
 
-profiles: source-tips jdk profiles-only
+profiles: source-tips jdk hotspot profiles-only
 profiles-only: start-make
 	@$(call TargetEnter)
 	@($(CD) $(JDK_TOPDIR)/make && $(BUILD_LOG_WRAPPER) $(MAKE) $(MAKE_ARGS) -f BuildJdk.gmk profiles)
@@ -204,7 +200,7 @@ $(OUTPUT_ROOT)/source_tips: FRC
 
 
 # Remove everything, except the output from configure.
-clean: clean-langtools clean-corba clean-jaxp clean-jaxws clean-jdk clean-nashorn clean-images clean-overlay-images clean-bootcycle-build clean-docs clean-test
+clean: clean-langtools clean-corba clean-jaxp clean-jaxws clean-hotspot clean-jdk clean-nashorn clean-images clean-overlay-images clean-bootcycle-build clean-docs clean-test
 	@($(CD) $(OUTPUT_ROOT) && $(RM) -r tmp source_tips build.log* build-trace*.log*)
 	@$(ECHO) Cleaned all build artifacts.
 

--- a/nashorn/src/jdk/nashorn/internal/runtime/resources/parser.js
+++ b/nashorn/src/jdk/nashorn/internal/runtime/resources/parser.js
@@ -23,10 +23,6 @@
  * questions.
  */
 
-/*
- * This file is backported from OpenJDK11
- */
-
 /**
  * Parse function returns a JSON object representing ECMAScript code passed.
  * name is optional name for the code source and location param tells whether to


### PR DESCRIPTION
* disable building hotspot at configuration time instead of modifying upstream makefiles
* clean up: indent consistently