### PR TITLE
Support including healthcenter agent

### DIFF
--- a/closed/CopyToBuildJdk.gmk
+++ b/closed/CopyToBuildJdk.gmk
@@ -228,3 +228,73 @@ ifeq (true,$(OPENJ9_ENABLE_DDR))
 		$(OPENJ9_VM_BUILD_DIR) \
 		$(OPENJ9_LIBS_DIR)/$(OPENJ9_LIBS_SUBDIR)))
 endif # OPENJ9_ENABLE_DDR
+
+ifneq (,$(HEALTHCENTER_JAR))
+
+# Extract the contents of HEALTHCENTER_JAR to HEALTHCENTER_HOME.
+
+HEALTHCENTER_HOME := $(JDK_OUTPUTDIR)/healthcenter
+HEALTHCENTER_EXTRACT := $(HEALTHCENTER_HOME)/extract_marker
+HEALTHCENTER_FILES := \
+	$(addprefix $(HEALTHCENTER_HOME)/, \
+		healthcenter.jar \
+		healthcenter.properties \
+		monitoring-api.jar \
+		$(call SHARED_LIBRARY,healthcenter) \
+		plugins/$(call SHARED_LIBRARY,hcapiplugin) \
+	)
+
+$(HEALTHCENTER_EXTRACT) : $(HEALTHCENTER_JAR)
+	@$(ECHO) Extracting contents of $<
+	@$(RM) -rf $(@D)
+	$(MKDIR) -p $(@D)
+	$(UNZIP) -q $< -d $(@D)
+	@$(TOUCH) $@
+
+$(HEALTHCENTER_FILES) : $(HEALTHCENTER_EXTRACT)
+
+# Copy the properties file, changing the default transport to jrmp.
+
+TRANSPORT_PROPERTY_NAME       := com.ibm.java.diagnostics.healthcenter.agent.transport
+TRANSPORT_PROPERTY_REGEX      := $(subst .,\.,$(TRANSPORT_PROPERTY_NAME))
+TRANSPORT_PROPERTY_SED_SCRIPT := -e 's|$(TRANSPORT_PROPERTY_REGEX)\s*=.*|$(TRANSPORT_PROPERTY_NAME)=jrmp|'
+
+all : $(JDK_OUTPUTDIR)/lib/healthcenter.properties
+
+$(JDK_OUTPUTDIR)/lib/healthcenter.properties : $(HEALTHCENTER_HOME)/healthcenter.properties
+	$(MKDIR) -p $(@D)
+	$(SED) $(TRANSPORT_PROPERTY_SED_SCRIPT) < $< > $@
+
+# Copy the jars, removing unwanted content.
+
+all : $(JDK_OUTPUTDIR)/lib/ext/healthcenter.jar
+
+$(JDK_OUTPUTDIR)/lib/ext/healthcenter.jar : $(HEALTHCENTER_HOME)/healthcenter.jar
+	$(call install-file)
+	$(ZIP) -d -q $@ "com/ibm/tools/attach/*" "com/sun/tools/attach/*"
+
+all : $(JDK_OUTPUTDIR)/lib/tools/monitoring-api.jar
+
+$(JDK_OUTPUTDIR)/lib/tools/monitoring-api.jar : $(HEALTHCENTER_HOME)/monitoring-api.jar
+	$(call install-file)
+	$(ZIP) -d -q $@ "com/ibm/jvm/*"
+
+# Copy the available shared libraries.
+
+HEALTHCENTER_COPY := $(HEALTHCENTER_HOME)/copy_marker
+
+# Not all components are available on all platforms, hence the use of $(wildcard).
+# Also note that evaluation must be delayed, so we use '=' instead of ':='.
+HEALTHCENTER_LIBRARIES = \
+	$(HEALTHCENTER_HOME)/$(call SHARED_LIBRARY,healthcenter) \
+	$(HEALTHCENTER_HOME)/plugins/$(call SHARED_LIBRARY,hcapiplugin) \
+	$(wildcard $(HEALTHCENTER_HOME)/plugins/$(call SHARED_LIBRARY,hcmqtt))
+
+all : $(HEALTHCENTER_COPY)
+
+$(HEALTHCENTER_COPY) : $(HEALTHCENTER_EXTRACT)
+	$(MKDIR) -p $(OPENJ9_LIBS_DIR)
+	$(CP) -f $(HEALTHCENTER_LIBRARIES) $(OPENJ9_LIBS_DIR)/
+	@$(TOUCH) $@
+
+endif # HEALTHCENTER_JAR

--- a/closed/make/CreateJars.gmk
+++ b/closed/make/CreateJars.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -122,3 +122,17 @@ OPENJ9_MANAGEMENT_TYPES := \
 PROFILE_1_RTJAR_EXCLUDE_TYPES += $(OPENJ9_MANAGEMENT_TYPES)
 PROFILE_2_RTJAR_EXCLUDE_TYPES += $(OPENJ9_MANAGEMENT_TYPES)
 PROFILE_3_RTJAR_EXCLUDE_TYPES += # no extra exclusions
+
+ifneq (,$(HEALTHCENTER_JAR))
+
+JARS += $(IMAGES_OUTPUTDIR)/lib/ext/healthcenter.jar
+
+$(IMAGES_OUTPUTDIR)/lib/ext/healthcenter.jar : $(JDK_OUTPUTDIR)/lib/ext/healthcenter.jar
+	$(call install-file)
+
+JARS += $(IMAGES_OUTPUTDIR)/lib/tools/monitoring-api.jar
+
+$(IMAGES_OUTPUTDIR)/lib/tools/monitoring-api.jar : $(JDK_OUTPUTDIR)/lib/tools/monitoring-api.jar
+	$(call install-file)
+
+endif # HEALTHCENTER_JAR

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4414,7 +4414,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1614187756
+DATE_WHEN_GENERATED=1615843596
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -42,6 +42,7 @@ AC_DEFUN_ONCE([CUSTOM_EARLY_HOOK],
   OPENJ9_CONFIGURE_COMPILERS
   OPENJ9_CONFIGURE_CUDA
   OPENJ9_CONFIGURE_DDR
+  OPENJ9_CONFIGURE_HEALTHCENTER
   OPENJ9_CONFIGURE_JITSERVER
   OPENJ9_CONFIGURE_OPENJDK_METHODHANDLES
 
@@ -210,6 +211,35 @@ AC_DEFUN([OPENJ9_CONFIGURE_DDR],
   fi
 
   AC_SUBST(OPENJ9_ENABLE_DDR)
+])
+
+AC_DEFUN([OPENJ9_CONFIGURE_HEALTHCENTER],
+[
+  HEALTHCENTER_JAR=
+  AC_ARG_WITH(healthcenter, [AS_HELP_STRING([--with-healthcenter], [import healthcenter artifacts from this archive])],
+    [
+      if test "x$with_healthcenter" != xno ; then
+        healthcenter_dir="`$DIRNAME "$with_healthcenter"`"
+        BASIC_FIXUP_PATH(healthcenter_dir)
+        healthcenter_jar="$healthcenter_dir/`$BASENAME "$with_healthcenter"`"
+        AC_MSG_CHECKING([healthcenter])
+        if ! test -f "$healthcenter_jar" ; then
+          AC_MSG_ERROR([healthcenter archive not found at $with_healthcenter])
+        else
+          if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
+            # BASIC_FIXUP_PATH yields a Unix-style path, but we need a mixed-mode path
+            healthcenter_jar="`$CYGPATH -m $healthcenter_jar`"
+          fi
+          if test "$healthcenter_jar" = "$with_healthcenter" ; then
+            AC_MSG_RESULT([$with_healthcenter])
+          else
+            AC_MSG_RESULT([$with_healthcenter @<:@$healthcenter_jar@:>@])
+          fi
+          HEALTHCENTER_JAR=$healthcenter_jar
+        fi
+      fi
+    ])
+  AC_SUBST(HEALTHCENTER_JAR)
 ])
 
 AC_DEFUN([OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU],

--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -38,6 +38,9 @@ endif
 ifneq (,@OPENJ9_GDK_HOME@)
 export GDK_HOME         := @OPENJ9_GDK_HOME@
 endif
+
+# Archive from which to import Health Center content.
+HEALTHCENTER_JAR := @HEALTHCENTER_JAR@
 
 # OpenSSL
 OPENSSL_DIR             := @OPENSSL_DIR@

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -893,6 +893,7 @@ CONF_NAME
 SPEC
 OPENJ9_ENABLE_OPENJDK_METHODHANDLES
 OPENJ9_ENABLE_JITSERVER
+HEALTHCENTER_JAR
 OPENJ9_ENABLE_DDR
 OPENJ9_GDK_HOME
 OPENJ9_CUDA_HOME
@@ -1087,6 +1088,7 @@ with_cuda
 with_gdk
 enable_cuda
 enable_ddr
+with_healthcenter
 enable_jitserver
 enable_openjdk_methodhandles
 with_conf_name
@@ -1962,6 +1964,7 @@ Optional Packages:
                           build OpenJ9 with a specific Xcode version
   --with-cuda             use this directory as CUDA_HOME
   --with-gdk              use this directory as GDK_HOME
+  --with-healthcenter     import healthcenter artifacts from this archive
   --with-conf-name        use this as the name of the configuration [generated
                           from important configuration options]
   --with-toolchain-version
@@ -4544,6 +4547,8 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 
+
+
 # Create a tool wrapper for use by cmake.
 # Consists of a shell script which wraps commands with an invocation of a wrapper command.
 # OPENJ9_GENERATE_TOOL_WRAPPER(<name_of_output>, <name_of_wrapper>, <command_to_call>)
@@ -4554,7 +4559,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1614187756
+DATE_WHEN_GENERATED=1615843596
 
 ###############################################################################
 #
@@ -16120,6 +16125,161 @@ $as_echo "no (default for $OPENJ9_PLATFORM_CODE)" >&6; }
   else
     as_fn_error $? "--enable-ddr accepts no argument" "$LINENO" 5
   fi
+
+
+
+
+  HEALTHCENTER_JAR=
+
+# Check whether --with-healthcenter was given.
+if test "${with_healthcenter+set}" = set; then :
+  withval=$with_healthcenter;
+      if test "x$with_healthcenter" != xno ; then
+        healthcenter_dir="`$DIRNAME "$with_healthcenter"`"
+
+  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.cygwin"; then
+
+  # Input might be given as Windows format, start by converting to
+  # unix format.
+  path="$healthcenter_dir"
+  new_path=`$CYGPATH -u "$path"`
+
+  # Cygwin tries to hide some aspects of the Windows file system, such that binaries are
+  # named .exe but called without that suffix. Therefore, "foo" and "foo.exe" are considered
+  # the same file, most of the time (as in "test -f"). But not when running cygpath -s, then
+  # "foo.exe" is OK but "foo" is an error.
+  #
+  # This test is therefore slightly more accurate than "test -f" to check for file precense.
+  # It is also a way to make sure we got the proper file name for the real test later on.
+  test_shortpath=`$CYGPATH -s -m "$new_path" 2> /dev/null`
+  if test "x$test_shortpath" = x; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: The path of healthcenter_dir, which resolves as \"$path\", is invalid." >&5
+$as_echo "$as_me: The path of healthcenter_dir, which resolves as \"$path\", is invalid." >&6;}
+    as_fn_error $? "Cannot locate the the path of healthcenter_dir" "$LINENO" 5
+  fi
+
+  # Call helper function which possibly converts this using DOS-style short mode.
+  # If so, the updated path is stored in $new_path.
+
+  input_path="$new_path"
+  # Check if we need to convert this using DOS-style short mode. If the path
+  # contains just simple characters, use it. Otherwise (spaces, weird characters),
+  # take no chances and rewrite it.
+  # Note: m4 eats our [], so we need to use [ and ] instead.
+  has_forbidden_chars=`$ECHO "$input_path" | $GREP [^-._/a-zA-Z0-9]`
+  if test "x$has_forbidden_chars" != x; then
+    # Now convert it to mixed DOS-style, short mode (no spaces, and / instead of \)
+    shortmode_path=`$CYGPATH -s -m -a "$input_path"`
+    path_after_shortmode=`$CYGPATH -u "$shortmode_path"`
+    if test "x$path_after_shortmode" != "x$input_to_shortpath"; then
+      # Going to short mode and back again did indeed matter. Since short mode is
+      # case insensitive, let's make it lowercase to improve readability.
+      shortmode_path=`$ECHO "$shortmode_path" | $TR 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz'`
+      # Now convert it back to Unix-style (cygpath)
+      input_path=`$CYGPATH -u "$shortmode_path"`
+      new_path="$input_path"
+    fi
+  fi
+
+  test_cygdrive_prefix=`$ECHO $input_path | $GREP ^/cygdrive/`
+  if test "x$test_cygdrive_prefix" = x; then
+    # As a simple fix, exclude /usr/bin since it's not a real path.
+    if test "x`$ECHO $new_path | $GREP ^/usr/bin/`" = x; then
+      # The path is in a Cygwin special directory (e.g. /home). We need this converted to
+      # a path prefixed by /cygdrive for fixpath to work.
+      new_path="$CYGWIN_ROOT_PATH$input_path"
+    fi
+  fi
+
+
+  if test "x$path" != "x$new_path"; then
+    healthcenter_dir="$new_path"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: Rewriting healthcenter_dir to \"$new_path\"" >&5
+$as_echo "$as_me: Rewriting healthcenter_dir to \"$new_path\"" >&6;}
+  fi
+
+  elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.msys"; then
+
+  path="$healthcenter_dir"
+  has_colon=`$ECHO $path | $GREP ^.:`
+  new_path="$path"
+  if test "x$has_colon" = x; then
+    # Not in mixed or Windows style, start by that.
+    new_path=`cmd //c echo $path`
+  fi
+
+
+  input_path="$new_path"
+  # Check if we need to convert this using DOS-style short mode. If the path
+  # contains just simple characters, use it. Otherwise (spaces, weird characters),
+  # take no chances and rewrite it.
+  # Note: m4 eats our [], so we need to use [ and ] instead.
+  has_forbidden_chars=`$ECHO "$input_path" | $GREP [^-_/:a-zA-Z0-9]`
+  if test "x$has_forbidden_chars" != x; then
+    # Now convert it to mixed DOS-style, short mode (no spaces, and / instead of \)
+    new_path=`cmd /c "for %A in (\"$input_path\") do @echo %~sA"|$TR \\\\\\\\ / | $TR 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz'`
+  fi
+
+
+  windows_path="$new_path"
+  if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.cygwin"; then
+    unix_path=`$CYGPATH -u "$windows_path"`
+    new_path="$unix_path"
+  elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.msys"; then
+    unix_path=`$ECHO "$windows_path" | $SED -e 's,^\\(.\\):,/\\1,g' -e 's,\\\\,/,g'`
+    new_path="$unix_path"
+  fi
+
+  if test "x$path" != "x$new_path"; then
+    healthcenter_dir="$new_path"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: Rewriting healthcenter_dir to \"$new_path\"" >&5
+$as_echo "$as_me: Rewriting healthcenter_dir to \"$new_path\"" >&6;}
+  fi
+
+  # Save the first 10 bytes of this path to the storage, so fixpath can work.
+  all_fixpath_prefixes=("${all_fixpath_prefixes[@]}" "${new_path:0:10}")
+
+  else
+    # We're on a posix platform. Hooray! :)
+    path="$healthcenter_dir"
+    has_space=`$ECHO "$path" | $GREP " "`
+    if test "x$has_space" != x; then
+      { $as_echo "$as_me:${as_lineno-$LINENO}: The path of healthcenter_dir, which resolves as \"$path\", is invalid." >&5
+$as_echo "$as_me: The path of healthcenter_dir, which resolves as \"$path\", is invalid." >&6;}
+      as_fn_error $? "Spaces are not allowed in this path." "$LINENO" 5
+    fi
+
+    # Use eval to expand a potential ~
+    eval path="$path"
+    if test ! -f "$path" && test ! -d "$path"; then
+      as_fn_error $? "The path of healthcenter_dir, which resolves as \"$path\", is not found." "$LINENO" 5
+    fi
+
+    healthcenter_dir="`cd "$path"; $THEPWDCMD -L`"
+  fi
+
+        healthcenter_jar="$healthcenter_dir/`$BASENAME "$with_healthcenter"`"
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking healthcenter" >&5
+$as_echo_n "checking healthcenter... " >&6; }
+        if ! test -f "$healthcenter_jar" ; then
+          as_fn_error $? "healthcenter archive not found at $with_healthcenter" "$LINENO" 5
+        else
+          if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
+            # BASIC_FIXUP_PATH yields a Unix-style path, but we need a mixed-mode path
+            healthcenter_jar="`$CYGPATH -m $healthcenter_jar`"
+          fi
+          if test "$healthcenter_jar" = "$with_healthcenter" ; then
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_healthcenter" >&5
+$as_echo "$with_healthcenter" >&6; }
+          else
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_healthcenter [$healthcenter_jar]" >&5
+$as_echo "$with_healthcenter [$healthcenter_jar]" >&6; }
+          fi
+          HEALTHCENTER_JAR=$healthcenter_jar
+        fi
+      fi
+
+fi
 
 
 


### PR DESCRIPTION
* unpack artifacts from archive named via `--with-healthcenter` option
* set default transport to `jrmp`

This is similar to ibmruntimes/openj9-openjdk-jdk11#395 but for Java 8.