### PR TITLE
Add new jpackcore launcher

### DIFF
--- a/closed/make/Images.gmk
+++ b/closed/make/Images.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -18,8 +18,8 @@
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
 # ===========================================================================
 
-# only include jextract in jre/bin
-NOT_JDK_BIN_FILES  := jextract$(EXE_SUFFIX)
+# only include jextract, jpackcore in jre/bin
+NOT_JDK_BIN_FILES  := jextract$(EXE_SUFFIX) jpackcore$(EXE_SUFFIX)
 JDK_BIN_STRIP_LIST := $(filter-out $(addprefix %, $(addsuffix .stripped, $(NOT_JDK_BIN_FILES))), $(JDK_BIN_STRIP_LIST))
 JDK_BIN_TARGETS    := $(filter-out $(addprefix %, $(NOT_JDK_BIN_FILES)), $(JDK_BIN_TARGETS))
 

--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 
 default: all
@@ -498,10 +498,10 @@ $(eval $(call SetupLauncher,rmiregistry, \
 #$(eval $(call SetupLauncher,jcmd, \
 #    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "sun.tools.jcmd.JCmd"$(COMMA) }'))
 
-# Include executables for OpenJ9 (jdmpview, traceformat and jextract).
+# Include executables for OpenJ9 (jdmpview, traceformat, jextract and jpackcore).
 ifeq ($(OPENJDK_TARGET_OS),macosx)
   # Required because of the use of ImageInputStream?
-  JDMPVIEW_EXTRA_ARGS := "-J-XstartOnFirstThread" $(COMMA)
+  JDMPVIEW_EXTRA_ARGS := "-J-XstartOnFirstThread"$(COMMA)
 else
   JDMPVIEW_EXTRA_ARGS :=
 endif
@@ -515,6 +515,9 @@ $(eval $(call SetupLauncher,traceformat, \
 
 ifneq ($(findstring $(OPENJDK_TARGET_OS),aix linux macosx),)
   $(eval $(call SetupLauncher,jextract, \
+    -DEXPAND_CLASSPATH_WILDCARDS \
+    -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.ibm.jvm.j9.dump.extract.Main" }'))
+  $(eval $(call SetupLauncher,jpackcore, \
     -DEXPAND_CLASSPATH_WILDCARDS \
     -DJAVA_ARGS='{ "-J-ms8m"$(COMMA) "com.ibm.jvm.j9.dump.extract.Main" }'))
 endif


### PR DESCRIPTION
Equivalent to `jextract` which will clash with an upstream tool.

See eclipse/openj9#11278.