### PR TITLE
Preprocess source from debugtools/DDR_VM

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -470,6 +470,23 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 			-xml jpp_configuration.xml \
 			-dest "$(call FixPath,$(JPP_DEST))" \
 			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))"
+  ifeq (true,$(OPENJ9_ENABLE_DDR))
+	@$(ECHO) Generating DDR_VM sources
+	@$(BOOT_JDK)/bin/java \
+		-cp "$(call FixPath,$(JPP_JAR))" \
+		-Dfile.encoding=US-ASCII \
+		com.ibm.jpp.commandline.CommandlineBuilder \
+			-includeIfUnsure \
+			-noWarnIncludeIf \
+			-verdict \
+			-baseDir "$(call FixPath,$(OPENJ9_TOPDIR)/debugtools)/" \
+			-config DDR_VM \
+			-srcRoot DDR_VM/ \
+			-xml "$(call FixPath,$(OPENJ9_TOPDIR)/jcl/jpp_configuration.xml)/" \
+			-dest "$(call FixPath,$(J9JCL_SOURCES_DIR)/ddr)" \
+			-macro:define "JAVA_SPEC_VERSION=8" \
+			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))"
+  endif # OPENJ9_ENABLE_DDR
 	@$(MKDIR) -p $(@D)
 	@$(TOUCH) $@
 

--- a/closed/make/DDR.gmk
+++ b/closed/make/DDR.gmk
@@ -41,8 +41,8 @@ include $(SRC_ROOT)/make/common/MakeBase.gmk
 include $(SRC_ROOT)/make/common/JavaCompilation.gmk
 include $(SRC_ROOT)/jdk/make/Setup.gmk
 
-# The main source directory.
-DDR_VM_SRC_ROOT := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src
+# The main (pre-processed) source directory.
+DDR_VM_SRC_ROOT := $(J9JCL_SOURCES_DIR)/ddr
 
 # The top-level directory for intermediate artifacts.
 DDR_SUPPORT_DIR := $(JDK_OUTPUTDIR)/ddr
@@ -192,8 +192,11 @@ $(eval $(call SetupJavaCompilation,BUILD_J9DDR_TEST_CLASSES, \
 	SETUP := GENERATE_JDKBYTECODE, \
 	BIN := $(DDR_TEST_BIN), \
 	ADD_JAVAC_FLAGS := -cp $(DDR_CLASSES_BIN), \
-	SRC := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src, \
-	EXCLUDES := $(DDR_SRC_EXCLUDES), \
+	SRC := $(DDR_VM_SRC_ROOT), \
+	EXCLUDES := \
+		$(DDR_SRC_EXCLUDES) \
+		com/ibm/j9ddr/vm29/pointer/generated \
+		com/ibm/j9ddr/vm29/structure, \
 	DEPENDS := $(DDR_CLASSES_MARKER) \
 	))
 


### PR DESCRIPTION
* use preprocessor on source from `debugtools/DDR_VM`
* adjust compilation for `BUILD_J9DDR_TEST_CLASSES`

Depends on eclipse-openj9/openj9#13040.