### PR TITLE
Set default load address for launchers on plinux

### DIFF
--- a/jdk/make/CompileLaunchers.gmk
+++ b/jdk/make/CompileLaunchers.gmk
@@ -94,10 +94,11 @@ define SetupLauncher
   $1_LDFLAGS := $3
 
   ifeq ($(OPENJDK_TARGET_OS), linux)
-  # Set the image base address for zLinux 64 to 0x60000 for launchers,
-  # allows compressedRefsShift to be 0 when -Xmx is set to 2040m or more.
-  # / RTC PR 100052
-    ifeq ($(OPENJDK_TARGET_CPU), s390x)
+    # Set the image base address for p/zLinux 64 to 0x60000 for launchers,
+    # allows compressedRefsShift to be 0 when -Xmx is set to 2040m or more.
+    # Also maximizes the address space available for the java heap.
+    # / RTC PR 100052
+    ifneq (,$(filter ppc64le s390x, $(OPENJDK_TARGET_CPU)))
       $1_LDFLAGS += -Wl,-Ttext-segment=0x60000
     endif
   endif


### PR DESCRIPTION
On some machines the java launcher is loaded around 0x100000000,
breaking up the address space.

Once this is reviewed I'll create the same change for the other versions.