### PR TITLE
Add j9criu to files to be copied as a library

### DIFF
--- a/closed/CopyToBuildJdk.gmk
+++ b/closed/CopyToBuildJdk.gmk
@@ -163,6 +163,7 @@ $(call openj9_copy_files_and_debuginfos, \
 
 $(call openj9_copy_shlibs, \
 	cuda4j29 \
+	$(if $(filter true,$(OPENJ9_ENABLE_CRIU_SUPPORT)),j9criu29) \
 	j9dmp29 \
 	j9jextract \
 	j9gc29 \


### PR DESCRIPTION
Added j9criu29 as one of the generated libraries to copy over
Related to: eclipse-openj9/openj9#13245

Signed-off-by: Oussama Saoudi <oussama.saoudi@ibm.com>