### PR TITLE
Exit immediately if any unexpected error occurs cloning source repos

### DIFF
--- a/get_source.sh
+++ b/get_source.sh
@@ -28,6 +28,9 @@
 # (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 
+# exit immediately if any unexpected error occurs
+set -e
+
 usage() {
 	echo "Usage: $0 [-h|--help] [... other j9 options] [-parallel=<true|false>] [--openssl-version=<openssl version to download>]"
 	echo "where:"


### PR DESCRIPTION
As is done for other jdk versions, e.g. https://github.com/ibmruntimes/openj9-openjdk-jdk11/blob/openj9/get_source.sh#L26