### PR TITLE
Fix processing of JPP_TAGS

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -457,7 +457,7 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 			-srcRoot jcl/ \
 			-xml jpp_configuration.xml \
 			-dest "$(call FixPath,$(JPP_DEST))" \
-			-tag:define "$(JPP_TAGS)"
+			-tag:define "$(subst $(SPACE),;,$(sort $(JPP_TAGS)))"
 	@$(ECHO) Generating J9JCL tools
 	@$(BOOT_JDK)/bin/java \
 		-cp "$(call FixPath,$(JPP_JAR))" \


### PR DESCRIPTION
The processing of JPP_TAGS has been corrected during the invocation of
Java Preprocessor (jpp.jar). This allows OPENJDK_METHODHANDLES (JPP
flag) to work correctly.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>