### PR TITLE
Fix @Stable annotation in MethodHandleImpl

### DIFF
--- a/jdk/src/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/jdk/src/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang.invoke;
 
 import java.security.AccessController;
@@ -448,7 +454,7 @@ import static java.lang.invoke.MethodHandles.Lookup.IMPL_LOOKUP;
     private static final class AsVarargsCollector extends DelegatingMethodHandle {
         private final MethodHandle target;
         private final Class<?> arrayType;
-        private @Stable MethodHandle asCollectorCache;
+        private MethodHandle asCollectorCache;
 
         AsVarargsCollector(MethodHandle target, Class<?> arrayType) {
             this(target.type(), target, arrayType);


### PR DESCRIPTION
This is a back-port of ibmruntimes/openj9-openjdk-jdk17#81, required when `--enable-openjdk-methodhandles` is used at configuration time.