### PR TITLE
Temporarily disable CRIU support on JDK8

### DIFF
--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4433,7 +4433,7 @@ VS_SDK_PLATFORM_NAME_2017=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1649165785
+DATE_WHEN_GENERATED=1649701470
 
 ###############################################################################
 #

--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -128,8 +128,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CRIU_SUPPORT],
   AC_ARG_ENABLE([criu-support], [AS_HELP_STRING([--enable-criu-support], [enable CRIU support @<:@disabled@:>@])])
   OPENJ9_ENABLE_CRIU_SUPPORT=false
   if test "x$enable_criu_support" = xyes ; then
-    AC_MSG_RESULT([yes (explicitly enabled)])
-    OPENJ9_ENABLE_CRIU_SUPPORT=true
+    AC_MSG_ERROR([--enable-criu-support is temporarily disabled on jdk8])
   elif test "x$enable_criu_support" = xno ; then
     AC_MSG_RESULT([no (explicitly disabled)])
   elif test "x$enable_criu_support" = x ; then

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -4604,7 +4604,7 @@ VS_SDK_PLATFORM_NAME_2017=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1649165785
+DATE_WHEN_GENERATED=1649701470
 
 ###############################################################################
 #
@@ -15820,9 +15820,7 @@ fi
 
   OPENJ9_ENABLE_CRIU_SUPPORT=false
   if test "x$enable_criu_support" = xyes ; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes (explicitly enabled)" >&5
-$as_echo "yes (explicitly enabled)" >&6; }
-    OPENJ9_ENABLE_CRIU_SUPPORT=true
+    as_fn_error $? "--enable-criu-support is temporarily disabled on jdk8" "$LINENO" 5
   elif test "x$enable_criu_support" = xno ; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no (explicitly disabled)" >&5
 $as_echo "no (explicitly disabled)" >&6; }


### PR DESCRIPTION
Temporarily disable criu support on JDK8

There are currently efforts to enable CRIU security support to openj9.
The intention is to do this in a phased approach by first support jdk11+
since the code is fairly similar, after JDK8.

Signed-off-by: Tobi Ajila <atobia@ca.ibm.com>