### PR TITLE
(0.32) Add openssl version 3+ support for Linux platforms

### DIFF
--- a/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto_md.h
+++ b/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto_md.h
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,9 @@
 #ifndef NATIVECRYPTO_MD_H
 #define NATIVECRYPTO_MD_H
 
-void * load_crypto_library();
+#include <jni.h>
+
+void * load_crypto_library(jboolean traceEnabled);
 void   unload_crypto_library(void *handle);
 void * find_crypto_symbol(void *handle, const char *symname);
 

--- a/closed/adds/jdk/src/solaris/native/jdk/crypto/jniprovider/NativeCrypto_md.c
+++ b/closed/adds/jdk/src/solaris/native/jdk/crypto/jniprovider/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,13 +29,18 @@
 #include <dlfcn.h>
 #include "NativeCrypto_md.h"
 
+#if defined(__linux__)
+#include <link.h>
+#endif /* defined(__linux__) */
+
 /* Load the crypto library (return NULL on error) */
-void * load_crypto_library() {
+void * load_crypto_library(jboolean traceEnabled)
+{
     void * result = NULL;
     int flags = RTLD_NOW;
     size_t i = 0;
 
-    // Library names for OpenSSL 1.1.1, 1.1.0, 1.0.2 and symbolic links
+    // Library names for OpenSSL 3.x, 1.1.1, 1.1.0, 1.0.2 and symbolic links
     static const char * const libNames[] = {
 #if defined(_AIX)
     "libcrypto.a(libcrypto64.so.1.1)",
@@ -47,6 +52,7 @@ void * load_crypto_library() {
     "libcrypto.1.0.0.dylib",
     "libcrypto.dylib"
 #else
+    "libcrypto.so.3", // 3.x library name
     "libcrypto.so.1.1",
     "libcrypto.so.1.0.0",
     "libcrypto.so.10",
@@ -66,6 +72,15 @@ void * load_crypto_library() {
 
         result = dlopen (libName,  flags);
     }
+
+#if defined(__linux__)
+    if (traceEnabled && (NULL != result)) {
+        struct link_map *map = NULL;
+        dlinfo(result, RTLD_DI_LINKMAP, &map);
+        fprintf(stderr, "Attempt to load OpenSSL %s\n", map->l_name);
+        fflush(stderr);
+    }
+#endif /* defined(__linux__) */
 
     return result;
 }

--- a/closed/adds/jdk/src/windows/native/jdk/crypto/jniprovider/NativeCrypto_md.c
+++ b/closed/adds/jdk/src/windows/native/jdk/crypto/jniprovider/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ static jboolean GetApplicationHome(char *buf, jint bufsize);
 static int JLI_Snprintf(char* buffer, size_t size, const char* format, ...);
 
 /* Load the crypto library (return NULL on error) */
-void * load_crypto_library() {
+void * load_crypto_library(jboolean traceEnabled) {
     void * result = NULL;
     const char *libname;
     const char *oldname = "libeay32.dll";

--- a/jdk/test/com/sun/crypto/provider/Cipher/AEAD/GCMParameterSpecTest.java
+++ b/jdk/test/com/sun/crypto/provider/Cipher/AEAD/GCMParameterSpecTest.java
@@ -21,6 +21,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
+
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.util.Arrays;
@@ -36,7 +42,15 @@ import javax.crypto.spec.GCMParameterSpec;
  */
 public class GCMParameterSpecTest {
 
-    private static final int[] IV_LENGTHS = { 96, 8, 1024 };
+    /*
+     * OpenSSL3 only supports IV lengths up to 16 bytes.
+     * When the IV length is set to be larger than 16 bytes, an error is thrown.
+     * According to the OpenSSL docs([1]), in OpenSSL1.1.1 and older, there is
+     * no error thrown but unpredictable behavior will happen for large IV sizes.
+     *
+     * [1] https://www.openssl.org/docs/man1.1.1/man3/EVP_CIPHER_CTX_block_size.html
+     */
+    private static final int[] IV_LENGTHS = { 96, 8 };
     private static final int[] KEY_LENGTHS = { 128, 192, 256 };
     private static final int[] DATA_LENGTHS = { 0, 128, 1024 };
     private static final int[] AAD_LENGTHS = { 0, 128, 1024 };


### PR DESCRIPTION
Cherry pick https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/563 for the 0.32 release.

Signed-off-by: Jinhang Zhang <Jinhang.Zhang@ibm.com>