### PR TITLE
Remove references to non-existent packages

### DIFF
--- a/closed/make/CreateJars.gmk
+++ b/closed/make/CreateJars.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -86,8 +86,6 @@ EXPORTED_PRIVATE_PKGS += \
 	jdk.internal.org.objectweb.asm.util \
 	openj9.lang.management \
 	openj9.lang.management.internal \
-	openj9.internal.tools.attach.diagnostics.base \
-	openj9.tools.attach.diagnostics.info \
 	#
 
 RT_JAR_EXCLUDES += \


### PR DESCRIPTION
This fixes these warnings seen in builds (e.g. the [latest nightly build](https://openj9-jenkins.osuosl.org/job/Build_JDK8_x86-64_linux_Nightly/280/)):
```
00:59:51.403  warning: package openj9.internal.tools.attach.diagnostics.base does not exist
00:59:51.403  warning: package openj9.tools.attach.diagnostics.info does not exist
```
