### PR TITLE
Apply patch to freetype.vcxproj as necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 /openj9
 /openssl
 
+# ignore files produced when "--with-freetype-src=..." is used
+/freetype.bat
+/freetype.log
+
 /build/
 /dist/
 /.idea/

--- a/common/autoconf/generated-configure.sh
+++ b/common/autoconf/generated-configure.sh
@@ -4051,7 +4051,7 @@ fi
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
 # ===========================================================================
 
 
@@ -4447,7 +4447,7 @@ VS_TOOLSET_SUPPORTED_2019=false
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1655751341
+DATE_WHEN_GENERATED=1656101123
 
 ###############################################################################
 #
@@ -44818,6 +44818,25 @@ $as_echo "$as_me: WARNING: Can't find an msbuild.exe executable (you may try to 
 
   # Ready to go..
   if test "x$BUILD_FREETYPE" = xyes; then
+
+    eval toolchain_name="\${VS_DESCRIPTION_$TOOLCHAIN_VERSION}"
+    vcxproj_patch="$SRC_ROOT/.github/workflows/freetype.vcxproj"
+    if test "$TOOLCHAIN_VERSION" -lt 2017 ; then
+      # The project file only needs to be patched for Visual Studio 2017 or newer.
+      { $as_echo "$as_me:${as_lineno-$LINENO}: Not patching $vcxproj_path for $toolchain_name" >&5
+$as_echo "$as_me: Not patching $vcxproj_path for $toolchain_name" >&6;}
+    elif $CMP -s "$vcxproj_path" "$vcxproj_patch" ; then
+      # The file has the desired content - perhaps it was already patched?
+      { $as_echo "$as_me:${as_lineno-$LINENO}: No need to patch $vcxproj_path for $toolchain_name" >&5
+$as_echo "$as_me: No need to patch $vcxproj_path for $toolchain_name" >&6;}
+    elif $RM -f "$vcxproj_path" && $CP "$vcxproj_patch" "$vcxproj_path" ; then
+      { $as_echo "$as_me:${as_lineno-$LINENO}: Patched $vcxproj_path for $toolchain_name" >&5
+$as_echo "$as_me: Patched $vcxproj_path for $toolchain_name" >&6;}
+    else
+      # The file may not be writable, so offer a warning.
+      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Unable to patch $vcxproj_path for $toolchain_name; build may fail" >&5
+$as_echo "$as_me: WARNING: Unable to patch $vcxproj_path for $toolchain_name; build may fail" >&2;}
+    fi
 
     # msbuild requires trailing slashes for output directories
     freetype_lib_path="$FREETYPE_SRC_PATH/lib$OPENJDK_TARGET_CPU_BITS/"

--- a/common/autoconf/libraries.m4
+++ b/common/autoconf/libraries.m4
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
 # ===========================================================================
 
 AC_DEFUN_ONCE([LIB_SETUP_INIT],
@@ -281,6 +281,21 @@ AC_DEFUN([LIB_BUILD_FREETYPE],
 
   # Ready to go..
   if test "x$BUILD_FREETYPE" = xyes; then
+
+    eval toolchain_name="\${VS_DESCRIPTION_$TOOLCHAIN_VERSION}"
+    vcxproj_patch="$SRC_ROOT/.github/workflows/freetype.vcxproj"
+    if test "$TOOLCHAIN_VERSION" -lt 2017 ; then
+      # The project file only needs to be patched for Visual Studio 2017 or newer.
+      AC_MSG_NOTICE([Not patching $vcxproj_path for $toolchain_name])
+    elif $CMP -s "$vcxproj_path" "$vcxproj_patch" ; then
+      # The file has the desired content - perhaps it was already patched?
+      AC_MSG_NOTICE([No need to patch $vcxproj_path for $toolchain_name])
+    elif $RM -f "$vcxproj_path" && $CP "$vcxproj_patch" "$vcxproj_path" ; then
+      AC_MSG_NOTICE([Patched $vcxproj_path for $toolchain_name])
+    else
+      # The file may not be writable, so offer a warning.
+      AC_MSG_WARN([Unable to patch $vcxproj_path for $toolchain_name; build may fail])
+    fi
 
     # msbuild requires trailing slashes for output directories
     freetype_lib_path="$FREETYPE_SRC_PATH/lib$OPENJDK_TARGET_CPU_BITS/"

--- a/jdk/make/closed/autoconf/generated-configure.sh
+++ b/jdk/make/closed/autoconf/generated-configure.sh
@@ -4157,7 +4157,7 @@ fi
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2021, 2022 All Rights Reserved
 # ===========================================================================
 
 
@@ -4618,7 +4618,7 @@ VS_TOOLSET_SUPPORTED_2019=false
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1655751341
+DATE_WHEN_GENERATED=1656101123
 
 ###############################################################################
 #
@@ -47830,6 +47830,25 @@ $as_echo "$as_me: WARNING: Can't find an msbuild.exe executable (you may try to 
 
   # Ready to go..
   if test "x$BUILD_FREETYPE" = xyes; then
+
+    eval toolchain_name="\${VS_DESCRIPTION_$TOOLCHAIN_VERSION}"
+    vcxproj_patch="$SRC_ROOT/.github/workflows/freetype.vcxproj"
+    if test "$TOOLCHAIN_VERSION" -lt 2017 ; then
+      # The project file only needs to be patched for Visual Studio 2017 or newer.
+      { $as_echo "$as_me:${as_lineno-$LINENO}: Not patching $vcxproj_path for $toolchain_name" >&5
+$as_echo "$as_me: Not patching $vcxproj_path for $toolchain_name" >&6;}
+    elif $CMP -s "$vcxproj_path" "$vcxproj_patch" ; then
+      # The file has the desired content - perhaps it was already patched?
+      { $as_echo "$as_me:${as_lineno-$LINENO}: No need to patch $vcxproj_path for $toolchain_name" >&5
+$as_echo "$as_me: No need to patch $vcxproj_path for $toolchain_name" >&6;}
+    elif $RM -f "$vcxproj_path" && $CP "$vcxproj_patch" "$vcxproj_path" ; then
+      { $as_echo "$as_me:${as_lineno-$LINENO}: Patched $vcxproj_path for $toolchain_name" >&5
+$as_echo "$as_me: Patched $vcxproj_path for $toolchain_name" >&6;}
+    else
+      # The file may not be writable, so offer a warning.
+      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Unable to patch $vcxproj_path for $toolchain_name; build may fail" >&5
+$as_echo "$as_me: WARNING: Unable to patch $vcxproj_path for $toolchain_name; build may fail" >&2;}
+    fi
 
     # msbuild requires trailing slashes for output directories
     freetype_lib_path="$FREETYPE_SRC_PATH/lib$OPENJDK_TARGET_CPU_BITS/"


### PR DESCRIPTION
Update `freetype.vcxproj` from the patch introduced in 16620b953a4d1e4ca91b795b44fe6e44201e4708 when configure option `--with-freetype-src` is used with VS toolchain version 2017 or newer.

Ignore files produced when `--with-freetype-src` is used.


