### PR TITLE
JDK8: Backport 8240226 from JDK17 to fix DeflateIn_InflateOut.skipBytes

### DIFF
--- a/jdk/test/java/util/zip/DeflateIn_InflateOut.java
+++ b/jdk/test/java/util/zip/DeflateIn_InflateOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,6 @@ public class DeflateIn_InflateOut {
     private static InflaterOutputStream ios;
 
     private static void reset() {
-        new Random(new Date().getTime()).nextBytes(data);
-
         bais = new ByteArrayInputStream(data);
         dis = new DeflaterInputStream(bais);
 
@@ -218,6 +216,8 @@ public class DeflateIn_InflateOut {
 
 
     public static void realMain(String[] args) throws Throwable {
+        new Random(new Date().getTime()).nextBytes(data);
+
         ArrayReadWrite();
 
         ArrayReadByteWrite();


### PR DESCRIPTION
java/util/zip/DeflateIn_InflateOut.skipBytes verifies functionality of DeflaterInputStream.skipBytes. While testing skipping of bytes, test uses different input data with same data length, and compares the compressed sizes of these data to verify skipping bytes. As per zlib specification which is what is used by Deflater in java, length of compressed data is highly dependable on input data contents, so it will be incorrect to assume that compression ratio would be constant for same length input data. For more details please see explaination in https://github.com/eclipse-openj9/openj9/issues/14948#issuecomment-1194616794.

Signed-off-by: Rahil Shah <rahil@ca.ibm.com>