### PR TITLE
Fix the PKCS11Exception: CKR_KEY_TYPE_INCONSISTENT in FIPS mode

### DIFF
--- a/closed/adds/jdk/src/share/lib/security/nss.fips.cfg
+++ b/closed/adds/jdk/src/share/lib/security/nss.fips.cfg
@@ -23,3 +23,5 @@ nssLibraryDirectory = /usr/lib64
 nssSecmodDirectory = /etc/pki/nssdb
 nssDbMode = readOnly
 nssModule = fips
+
+attributes(*,CKO_SECRET_KEY,CKK_GENERIC_SECRET)={ CKA_SIGN=true }


### PR DESCRIPTION
Refer to [Redhat-2007331](https://bugzilla.redhat.com/show_bug.cgi?id=2007331). Add a CKA_SIGN attribute to a key that is generated by the MAC service initialization in the FIPS mode.

Signed-off-by: Jinhang Zhang <Jinhang.Zhang@ibm.com>