### PR TITLE
Use the OpenSSL PKCS12 method for PBE and simplify NativeCrypto property checking

### DIFF
--- a/closed/adds/jdk/src/share/classes/sun/security/ec/NativeECDHKeyAgreement.java
+++ b/closed/adds/jdk/src/share/classes/sun/security/ec/NativeECDHKeyAgreement.java
@@ -55,7 +55,6 @@ import javax.crypto.spec.SecretKeySpec;
 
 import jdk.crypto.jniprovider.NativeCrypto;
 
-import sun.security.action.GetPropertyAction;
 import sun.security.util.NamedCurve;
 
 /**
@@ -64,7 +63,7 @@ import sun.security.util.NamedCurve;
 public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
 
     private static final NativeCrypto nativeCrypto = NativeCrypto.getNativeCrypto();
-    private static final String nativeCryptTrace = GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace");
+    private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
 
     /* false if OPENSSL_NO_EC2M is defined, true otherwise */
     private static final boolean nativeGF2m = nativeCrypto.ECNativeGF2m();
@@ -123,7 +122,7 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
 
             if ((!nativeGF2m) && this.privateKey.isECFieldF2m()) {
                 /* only print the first time a curve is used */
-                if ((curveSupported.putIfAbsent("EC2m", Boolean.FALSE) == null) && (nativeCryptTrace != null)) {
+                if ((curveSupported.putIfAbsent("EC2m", Boolean.FALSE) == null) && nativeCryptTrace) {
                     System.err.println("EC2m is not supported by OpenSSL, using Java crypto implementation.");
                 }
                 this.initializeJavaImplementation(key, random);
@@ -133,7 +132,7 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
                 this.javaImplementation = null;
             }
         } else {
-            if ((curveSupported.putIfAbsent("ECKeyImpl", Boolean.FALSE) == null) && (nativeCryptTrace != null)) {
+            if ((curveSupported.putIfAbsent("ECKeyImpl", Boolean.FALSE) == null) && nativeCryptTrace) {
                 System.err.println("Only ECPrivateKeyImpl and ECPublicKeyImpl are supported by the native implementation,"
                         + " using Java crypto implementation.");
             }
@@ -181,7 +180,7 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
 
             return null;
         } else {
-            if ((curveSupported.putIfAbsent("ECKeyImpl", Boolean.FALSE) == null) && (nativeCryptTrace != null)) {
+            if ((curveSupported.putIfAbsent("ECKeyImpl", Boolean.FALSE) == null) && nativeCryptTrace) {
                 System.err.println("Only ECPrivateKeyImpl and ECPublicKeyImpl are supported by the native implementation,"
                         + " using Java crypto implementation.");
             }
@@ -225,7 +224,7 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
             if (curveSupported.putIfAbsent(this.curve, Boolean.FALSE) != null) {
                 throw new ProviderException("Could not convert keys to native format");
             }
-            if (nativeCryptTrace != null) {
+            if (nativeCryptTrace) {
                 System.err.println(this.curve + " is not supported by OpenSSL, using Java crypto implementation.");
             }
             try {
@@ -237,7 +236,7 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
             }
             return this.javaImplementation.engineGenerateSecret(sharedSecret, offset);
         }
-        if ((curveSupported.putIfAbsent(this.curve, Boolean.TRUE) == null) && (nativeCryptTrace != null)) {
+        if ((curveSupported.putIfAbsent(this.curve, Boolean.TRUE) == null) && nativeCryptTrace) {
             System.err.println(this.curve + " is supported by OpenSSL, using native crypto implementation.");
         }
         int ret;

--- a/closed/adds/jdk/src/share/classes/sun/security/provider/NativeSHA.java
+++ b/closed/adds/jdk/src/share/classes/sun/security/provider/NativeSHA.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,14 @@
 
 package sun.security.provider;
 
+import jdk.crypto.jniprovider.NativeCrypto;
+
 public final class NativeSHA extends NativeDigest {
 
     /**
      * Creates a new native SHA object.
      */
     public NativeSHA() {
-        super("SHA-1", 20, 0);
+        super("SHA-1", 20, NativeCrypto.SHA1_160);
     }
 }

--- a/closed/adds/jdk/src/share/classes/sun/security/provider/NativeSHA2.java
+++ b/closed/adds/jdk/src/share/classes/sun/security/provider/NativeSHA2.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
 
 package sun.security.provider;
 
+import jdk.crypto.jniprovider.NativeCrypto;
+
 abstract class NativeSHA2 {
 
     /**
@@ -32,7 +34,7 @@ abstract class NativeSHA2 {
     public static final class SHA224 extends NativeDigest {
 
         public SHA224() {
-            super("SHA-224", 28, 2);
+            super("SHA-224", 28, NativeCrypto.SHA2_224);
         }
     }
 
@@ -42,7 +44,7 @@ abstract class NativeSHA2 {
     public static final class SHA256 extends NativeDigest {
 
         public SHA256() {
-            super("SHA-256", 32, 1);
+            super("SHA-256", 32, NativeCrypto.SHA2_256);
         }
     }
 }

--- a/closed/adds/jdk/src/share/classes/sun/security/provider/NativeSHA5.java
+++ b/closed/adds/jdk/src/share/classes/sun/security/provider/NativeSHA5.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
 
 package sun.security.provider;
 
+import jdk.crypto.jniprovider.NativeCrypto;
+
 abstract class NativeSHA5 {
 
     /**
@@ -32,7 +34,7 @@ abstract class NativeSHA5 {
     public static final class SHA512 extends NativeDigest {
 
         public SHA512() {
-            super("SHA-512", 64, 4);
+            super("SHA-512", 64, NativeCrypto.SHA5_512);
         }
     }
 
@@ -42,7 +44,7 @@ abstract class NativeSHA5 {
     public static final class SHA384 extends NativeDigest {
 
         public SHA384() {
-            super("SHA-384", 48, 3);
+            super("SHA-384", 48, NativeCrypto.SHA5_384);
         }
     }
 }

--- a/closed/make/mapfiles/libjncrypto/mapfile-vers
+++ b/closed/make/mapfiles/libjncrypto/mapfile-vers
@@ -48,6 +48,7 @@ SUNWprivate_1.1 {
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECDestroyKey;
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECDeriveKey;
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECNativeGF2m;
+		Java_jdk_crypto_jniprovider_NativeCrypto_PBEDerive;
 	local:
 		*;
 };

--- a/jdk/src/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/jdk/src/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -63,22 +63,12 @@ import java.security.PrivilegedAction;
 
 final class CipherCore {
 
-    /*
-     * Check whether native crypto is disabled with property.
-     *
-     * By default, the native crypto is enabled and uses the native
-     * crypto library implementation.
-     *
-     * The property 'jdk.nativeCBC' is used to disable Native CBC alone,
-     * 'jdk.nativeGCM' is used to disable Native GCM alone and
-     * 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
-     * CBC, GCM, RSA, and EC).
+    /* The property 'jdk.nativeCBC' is used to control enablement of the native
+     * CBC implementation and 'jdk.nativeGCM' is used to control enablement of
+     * the native GCM implementation.
      */
-    private static boolean useNativeCrypto;
-
-    private static boolean useNativeCBC;
-
-    private static boolean useNativeGCM;
+    private static final boolean useNativeCBC = NativeCrypto.isAlgorithmEnabled("jdk.nativeCBC", "CipherCore (CBC)");
+    private static final boolean useNativeGCM = NativeCrypto.isAlgorithmEnabled("jdk.nativeGCM", "CipherCore (GCM)");
 
     /*
      * internal buffer
@@ -1279,56 +1269,5 @@ final class CipherCore {
     void updateAAD(byte[] src, int offset, int len) {
         checkReinit();
         cipher.updateAAD(src, offset, len);
-    }
-
-    private static String privilegedGetProperty(final String property) {
-        return AccessController.doPrivileged(new PrivilegedAction<String>() {
-            public String run() {
-                return System.getProperty(property);
-            }
-        });
-    }
-
-    static {
-        String nativeCryptTrace = privilegedGetProperty("jdk.nativeCryptoTrace");
-        String nativeCryptStr   = privilegedGetProperty("jdk.nativeCrypto");
-        String nativeCBCStr     = privilegedGetProperty("jdk.nativeCBC");
-        String nativeGCMStr     = privilegedGetProperty("jdk.nativeGCM");
-
-        useNativeCrypto = (nativeCryptStr == null) || Boolean.parseBoolean(nativeCryptStr);
-
-        if (!useNativeCrypto) {
-            useNativeCBC = false;
-            useNativeGCM = false;
-        } else {
-            useNativeCBC = (nativeCBCStr == null) || Boolean.parseBoolean(nativeCBCStr);
-            useNativeGCM = (nativeGCMStr == null) || Boolean.parseBoolean(nativeGCMStr);
-        }
-
-        if (useNativeCBC || useNativeGCM) {
-            /*
-             * User want to use native crypto implementation.
-             * Make sure the native crypto libraries are loaded successfully.
-             * Otherwise, throw a warning message and fall back to the in-built
-             * java crypto implementation.
-             */
-            if (!NativeCrypto.isLoaded()) {
-                useNativeCBC = false;
-                useNativeGCM = false;
-
-                if (nativeCryptTrace != null) {
-                    System.err.println("Warning: Native crypto library load failed." +
-                            " Using Java crypto implementation");
-                }
-            } else {
-                if (nativeCryptTrace != null) {
-                    System.err.println("CipherCore Load - using native crypto library.");
-                }
-            }
-        } else {
-            if (nativeCryptTrace != null) {
-                System.err.println("CipherCore Load - native crypto library disabled.");
-            }
-        }
     }
 }

--- a/jdk/src/share/classes/com/sun/crypto/provider/PKCS12PBECipherCore.java
+++ b/jdk/src/share/classes/com/sun/crypto/provider/PKCS12PBECipherCore.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * ===========================================================================
+ */
 
 package com.sun.crypto.provider;
 
@@ -31,6 +36,7 @@ import java.security.spec.*;
 import java.util.Arrays;
 import javax.crypto.*;
 import javax.crypto.spec.*;
+import jdk.crypto.jniprovider.NativeCrypto;
 
 /**
  * This class implements password-base encryption algorithm with
@@ -57,6 +63,12 @@ final class PKCS12PBECipherCore {
 
     private static final int DEFAULT_SALT_LENGTH = 20;
     private static final int DEFAULT_COUNT = 1024;
+    private static final NativeCrypto nativeCrypto = NativeCrypto.getNativeCrypto();
+    private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
+    /* The property 'jdk.nativePBE' is used to control enablement of the native
+     * PBE implementation.
+     */
+    private static final boolean useNativePBE = NativeCrypto.isAlgorithmEnabled("jdk.nativePBE", "PKCS12PBECipherCore");
 
     static final int CIPHER_KEY = 1;
     static final int CIPHER_IV = 2;
@@ -88,6 +100,33 @@ final class PKCS12PBECipherCore {
             passwd[j+1] = (byte) (chars[i] & 0xFF);
         }
         byte[] key = new byte[n];
+
+        if (useNativePBE) {
+            boolean hashSupported = true;
+            int hashIndex = 0;
+            if (hashAlgo.equals("SHA") || hashAlgo.equals("SHA1") || hashAlgo.equals("SHA-1")) {
+                hashIndex = NativeCrypto.SHA1_160;
+            } else if (hashAlgo.equals("SHA224") || hashAlgo.equals("SHA-224")) {
+                hashIndex = NativeCrypto.SHA2_224;
+            } else if (hashAlgo.equals("SHA256") || hashAlgo.equals("SHA-256")) {
+                hashIndex = NativeCrypto.SHA2_256;
+            } else if (hashAlgo.equals("SHA384") || hashAlgo.equals("SHA-384")) {
+                hashIndex = NativeCrypto.SHA5_384;
+            } else if (hashAlgo.equals("SHA512") || hashAlgo.equals("SHA-512")) {
+                hashIndex = NativeCrypto.SHA5_512;
+            } else {
+                hashSupported = false;
+            }
+            if (hashSupported) {
+                if (nativeCrypto.PBEDerive(passwd, passwd.length, salt, salt.length, key, ic, n, type, hashIndex) != -1) {
+                    return key;
+                } else if (nativeCryptTrace) {
+                    System.err.println("Native PBE derive failed for algorithm " + hashAlgo + ", using Java implementation.");
+                }
+            } else if (nativeCryptTrace) {
+                System.err.println("The algorithm " + hashAlgo + " is not supported in native code, using Java implementation.");
+            }
+        }
 
         try {
             MessageDigest sha = MessageDigest.getInstance(hashAlgo);

--- a/jdk/src/share/classes/sun/security/ec/SunECEntries.java
+++ b/jdk/src/share/classes/sun/security/ec/SunECEntries.java
@@ -38,7 +38,6 @@ import java.util.regex.Pattern;
 import sun.security.util.CurveDB;
 import sun.security.util.NamedCurve;
 
-import sun.security.action.GetPropertyAction;
 import jdk.crypto.jniprovider.NativeCrypto;
 
 /**
@@ -48,19 +47,10 @@ import jdk.crypto.jniprovider.NativeCrypto;
  */
 final class SunECEntries {
 
-    /*
-     * Check whether native crypto is disabled with property.
-     *
-     * By default, the native crypto is enabled and uses the native
-     * crypto library implementation.
-     *
-     * The property 'jdk.nativeEC' is used to disable Native EC alone and
-     * 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
-     * CBC, GCM, RSA, and EC).
+    /* The property 'jdk.nativeEC' is used to control enablement of the native
+     * EC implementation.
      */
-    private static boolean useNativeCrypto;
-
-    private static boolean useNativeEC;
+    private static final boolean useNativeEC = NativeCrypto.isAlgorithmEnabled("jdk.nativeEC", "SunEC");
 
     private SunECEntries() {
         // empty
@@ -194,44 +184,5 @@ final class SunECEntries {
         map.put("KeyAgreement.ECDH SupportedKeyClasses", ecKeyClasses);
 
         map.put("KeyAgreement.ECDH ImplementedIn", "Software");
-    }
-
-    static {
-        String nativeCryptTrace = GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace");
-        String nativeCryptStr   = GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto");
-        String nativeECStr      = GetPropertyAction.privilegedGetProperty("jdk.nativeEC");
-
-        useNativeCrypto = (nativeCryptStr == null) || Boolean.parseBoolean(nativeCryptStr);
-
-        if (!useNativeCrypto) {
-            useNativeEC = false;
-        } else {
-            useNativeEC = (nativeECStr == null) || Boolean.parseBoolean(nativeECStr);
-        }
-
-        if (useNativeEC) {
-            /*
-             * User want to use native crypto implementation.
-             * Make sure the native crypto libraries are loaded successfully.
-             * Otherwise, throw a warning message and fall back to the in-built
-             * java crypto implementation.
-             */
-            if (!NativeCrypto.isLoaded()) {
-                useNativeEC = false;
-
-                if (nativeCryptTrace != null) {
-                    System.err.println("Warning: Native crypto library load failed." +
-                            " Using Java crypto implementation");
-                }
-            } else {
-                if (nativeCryptTrace != null) {
-                    System.err.println("SunECEntries Load - using native crypto library.");
-                }
-            }
-        } else {
-            if (nativeCryptTrace != null) {
-                System.err.println("SunECEntries Load - native crypto library disabled.");
-            }
-        }
     }
 }

--- a/jdk/src/share/classes/sun/security/provider/SunEntries.java
+++ b/jdk/src/share/classes/sun/security/provider/SunEntries.java
@@ -92,17 +92,10 @@ final class SunEntries {
         Boolean.parseBoolean(GetPropertyAction.privilegedGetProperty
             ("jdk.security.legacyDSAKeyPairGenerator"));
 
-    /*
-     * Check whether native crypto is enabled with property.
-     *
-     * By default, the native crypto is enabled and uses the native
-     * crypto library implementation.
-     *
-     * The property 'jdk.nativeDigest' is used to disable Native digest alone
-     * and 'jdk.nativeCrypto' is used to disable all native cryptos (Digest,
-     * CBC, GCM, RSA, and EC).
+    /* The property 'jdk.nativeDigest' is used to control enablement of the native
+     * digest implementation.
      */
-    private static boolean useNativeDigest = true;
+    private static final boolean useNativeDigest = NativeCrypto.isAlgorithmEnabled("jdk.nativeDigest", "MessageDigest");
 
     private SunEntries() {
         // empty
@@ -434,48 +427,6 @@ final class SunEntries {
              * We can try using the URL path.
              */
             return new File(device.getPath());
-        }
-    }
-
-    static {
-
-        String nativeCryptTrace = GetPropertyAction.privilegedGetProperty("jdk.nativeCryptoTrace");
-        String nativeCryptStr = GetPropertyAction.privilegedGetProperty("jdk.nativeCrypto");
-        String nativeDigestStr = GetPropertyAction.privilegedGetProperty("jdk.nativeDigest");
-
-        if (Boolean.parseBoolean(nativeCryptStr) || nativeCryptStr == null) {
-                /* nativeCrypto is enabled */
-                if (!(Boolean.parseBoolean(nativeDigestStr) || nativeDigestStr == null)) {
-                        useNativeDigest = false;
-                }
-        } else {
-                /* nativeCrypto is disabled */
-                useNativeDigest = false;
-        }
-
-        if (useNativeDigest) {
-            /*
-             * User want to use native crypto implementation.
-             * Make sure the native crypto libraries are loaded successfully.
-             * Otherwise, throw a warning message and fall back to the in-built
-             * java crypto implementation.
-             */
-            if (!NativeCrypto.isLoaded()) {
-                useNativeDigest = false;
-
-                if (nativeCryptTrace != null) {
-                   System.err.println("Warning: Native crypto library load failed." +
-                                   " Using Java crypto implementation");
-                }
-            } else {
-                if (nativeCryptTrace != null) {
-                   System.err.println("MessageDigest load - using Native crypto library.");
-                }
-            }
-        } else {
-            if (nativeCryptTrace != null) {
-               System.err.println("MessageDigest load - Native crypto library disabled.");
-            }
         }
     }
 }


### PR DESCRIPTION
Porting PR [openj9-openjdk-jdk11#585](https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/585)

Signed-off-by: Zainab Fatmi <zainab@ibm.com>