### PR TITLE
Fail test-image-openj9 target when java -version fails

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -63,7 +63,7 @@ test-image : test-image-openj9
 test-image-openj9 : images
 	@+$(MAKE) $(MAKE_ARGS) -f $(SRC_ROOT)/closed/TestImage.gmk
 ifneq ($(COMPILE_TYPE), cross)
-	$(JRE_IMAGE_DIR)/bin/java -version 2>&1 | $(TEE) $(IMAGES_OUTPUTDIR)/test/openj9/java-version.txt
+	rc=0; $(JRE_IMAGE_DIR)/bin/java -version >$(IMAGES_OUTPUTDIR)/test/openj9/java-version.txt 2>&1 || rc="$$?"; $(CAT) $(IMAGES_OUTPUTDIR)/test/openj9/java-version.txt; exit "$$rc"
 endif
 
 clean-docs : clean-openj9-only-docs


### PR DESCRIPTION
Previously, the exit status would come from `tee`, which succeeded.