### PR TITLE
Merge openj9 to 0.36.0

### DIFF
--- a/closed/openjdk-tag.gmk
+++ b/closed/openjdk-tag.gmk
@@ -1,1 +1,1 @@
-OPENJDK_TAG := jdk8u362-b06
+OPENJDK_TAG := jdk8u362-b07


### PR DESCRIPTION
To include https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/642.