### PR TITLE
OpenJ9 doesn't support Perf, don't try to use it

### DIFF
--- a/jdk/src/share/classes/sun/tools/jconsole/LocalVirtualMachine.java
+++ b/jdk/src/share/classes/sun/tools/jconsole/LocalVirtualMachine.java
@@ -141,16 +141,6 @@ public class LocalVirtualMachine {
                 String name = vmid.toString(); // default to pid if name not available
                 boolean attachable = false;
                 String address = null;
-                try {
-                     MonitoredVm mvm = host.getMonitoredVm(new VmIdentifier(name));
-                     // use the command line as the display name
-                     name =  MonitoredVmUtil.commandLine(mvm);
-                     attachable = MonitoredVmUtil.isAttachable(mvm);
-                     address = ConnectorAddressLink.importFrom(pid);
-                     mvm.detach();
-                } catch (Exception x) {
-                     // ignore
-                }
                 map.put((Integer) vmid,
                         new LocalVirtualMachine(pid, name, attachable, address));
             }


### PR DESCRIPTION
Trying to use sun.misc.Perf may result in an Assertion "Java_sun_misc_Perf_attach unimplemented" or similar. Calling sun.tools.jconsole.LocalVirtualMachine.getAllVirtualMachines() tries to use Perf.

Issue https://github.com/eclipse-openj9/openj9/issues/16719