### PR TITLE
Recognize OpenJ9 flags in openjdk jcl natives

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -99,6 +99,7 @@ endif
 	build-j9vm \
 	generate-j9jcl-sources \
 	generate-j9-version-headers \
+	openj9-config-headers \
 	run-preprocessors-j9 \
 	stage-j9 \
 	#
@@ -120,6 +121,23 @@ define openj9_copy_tree_impl
 		| $(TAR) --extract --directory=$1 -m
 	@$(TOUCH) $1/$(OPENJ9_MARKER_FILE)
 endef
+
+ifeq (true,$(OPENJ9_ENABLE_CMAKE))
+  CONFIG_HEADERS := j9cfg.h omr/omrcfg.h
+else
+  CONFIG_HEADERS := include/j9cfg.h omr/include_core/omrcfg.h
+endif
+
+define openj9_config_header_rules
+  openj9-config-headers : $(JDK_OUTPUTDIR)/openj9_include/$(notdir $1)
+
+  $(JDK_OUTPUTDIR)/openj9_include/$(notdir $1) : $1
+	$$(call install-file)
+endef
+
+$(foreach file, \
+	$(CONFIG_HEADERS), \
+	$(eval $(call openj9_config_header_rules, $(OPENJ9_VM_BUILD_DIR)/$(file))))
 
 # Comments for stage-j9
 # Currently there is a staged location where j9 is built.  This is due to a number of reasons:

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -48,6 +48,7 @@ build-j9vm : start-make
 	@+$(MAKE) $(MAKE_ARGS) -f $(SRC_ROOT)/closed/openssl.gmk
   endif # BUILD_OPENSSL
 	@+$(MAKE) $(MAKE_ARGS) -f $(SRC_ROOT)/closed/OpenJ9.gmk build-j9vm
+	@+$(MAKE) $(MAKE_ARGS) -f $(SRC_ROOT)/closed/OpenJ9.gmk openj9-config-headers
 	@+$(MAKE) $(MAKE_ARGS) -f $(SRC_ROOT)/closed/CopyToBuildJdk.gmk
 
 all : debug-image

--- a/jdk/make/closed/autoconf/custom-spec.gmk.in
+++ b/jdk/make/closed/autoconf/custom-spec.gmk.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -133,5 +133,10 @@ ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 else
   OPENJ9_VM_BUILD_DIR = $(OUTPUT_ROOT)/vm
 endif
+
+# Enable use of j9cfg.h in openjdk native code.
+$(foreach var, \
+	CFLAGS_JDKEXE CFLAGS_JDKLIB CXXFLAGS_JDKEXE CXXFLAGS_JDKLIB, \
+	$(eval $(var) += -I$(JDK_OUTPUTDIR)/openj9_include))
 
 J9JCL_SOURCES_DIR := $(JDK_OUTPUTDIR)/j9jcl


### PR DESCRIPTION
Recognize `OpenJ9` flags in `openjdk` `jcl` natives

Created `openj9_config_header_rules` and `target openj9-config-headers` which is invoked after `build-j9`, and copy `j9cfg.h` & `omrcfg.h` into `$(SUPPORT_OUTPUTDIR)/openj9_include`;
Added `-I$(SUPPORT_OUTPUTDIR)/openj9_include` for OpenJDK natives.


Backporting
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/592
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/596

Signed-off-by: Jason Feng <fengj@ca.ibm.com>