### PR TITLE
Remove useless patterns from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,31 @@
-/.project
-/build
+# ===========================================================================
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+#
+# exclude all source directories
 /omr
 /openj9
 /openssl
+# exclude optional eclipse project file
+/.project
 
-# ignore files produced when "--with-freetype-src=..." is used
-/freetype.bat
-/freetype.log
-
+# openjdk gitignore
 /build/
 /dist/
 /.idea/


### PR DESCRIPTION
* configure option `--with-freetype-src` has been removed, so `freetype.bat` and `freetype.log` should not be created

See also https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/654.