### PR TITLE
Show macro definitions generated in openj9_version_info.h

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -296,6 +296,9 @@ generate-j9-version-headers :
 	$(call create_or_update, \
 		@$(SED) $(OPENJ9_VERSION_SCRIPT) < $(SRC_ROOT)/closed/openj9_version_info.h.in, \
 		$(OPENJ9_VM_BUILD_DIR)/include/openj9_version_info.h)
+	@$(ECHO) "==== openj9_version_info.h ===="
+	@$(GREP) define $(OPENJ9_VM_BUILD_DIR)/include/openj9_version_info.h
+	@$(ECHO) "===="
 
 ifeq (true,$(OPENJ9_ENABLE_CMAKE))
 CMAKE_ARGS := \


### PR DESCRIPTION
This is a back-port of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/602.