### PR TITLE
Add support for EC key generation using native OpenSSL library and restructure ECDH key agreement

### DIFF
--- a/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -44,6 +44,10 @@ public class NativeCrypto {
     public static final int SHA5_384 = 3;
     public static final int SHA5_512 = 4;
 
+    /* Define constants for the EC field types. */
+    public static final int ECField_Fp = 0;
+    public static final int ECField_F2m = 1;
+
     public static final long OPENSSL_VERSION_1_0_0 = 0x1_00_00_000L;
     public static final long OPENSSL_VERSION_1_1_0 = 0x1_01_00_000L;
     public static final long OPENSSL_VERSION_3_0_0 = 0x3_00_00_000L;
@@ -320,6 +324,15 @@ public class NativeCrypto {
                                   long RSAPublicKey);
 
     /* Native EC interfaces */
+    public final native int ECGenerateKeyPair(long key,
+                                              byte[] x,
+                                              int xLen,
+                                              byte[] y,
+                                              int yLen,
+                                              byte[] s,
+                                              int sLen,
+                                              int fieldType);
+
     public final native int ECCreatePublicKey(long key,
                                               byte[] x,
                                               int xLen,
@@ -331,35 +344,21 @@ public class NativeCrypto {
                                                byte[] s,
                                                int sLen);
 
-    public final native long ECEncodeGFp(byte[] a,
-                                         int aLen,
-                                         byte[] b,
-                                         int bLen,
-                                         byte[] p,
-                                         int pLen,
-                                         byte[] x,
-                                         int xLen,
-                                         byte[] y,
-                                         int yLen,
-                                         byte[] n,
-                                         int nLen,
-                                         byte[] h,
-                                         int hLen);
-
-    public final native long ECEncodeGF2m(byte[] a,
-                                          int aLen,
-                                          byte[] b,
-                                          int bLen,
-                                          byte[] p,
-                                          int pLen,
-                                          byte[] x,
-                                          int xLen,
-                                          byte[] y,
-                                          int yLen,
-                                          byte[] n,
-                                          int nLen,
-                                          byte[] h,
-                                          int hLen);
+    public final native long ECEncodeGF(int fieldType,
+                                        byte[] a,
+                                        int aLen,
+                                        byte[] b,
+                                        int bLen,
+                                        byte[] p,
+                                        int pLen,
+                                        byte[] x,
+                                        int xLen,
+                                        byte[] y,
+                                        int yLen,
+                                        byte[] n,
+                                        int nLen,
+                                        byte[] h,
+                                        int hLen);
 
     public final native int ECDestroyKey(long key);
 

--- a/closed/adds/jdk/src/share/classes/sun/security/ec/NativeECKeyPairGenerator.java
+++ b/closed/adds/jdk/src/share/classes/sun/security/ec/NativeECKeyPairGenerator.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+package sun.security.ec;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.AlgorithmParameters;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidParameterException;
+import java.security.KeyPair;
+import java.security.KeyPairGeneratorSpi;
+import java.security.PrivateKey;
+import java.security.ProviderException;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECField;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECFieldF2m;
+import java.security.spec.InvalidParameterSpecException;
+import java.util.Arrays;
+
+import jdk.crypto.jniprovider.NativeCrypto;
+
+import sun.security.ec.point.*;
+import sun.security.jca.JCAUtil;
+import sun.security.util.ECUtil;
+
+import static sun.security.ec.ECOperations.IntermediateValueException;
+import static sun.security.util.SecurityProviderConstants.DEF_EC_KEY_SIZE;
+
+/**
+ * Native EC keypair generator.
+ */
+public final class NativeECKeyPairGenerator extends KeyPairGeneratorSpi {
+
+    private static final int KEY_SIZE_MIN = 112;
+    private static final int KEY_SIZE_MAX = 571;
+
+    private static NativeCrypto nativeCrypto;
+    private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
+
+    /* used to seed the keypair generator */
+    private SecureRandom random;
+
+    /* size of the key to generate, KEY_SIZE_MIN <= keySize <= KEY_SIZE_MAX */
+    private int keySize;
+
+    /* parameters specified via init, if any */
+    private ECParameterSpec params;
+
+    /* the type of EC curve */
+    private String curve;
+
+    /* the java implementation, initialized if needed */
+    private ECKeyPairGenerator javaImplementation;
+
+    /**
+     * Constructs a new NativeECKeyPairGenerator.
+     */
+    public NativeECKeyPairGenerator() {
+        // initialize to default in case the app does not call initialize()
+        initialize(DEF_EC_KEY_SIZE, null);
+    }
+
+    @Override
+    public void initialize(int keySize, SecureRandom random) {
+        if (keySize < KEY_SIZE_MIN) {
+            throw new InvalidParameterException
+                ("Key size must be at least " + KEY_SIZE_MIN + " bits");
+        }
+        if (keySize > KEY_SIZE_MAX) {
+            throw new InvalidParameterException
+                ("Key size must be at most " + KEY_SIZE_MAX + " bits");
+        }
+        this.keySize = keySize;
+        this.params = ECUtil.getECParameterSpec(null, keySize);
+        if (this.params == null) {
+            throw new InvalidParameterException(
+                "No EC parameters available for key size " + keySize + " bits");
+        }
+        this.random = random;
+
+        this.curve = NativeECUtil.getCurveName(this.params);
+        if ((this.curve != null) && NativeECUtil.isCurveSupported(this.curve, this.params)) {
+            this.javaImplementation = null;
+        } else {
+            this.javaImplementation = new ECKeyPairGenerator();
+            this.javaImplementation.initialize(this.keySize, this.random);
+        }
+    }
+
+    @Override
+    public void initialize(AlgorithmParameterSpec params, SecureRandom random)
+            throws InvalidAlgorithmParameterException {
+        ECParameterSpec ecSpec = null;
+
+        if (params instanceof ECParameterSpec) {
+            ECParameterSpec ecParams = (ECParameterSpec) params;
+            ecSpec = ECUtil.getECParameterSpec(null, ecParams);
+            if (ecSpec == null) {
+                throw new InvalidAlgorithmParameterException(
+                    "Unsupported curve: " + params);
+            }
+        } else if (params instanceof ECGenParameterSpec) {
+            ECGenParameterSpec ecGenParams = (ECGenParameterSpec) params;
+            String name = ecGenParams.getName();
+            ecSpec = ECUtil.getECParameterSpec(null, name);
+            if (ecSpec == null) {
+                throw new InvalidAlgorithmParameterException(
+                    "Unknown curve name: " + name);
+            }
+        } else {
+            throw new InvalidAlgorithmParameterException(
+                "ECParameterSpec or ECGenParameterSpec required for EC");
+        }
+
+        // Not all known curves are supported by the native implementation
+        ECKeyPairGenerator.ensureCurveIsSupported(ecSpec);
+        this.params = ecSpec;
+
+        this.keySize = ecSpec.getCurve().getField().getFieldSize();
+        this.random = random;
+
+        this.curve = NativeECUtil.getCurveName(this.params);
+        if ((this.curve != null) && (NativeECUtil.isCurveSupported(this.curve, this.params))) {
+            this.javaImplementation = null;
+        } else {
+            this.initializeJavaImplementation();
+        }
+    }
+
+    @Override
+    public KeyPair generateKeyPair() {
+        if (this.javaImplementation != null) {
+            return this.javaImplementation.generateKeyPair();
+        }
+
+        boolean absent;
+        long nativePointer = NativeECUtil.encodeGroup(this.params);
+
+        if (nativePointer == -1) {
+            absent = NativeECUtil.putCurveIfAbsent(this.curve, Boolean.FALSE);
+            if (!absent) {
+                throw new ProviderException("Could not encode group");
+            }
+            if (nativeCryptTrace) {
+                System.err.println(this.curve +
+                        " is not supported by OpenSSL, using Java crypto implementation.");
+            }
+            try {
+                this.initializeJavaImplementation();
+            } catch (InvalidAlgorithmParameterException ex) {
+                throw new ProviderException(ex);
+            }
+            return this.javaImplementation.generateKeyPair();
+        }
+
+        int fieldType;
+        ECField field = params.getCurve().getField();
+        if (field instanceof ECFieldFp) {
+            fieldType = NativeCrypto.ECField_Fp;
+        } else if (field instanceof ECFieldF2m) {
+            fieldType = NativeCrypto.ECField_F2m;
+        } else {
+            absent = NativeECUtil.putCurveIfAbsent(this.curve, Boolean.FALSE);
+            if (!absent) {
+                throw new ProviderException("Field type not supported");
+            }
+            if (nativeCryptTrace) {
+                System.err.println(this.curve +
+                        " is not supported by OpenSSL, using Java crypto implementation.");
+            }
+            try {
+                this.initializeJavaImplementation();
+            } catch (InvalidAlgorithmParameterException ex) {
+                throw new ProviderException(ex);
+            }
+            return this.javaImplementation.generateKeyPair();
+        }
+        if (nativeCrypto == null) {
+            nativeCrypto = NativeCrypto.getNativeCrypto();
+        }
+
+        int coordinatesSize = (params.getCurve().getField().getFieldSize() + 7) >> 3;
+        byte[] x = new byte[coordinatesSize];
+        byte[] y = new byte[coordinatesSize];
+        byte[] s = new byte[coordinatesSize];
+
+        int ret = nativeCrypto.ECGenerateKeyPair(nativePointer,
+                                                 x, x.length,
+                                                 y, y.length,
+                                                 s, s.length,
+                                                 fieldType);
+
+        if (ret == -1) {
+            absent = NativeECUtil.putCurveIfAbsent(this.curve, Boolean.FALSE);
+            if (!absent) {
+                throw new ProviderException("Could not generate key pair");
+            }
+            if (nativeCryptTrace) {
+                System.err.println(this.curve +
+                        " is not supported by OpenSSL, using Java crypto implementation for key generation.");
+            }
+            try {
+                this.initializeJavaImplementation();
+            } catch (InvalidAlgorithmParameterException ex) {
+                throw new ProviderException(ex);
+            }
+            return this.javaImplementation.generateKeyPair();
+        }
+
+        BigInteger xBI = new BigInteger(1, x);
+        BigInteger yBI = new BigInteger(1, y);
+        BigInteger sBI = new BigInteger(1, s);
+        ECPoint w = new ECPoint(xBI, yBI);
+        PublicKey publicKey;
+        PrivateKey privateKey;
+        try {
+            publicKey = new ECPublicKeyImpl(w, this.params);
+        } catch (Exception ex) {
+            throw new ProviderException("Could not generate key pair. Error with data transformation.");
+        }
+        try {
+            privateKey = new ECPrivateKeyImpl(sBI, this.params);
+        } catch (Exception ex) {
+            throw new ProviderException("Could not generate key pair. Error with data transformation.");
+        }
+
+        return new KeyPair(publicKey, privateKey);
+    }
+
+    /**
+     * Initializes the java implementation.
+     */
+    private void initializeJavaImplementation() throws InvalidAlgorithmParameterException{
+        this.javaImplementation = new ECKeyPairGenerator();
+        this.javaImplementation.initialize(this.params, this.random);
+    }
+}

--- a/closed/adds/jdk/src/share/classes/sun/security/ec/NativeECUtil.java
+++ b/closed/adds/jdk/src/share/classes/sun/security/ec/NativeECUtil.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
+package sun.security.ec;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.math.BigInteger;
+import java.security.ProviderException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidParameterSpecException;
+import java.security.spec.ECPoint;
+import java.security.spec.EllipticCurve;
+import java.security.spec.ECField;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECFieldF2m;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECGenParameterSpec;
+import java.security.AlgorithmParameters;
+import sun.security.util.NamedCurve;
+
+import jdk.crypto.jniprovider.NativeCrypto;
+
+/**
+ * Utility methods for the native EC implementation.
+ */
+public final class NativeECUtil {
+
+    private static NativeCrypto nativeCrypto;
+    private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
+
+    /* false if OPENSSL_NO_EC2M is defined, true otherwise */
+    private static boolean nativeGF2m;
+
+    /* stores whether a curve is supported by OpenSSL (true) or not (false) */
+    private static final Map<String, Boolean> curveSupported = new ConcurrentHashMap<>();
+
+    private NativeECUtil() {}
+
+    /**
+     * Checks whether the given EC curve is supported by OpenSSL.
+     * @param curve the EC curve type
+     * @param params the parameters of the EC curve
+     * @return true if the curve is supported, false otherwise
+     */
+    static boolean isCurveSupported(String curve, ECParameterSpec params) {
+        if (nativeCrypto == null) {
+            nativeCrypto = NativeCrypto.getNativeCrypto();
+        }
+        nativeGF2m = nativeCrypto.ECNativeGF2m();
+        if ((!nativeGF2m) && (params.getCurve().getField() instanceof ECFieldF2m)) {
+            boolean absent = NativeECUtil.putCurveIfAbsent("EC2m", Boolean.FALSE);
+            if (absent && nativeCryptTrace) {
+                System.err.println("EC2m is not supported by OpenSSL, using Java crypto implementation.");
+            }
+            return false;
+        } else {
+            return curveSupported.getOrDefault(curve, Boolean.TRUE).booleanValue();
+        }
+    }
+
+    /**
+     * Records whether the specified EC curve is supported by OpenSSL or not,
+     * if the curve is not already associated with a value.
+     * @param curve the EC curve type
+     * @param supported true if the curve is supported by OpenSSL, false otherwise
+     * @return true on success (i.e. the curve was not associated with a value), false otherwise
+     */
+    static boolean putCurveIfAbsent(String curve, Boolean supported) {
+        return curveSupported.putIfAbsent(curve, supported) == null;
+    }
+
+    /**
+     * Returns the EC curve type.
+     * @param params the parameters of the EC curve
+     * @return the name or OID of the EC curve
+     */
+    static String getCurveName(ECParameterSpec params) {
+        String curveName;
+        if (params instanceof NamedCurve) {
+            NamedCurve namedCurve = (NamedCurve) params;
+            curveName = namedCurve.getName();
+        } else {
+            /* use the OID */
+            try {
+                AlgorithmParameters algParams = AlgorithmParameters.getInstance("EC");
+                algParams.init(params);
+                curveName = algParams.getParameterSpec(ECGenParameterSpec.class).getName();
+            } catch (InvalidParameterSpecException | NoSuchAlgorithmException e) {
+                curveName = null;
+            }
+        }
+        return curveName;
+    }
+
+    /**
+     * Returns the native EC public key context pointer.
+     * @param params the parameters of the EC curve
+     * @return the native EC key context pointer or -1 on error
+     */
+    static long encodeGroup(ECParameterSpec params) {
+        ECPoint generator = params.getGenerator();
+        EllipticCurve curve = params.getCurve();
+        ECField field = curve.getField();
+        byte[] a = curve.getA().toByteArray();
+        byte[] b = curve.getB().toByteArray();
+        byte[] gx = generator.getAffineX().toByteArray();
+        byte[] gy = generator.getAffineY().toByteArray();
+        byte[] n = params.getOrder().toByteArray();
+        byte[] h = BigInteger.valueOf(params.getCofactor()).toByteArray();
+        int fieldType;
+        byte[] p;
+        if (field instanceof ECFieldFp) {
+            ECFieldFp ecFieldFp = (ECFieldFp) field;
+            p = ecFieldFp.getP().toByteArray();
+            fieldType = NativeCrypto.ECField_Fp;
+        } else if (field instanceof ECFieldF2m) {
+            ECFieldF2m ecFieldF2m = (ECFieldF2m) field;
+            p = ecFieldF2m.getReductionPolynomial().toByteArray();
+            fieldType = NativeCrypto.ECField_F2m;
+        } else {
+            return -1;
+        }
+        if (nativeCrypto == null) {
+            nativeCrypto = NativeCrypto.getNativeCrypto();
+        }
+        return nativeCrypto.ECEncodeGF(fieldType,
+                                       a, a.length,
+                                       b, b.length,
+                                       p, p.length,
+                                       gx, gx.length,
+                                       gy, gy.length,
+                                       n, n.length,
+                                       h, h.length);
+    }
+}

--- a/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto.c
+++ b/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto.c
@@ -102,10 +102,15 @@ typedef int OSSL_RSA_set0_factors_t(RSA *, BIGNUM *, BIGNUM *);
 typedef void OSSL_RSA_free_t (RSA *);
 typedef int OSSL_RSA_public_decrypt_t(int, const unsigned char *, unsigned char *, RSA *, int);
 typedef int OSSL_RSA_private_encrypt_t (int, const unsigned char *, unsigned char *, RSA *, int);
-typedef BIGNUM* OSSL_BN_bin2bn_t (const unsigned char *, int, BIGNUM *);
+
+typedef BIGNUM *OSSL_BN_new_t();
+typedef BIGNUM *OSSL_BN_bin2bn_t (const unsigned char *, int, BIGNUM *);
 typedef void OSSL_BN_set_negative_t (BIGNUM *, int);
 typedef void OSSL_BN_free_t (BIGNUM *);
+typedef int OSSL_BN_bn2bin_t(const BIGNUM *, unsigned char *);
+typedef int OSSL_BN_num_bits_t(const BIGNUM *);
 
+typedef int OSSL_EC_KEY_generate_key_t(EC_KEY *);
 typedef void OSSL_EC_KEY_free_t(EC_KEY *);
 typedef int OSSL_ECDH_compute_key_t(void *, size_t, const EC_POINT *, EC_KEY *, void *(*KDF)(const void *, size_t, void *, size_t *));
 typedef const EC_POINT* OSSL_EC_KEY_get0_public_key_t(const EC_KEY *);
@@ -119,6 +124,8 @@ typedef int OSSL_EC_KEY_set_group_t(EC_KEY *, const EC_GROUP *);
 typedef EC_POINT* OSSL_EC_POINT_new_t(const EC_GROUP *);
 typedef int OSSL_EC_POINT_set_affine_coordinates_GFp_t(const EC_GROUP *, EC_POINT *, const BIGNUM *, const BIGNUM *, BN_CTX *);
 typedef int OSSL_EC_POINT_set_affine_coordinates_GF2m_t(const EC_GROUP *, EC_POINT *, const BIGNUM *, const BIGNUM *, BN_CTX *);
+typedef int OSSL_EC_POINT_get_affine_coordinates_GFp_t(const EC_GROUP *, const EC_POINT *, BIGNUM *, BIGNUM *, BN_CTX *);
+typedef int OSSL_EC_POINT_get_affine_coordinates_GF2m_t(const EC_GROUP *, const EC_POINT *, BIGNUM *, BIGNUM *, BN_CTX *);
 typedef int OSSL_EC_GROUP_set_generator_t(EC_GROUP *, const EC_POINT *, const BIGNUM *, const BIGNUM *);
 typedef const EC_GROUP* OSSL_EC_KEY_get0_group_t(const EC_KEY *);
 typedef void OSSL_EC_POINT_free_t(EC_POINT *);
@@ -127,6 +134,7 @@ typedef void OSSL_BN_CTX_free_t(BN_CTX *);
 typedef int OSSL_EC_KEY_set_public_key_t(EC_KEY *, const EC_POINT *);
 typedef int OSSL_EC_KEY_check_key_t(const EC_KEY *);
 typedef int EC_set_public_key_t(EC_KEY *, BIGNUM *, BIGNUM *, int);
+typedef const BIGNUM *OSSL_EC_KEY_get0_private_key_t(const EC_KEY *);
 
 typedef int OSSL_PKCS12_key_gen_t(const char *, int, unsigned char *, int, int, int, int, unsigned char *, const EVP_MD *);
 
@@ -200,11 +208,17 @@ OSSL_RSA_set0_key_t* OSSL_RSA_set0_crt_params;
 OSSL_RSA_free_t* OSSL_RSA_free;
 OSSL_RSA_public_decrypt_t* OSSL_RSA_public_decrypt;
 OSSL_RSA_private_encrypt_t* OSSL_RSA_private_encrypt;
+
+/* Define pointers for OpenSSL BIGNUM structs. */
+OSSL_BN_new_t *OSSL_BN_new;
 OSSL_BN_bin2bn_t* OSSL_BN_bin2bn;
 OSSL_BN_set_negative_t* OSSL_BN_set_negative;
 OSSL_BN_free_t* OSSL_BN_free;
+OSSL_BN_bn2bin_t *OSSL_BN_bn2bin;
+OSSL_BN_num_bits_t *OSSL_BN_num_bits;
 
 /* Define pointers for OpenSSL functions to handle EC algorithm. */
+OSSL_EC_KEY_generate_key_t *OSSL_EC_KEY_generate_key;
 OSSL_EC_KEY_free_t* OSSL_EC_KEY_free;
 OSSL_ECDH_compute_key_t* OSSL_ECDH_compute_key;
 OSSL_EC_KEY_get0_public_key_t* OSSL_EC_KEY_get0_public_key;
@@ -218,6 +232,8 @@ OSSL_EC_KEY_set_group_t* OSSL_EC_KEY_set_group;
 OSSL_EC_POINT_new_t* OSSL_EC_POINT_new;
 OSSL_EC_POINT_set_affine_coordinates_GFp_t* OSSL_EC_POINT_set_affine_coordinates_GFp;
 OSSL_EC_POINT_set_affine_coordinates_GF2m_t* OSSL_EC_POINT_set_affine_coordinates_GF2m;
+OSSL_EC_POINT_get_affine_coordinates_GFp_t *OSSL_EC_POINT_get_affine_coordinates_GFp;
+OSSL_EC_POINT_get_affine_coordinates_GF2m_t *OSSL_EC_POINT_get_affine_coordinates_GF2m;
 OSSL_EC_GROUP_set_generator_t* OSSL_EC_GROUP_set_generator;
 OSSL_EC_KEY_get0_group_t* OSSL_EC_KEY_get0_group;
 OSSL_EC_POINT_free_t* OSSL_EC_POINT_free;
@@ -226,6 +242,7 @@ OSSL_BN_CTX_free_t* OSSL_BN_CTX_free;
 OSSL_EC_KEY_set_public_key_t* OSSL_EC_KEY_set_public_key;
 OSSL_EC_KEY_check_key_t* OSSL_EC_KEY_check_key;
 EC_set_public_key_t* EC_set_public_key;
+OSSL_EC_KEY_get0_private_key_t *OSSL_EC_KEY_get0_private_key;
 
 /* Define pointers for OpenSSL functions to handle PBE algorithm. */
 OSSL_PKCS12_key_gen_t* OSSL_PKCS12_key_gen;
@@ -428,14 +445,21 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
     OSSL_RSA_free = (OSSL_RSA_free_t *)find_crypto_symbol(crypto_library, "RSA_free");
     OSSL_RSA_public_decrypt = (OSSL_RSA_public_decrypt_t *)find_crypto_symbol(crypto_library, "RSA_public_decrypt");
     OSSL_RSA_private_encrypt = (OSSL_RSA_private_encrypt_t *)find_crypto_symbol(crypto_library, "RSA_private_decrypt");
+
+    /* Load the function symbols for BIGNUM manipulation. */
+    OSSL_BN_new = (OSSL_BN_new_t *)find_crypto_symbol(crypto_library, "BN_new");
     OSSL_BN_bin2bn = (OSSL_BN_bin2bn_t *)find_crypto_symbol(crypto_library, "BN_bin2bn");
     OSSL_BN_set_negative = (OSSL_BN_set_negative_t *)find_crypto_symbol(crypto_library, "BN_set_negative");
     OSSL_BN_free = (OSSL_BN_free_t *)find_crypto_symbol(crypto_library, "BN_free");
+    OSSL_BN_bn2bin = (OSSL_BN_bn2bin_t *)find_crypto_symbol(crypto_library, "BN_bn2bin");
+    OSSL_BN_num_bits = (OSSL_BN_num_bits_t *)find_crypto_symbol(crypto_library, "BN_num_bits");
 
     /* Load the functions symbols for OpenSSL EC algorithm. */
+    OSSL_EC_KEY_generate_key = (OSSL_EC_KEY_generate_key_t *)find_crypto_symbol(crypto_library, "EC_KEY_generate_key");
     OSSL_EC_KEY_free = (OSSL_EC_KEY_free_t*)find_crypto_symbol(crypto_library, "EC_KEY_free");
     OSSL_ECDH_compute_key = (OSSL_ECDH_compute_key_t*)find_crypto_symbol(crypto_library, "ECDH_compute_key");
     OSSL_EC_KEY_get0_public_key = (OSSL_EC_KEY_get0_public_key_t*)find_crypto_symbol(crypto_library, "EC_KEY_get0_public_key");
+    OSSL_EC_KEY_get0_private_key = (OSSL_EC_KEY_get0_private_key_t *)find_crypto_symbol(crypto_library, "EC_KEY_get0_private_key");
     OSSL_EC_KEY_new = (OSSL_EC_KEY_new_t*)find_crypto_symbol(crypto_library, "EC_KEY_new");
     OSSL_EC_KEY_set_public_key_affine_coordinates = (OSSL_EC_KEY_set_public_key_affine_coordinates_t*)find_crypto_symbol(crypto_library, "EC_KEY_set_public_key_affine_coordinates");
     OSSL_EC_KEY_set_private_key = (OSSL_EC_KEY_set_private_key_t*)find_crypto_symbol(crypto_library, "EC_KEY_set_private_key");
@@ -452,6 +476,7 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
     OSSL_EC_KEY_set_public_key = (OSSL_EC_KEY_set_public_key_t*)find_crypto_symbol(crypto_library, "EC_KEY_set_public_key");
     OSSL_EC_KEY_check_key = (OSSL_EC_KEY_check_key_t*)find_crypto_symbol(crypto_library, "EC_KEY_check_key");
     OSSL_EC_POINT_set_affine_coordinates_GFp = (OSSL_EC_POINT_set_affine_coordinates_GFp_t*)find_crypto_symbol(crypto_library, "EC_POINT_set_affine_coordinates");
+    OSSL_EC_POINT_get_affine_coordinates_GFp = (OSSL_EC_POINT_get_affine_coordinates_GFp_t *)find_crypto_symbol(crypto_library, "EC_POINT_get_affine_coordinates");
     if (NULL == OSSL_EC_KEY_set_public_key_affine_coordinates) {
         /* method missing in OpenSSL version 1.0.0 */
         EC_set_public_key = &setECPublicKey;
@@ -465,7 +490,17 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
     } else {
         OSSL_EC_POINT_set_affine_coordinates_GF2m = (OSSL_EC_POINT_set_affine_coordinates_GF2m_t*)find_crypto_symbol(crypto_library, "EC_POINT_set_affine_coordinates");
     }
-    if ((NULL == OSSL_EC_GROUP_new_curve_GF2m) || (NULL == OSSL_EC_POINT_set_affine_coordinates_GF2m)) {
+    if (NULL == OSSL_EC_POINT_get_affine_coordinates_GFp) {
+        /* deprecated in OpenSSL version 1.1.1 */
+        OSSL_EC_POINT_get_affine_coordinates_GFp = (OSSL_EC_POINT_get_affine_coordinates_GFp_t *)find_crypto_symbol(crypto_library, "EC_POINT_get_affine_coordinates_GFp");
+        OSSL_EC_POINT_get_affine_coordinates_GF2m = (OSSL_EC_POINT_get_affine_coordinates_GF2m_t *)find_crypto_symbol(crypto_library, "EC_POINT_get_affine_coordinates_GF2m");
+    } else {
+        OSSL_EC_POINT_get_affine_coordinates_GF2m = (OSSL_EC_POINT_get_affine_coordinates_GF2m_t *)OSSL_EC_POINT_get_affine_coordinates_GFp;
+    }
+    if ((NULL == OSSL_EC_GROUP_new_curve_GF2m)
+    || (NULL == OSSL_EC_POINT_set_affine_coordinates_GF2m)
+    || (NULL == OSSL_EC_POINT_get_affine_coordinates_GF2m)
+    ) {
         /* the OPENSSL_NO_EC2M flag is set and the EC2m methods are unavailable */
         OSSL_ECGF2M = JNI_FALSE;
     } else {
@@ -513,12 +548,17 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
         (NULL == OSSL_RSA_free) ||
         (NULL == OSSL_RSA_public_decrypt) ||
         (NULL == OSSL_RSA_private_encrypt) ||
+        (NULL == OSSL_BN_new) ||
         (NULL == OSSL_BN_bin2bn) ||
         (NULL == OSSL_BN_set_negative) ||
         (NULL == OSSL_BN_free) ||
+        (NULL == OSSL_BN_bn2bin) ||
+        (NULL == OSSL_BN_num_bits) ||
+        (NULL == OSSL_EC_KEY_generate_key) ||
         (NULL == OSSL_EC_KEY_free) ||
         (NULL == OSSL_ECDH_compute_key) ||
         (NULL == OSSL_EC_KEY_get0_public_key) ||
+        (NULL == OSSL_EC_KEY_get0_private_key) ||
         (NULL == OSSL_EC_KEY_new) ||
         (NULL == OSSL_EC_KEY_set_private_key) ||
         (NULL == OSSL_BN_CTX_new) ||
@@ -526,6 +566,7 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
         (NULL == OSSL_EC_KEY_set_group) ||
         (NULL == OSSL_EC_POINT_new) ||
         (NULL == OSSL_EC_POINT_set_affine_coordinates_GFp) ||
+        (NULL == OSSL_EC_POINT_get_affine_coordinates_GFp) ||
         (NULL == OSSL_EC_GROUP_set_generator) ||
         (NULL == OSSL_EC_KEY_get0_group) ||
         (NULL == OSSL_EC_POINT_free) ||
@@ -539,7 +580,8 @@ JNIEXPORT jlong JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto
         ((NULL == OSSL_OPENSSL_malloc) && (ossl_ver < OPENSSL_VERSION_1_1_0)) ||
         ((NULL == OSSL_OPENSSL_free) && (ossl_ver < OPENSSL_VERSION_1_1_0)) ||
         ((NULL == OSSL_CRYPTO_THREADID_set_callback) && (ossl_ver < OPENSSL_VERSION_1_1_0)) ||
-        ((NULL == OSSL_CRYPTO_set_locking_callback) && (ossl_ver < OPENSSL_VERSION_1_1_0))) {
+        ((NULL == OSSL_CRYPTO_set_locking_callback) && (ossl_ver < OPENSSL_VERSION_1_1_0))
+    ) {
 #if 0
         fprintf(stderr, "One or more of the required symbols are missing in the crypto library\n");
         fflush(stderr);
@@ -2018,6 +2060,141 @@ Java_jdk_crypto_jniprovider_NativeCrypto_ECNativeGF2m
     return OSSL_ECGF2M;
 }
 
+static int
+getArrayFromBN(const BIGNUM *bn, unsigned char *out, int len)
+{
+    int ret = -1;
+    int bn_len_bits = (*OSSL_BN_num_bits)(bn);
+    int bn_len = (bn_len_bits + 7) / 8;
+
+    if (bn_len <= len) {
+        int size_diff = len - bn_len;
+        int retLen = (*OSSL_BN_bn2bin)(bn, out + size_diff);
+        if (retLen > 0) {
+            if (size_diff > 0) {
+                memset(out, 0x00, size_diff);
+            }
+            ret = 1;
+        }
+    }
+
+    return ret;
+}
+
+/* Generate an EC Key Pair
+ *
+ * Class:     jdk_crypto_jniprovider_NativeCrypto
+ * Method:    ECGenerateKeyPair
+ * Signature: (J[BI[BI[BII)I
+ */
+JNIEXPORT jint JNICALL
+Java_jdk_crypto_jniprovider_NativeCrypto_ECGenerateKeyPair
+  (JNIEnv *env, jclass obj, jlong key, jbyteArray x, jint xLen, jbyteArray y, jint yLen, jbyteArray s, jint sLen, jint fieldType)
+{
+    jint ret = -1;
+
+    unsigned char *nativeX = NULL;
+    unsigned char *nativeY = NULL;
+    unsigned char *nativeS = NULL;
+    BN_CTX *ctx = NULL;
+    const EC_POINT *publicKey = NULL;
+    const EC_GROUP *publicGroup = NULL;
+    BIGNUM *xBN = (*OSSL_BN_new)();
+    BIGNUM *yBN = (*OSSL_BN_new)();
+    const BIGNUM *sBN = NULL;
+    EC_KEY *nativeKey = (EC_KEY *)(intptr_t) key;
+
+    if (NULL == nativeKey) {
+        goto cleanup;
+    }
+
+    nativeX = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, x, 0));
+    if (NULL == nativeX) {
+        goto cleanup;
+    }
+
+    nativeY = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, y, 0));
+    if (NULL == nativeY) {
+        goto cleanup;
+    }
+
+    nativeS = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, s, 0));
+    if (NULL == nativeS) {
+        goto cleanup;
+    }
+
+    if (0 == (*OSSL_EC_KEY_generate_key)(nativeKey)) {
+        goto cleanup;
+    }
+
+    // to translate the public key to java format, we need to extract the public key coordinates: xBN, yBN
+    ctx = (*OSSL_BN_CTX_new)();
+    if (NULL == ctx) {
+        goto cleanup;
+    }
+
+    publicKey = (*OSSL_EC_KEY_get0_public_key)(nativeKey);
+    publicGroup = (*OSSL_EC_KEY_get0_group)(nativeKey);
+
+    if (jdk_crypto_jniprovider_NativeCrypto_ECField_Fp == fieldType) {
+        if (0 == (*OSSL_EC_POINT_get_affine_coordinates_GFp)(publicGroup, publicKey, xBN, yBN, ctx)) {
+            goto cleanup;
+        }
+    } else {
+        if (JNI_FALSE == OSSL_ECGF2M) {
+            goto cleanup;
+        }
+        if (0 == (*OSSL_EC_POINT_get_affine_coordinates_GF2m)(publicGroup, publicKey, xBN, yBN, ctx)) {
+            goto cleanup;
+        }
+    }
+
+    ret = getArrayFromBN(xBN, nativeX, xLen);
+    if (ret == -1) {
+        goto cleanup;
+    }
+
+    ret = getArrayFromBN(yBN, nativeY, yLen);
+    if (ret == -1) {
+        goto cleanup;
+    }
+
+    // to translate the private key to java format, we need the private key BIGNUM
+    sBN = (*OSSL_EC_KEY_get0_private_key)(nativeKey);
+
+    ret = getArrayFromBN(sBN, nativeS, sLen);
+    if (ret == -1) {
+        goto cleanup;
+    }
+
+    ret = 1;
+
+cleanup:
+    if (NULL != nativeX) {
+        (*env)->ReleasePrimitiveArrayCritical(env, x, nativeX, 0);
+    }
+    if (NULL != nativeY) {
+        (*env)->ReleasePrimitiveArrayCritical(env, y, nativeY, 0);
+    }
+    if (NULL != nativeS) {
+        (*env)->ReleasePrimitiveArrayCritical(env, s, nativeS, 0);
+    }
+    if (NULL != ctx) {
+        (*OSSL_BN_CTX_free)(ctx);
+    }
+    if (NULL != nativeKey) {
+        (*OSSL_EC_KEY_free)(nativeKey);
+    }
+    if (NULL != xBN) {
+        (*OSSL_BN_free)(xBN);
+    }
+    if (NULL != yBN) {
+        (*OSSL_BN_free)(yBN);
+    }
+
+    return ret;
+}
+
 /* Create an EC Public Key
  *
  * Class:     jdk_crypto_jniprovider_NativeCrypto
@@ -2028,37 +2205,44 @@ JNIEXPORT jint JNICALL
 Java_jdk_crypto_jniprovider_NativeCrypto_ECCreatePublicKey
   (JNIEnv *env, jclass obj, jlong key, jbyteArray x, jint xLen, jbyteArray y, jint yLen, jint field)
 {
+    jint ret = -1;
+
     unsigned char *nativeX = NULL;
     unsigned char *nativeY = NULL;
     EC_KEY *publicKey = (EC_KEY*)(intptr_t) key;
     BIGNUM *xBN = NULL;
     BIGNUM *yBN = NULL;
-    int ret = 0;
 
     nativeX = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, x, 0));
     if (NULL == nativeX) {
-        return -1;
+        goto cleanup;
     }
 
     nativeY = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, y, 0));
     if (NULL == nativeY) {
-        (*env)->ReleasePrimitiveArrayCritical(env, x, nativeX, JNI_ABORT);
-        return -1;
+        goto cleanup;
     }
 
     xBN = convertJavaBItoBN(nativeX, xLen);
     yBN = convertJavaBItoBN(nativeY, yLen);
 
     if ((NULL == xBN) || (NULL == yBN)) {
-        (*env)->ReleasePrimitiveArrayCritical(env, x, nativeX, JNI_ABORT);
-        (*env)->ReleasePrimitiveArrayCritical(env, y, nativeY, JNI_ABORT);
-        return -1;
+        goto cleanup;
     }
 
-    ret = (*EC_set_public_key)(publicKey, xBN, yBN, field);
+    if (0 == (*EC_set_public_key)(publicKey, xBN, yBN, field)) {
+        goto cleanup;
+    }
+    ret = 1;
 
-    (*env)->ReleasePrimitiveArrayCritical(env, x, nativeX, JNI_ABORT);
-    (*env)->ReleasePrimitiveArrayCritical(env, y, nativeY, JNI_ABORT);
+cleanup:
+    if (NULL != nativeX) {
+        (*env)->ReleasePrimitiveArrayCritical(env, x, nativeX, JNI_ABORT);
+    }
+
+    if (NULL != nativeY) {
+        (*env)->ReleasePrimitiveArrayCritical(env, y, nativeY, JNI_ABORT);
+    }
 
     if (NULL != xBN) {
         (*OSSL_BN_free)(xBN);
@@ -2068,11 +2252,7 @@ Java_jdk_crypto_jniprovider_NativeCrypto_ECCreatePublicKey
         (*OSSL_BN_free)(yBN);
     }
 
-    if (0 == ret) {
-        return -1;
-    }
-
-    return 0;
+    return ret;
 }
 
 /* Create an EC Private Key
@@ -2085,36 +2265,39 @@ JNIEXPORT jint JNICALL
 Java_jdk_crypto_jniprovider_NativeCrypto_ECCreatePrivateKey
   (JNIEnv *env, jclass obj, jlong key, jbyteArray s, jint sLen)
 {
+    jint ret = -1;
+
     unsigned char *nativeS = NULL;
     EC_KEY *privateKey = (EC_KEY*)(intptr_t) key;
     BIGNUM *sBN = NULL;
-    int ret = 0;
 
     nativeS = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, s, 0));
     if (NULL == nativeS) {
-        return -1;
+        goto cleanup;
     }
 
     sBN = convertJavaBItoBN(nativeS, sLen);
 
     if (NULL == sBN) {
-        (*env)->ReleasePrimitiveArrayCritical(env, s, nativeS, JNI_ABORT);
-        return -1;
+        goto cleanup;
     }
 
-    ret = (*OSSL_EC_KEY_set_private_key)(privateKey, sBN);
+    if (0 == (*OSSL_EC_KEY_set_private_key)(privateKey, sBN)) {
+        goto cleanup;
+    }
 
-    (*env)->ReleasePrimitiveArrayCritical(env, s, nativeS, JNI_ABORT);
+    ret = 1;
+
+cleanup:
+    if (NULL != nativeS) {
+        (*env)->ReleasePrimitiveArrayCritical(env, s, nativeS, JNI_ABORT);
+    }
 
     if (NULL != sBN) {
         (*OSSL_BN_free)(sBN);
     }
 
-    if (0 == ret) {
-        return -1;
-    }
-
-    return 0;
+    return ret;
 }
 
 /* Encode an EC Elliptic Curve over a Prime Field */
@@ -2260,14 +2443,15 @@ cleanup:
 /* Encode an EC Elliptic Curve over a Field
  *
  * Class:     jdk_crypto_jniprovider_NativeCrypto
- * Method:    ECEncodeGFp
- * Signature: ([BI[BI[BI[BI[BI[BI[BI)J
+ * Method:    ECEncodeGF
+ * Signature: (I[BI[BI[BI[BI[BI[BI[BI)J
  */
 JNIEXPORT jlong JNICALL
-Java_jdk_crypto_jniprovider_NativeCrypto_ECEncodeGFp
-  (JNIEnv *env, jclass obj, jbyteArray a, jint aLen, jbyteArray b, jint bLen, jbyteArray p, jint pLen, jbyteArray x, jint xLen, jbyteArray y, jint yLen, jbyteArray n, jint nLen, jbyteArray h, jint hLen)
+Java_jdk_crypto_jniprovider_NativeCrypto_ECEncodeGF
+  (JNIEnv *env, jclass obj, jint fieldType, jbyteArray a, jint aLen, jbyteArray b, jint bLen, jbyteArray p, jint pLen, jbyteArray x, jint xLen, jbyteArray y, jint yLen, jbyteArray n, jint nLen, jbyteArray h, jint hLen)
 {
     EC_KEY *key = NULL;
+
     unsigned char *nativeA = NULL;
     unsigned char *nativeB = NULL;
     unsigned char *nativeP = NULL;
@@ -2282,41 +2466,44 @@ Java_jdk_crypto_jniprovider_NativeCrypto_ECEncodeGFp
     BIGNUM *yBN = NULL;
     BIGNUM *nBN = NULL;
     BIGNUM *hBN = NULL;
+    EC_GROUP *group = NULL;
+    EC_POINT *generator = NULL;
+    BN_CTX *ctx = NULL;
     int ret = 0;
 
-    nativeA = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, a, 0));
+    nativeA = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, a, 0));
     if (NULL == nativeA) {
-        goto cleanup;
+        goto releaseArrays;
     }
 
-    nativeB = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, b, 0));
+    nativeB = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, b, 0));
     if (NULL == nativeB) {
-        goto cleanup;
+        goto releaseArrays;
     }
 
-    nativeP = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, p, 0));
+    nativeP = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, p, 0));
     if (NULL == nativeP) {
-        goto cleanup;
+        goto releaseArrays;
     }
 
-    nativeX = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, x, 0));
+    nativeX = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, x, 0));
     if (NULL == nativeX) {
-        goto cleanup;
+        goto releaseArrays;
     }
 
-    nativeY = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, y, 0));
+    nativeY = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, y, 0));
     if (NULL == nativeY) {
-        goto cleanup;
+        goto releaseArrays;
     }
 
-    nativeN = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, n, 0));
+    nativeN = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, n, 0));
     if (NULL == nativeN) {
-        goto cleanup;
+        goto releaseArrays;
     }
 
-    nativeH = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, h, 0));
+    nativeH = (unsigned char *)((*env)->GetPrimitiveArrayCritical(env, h, 0));
     if (NULL == nativeH) {
-        goto cleanup;
+        goto releaseArrays;
     }
 
     aBN = convertJavaBItoBN(nativeA, aLen);
@@ -2327,13 +2514,7 @@ Java_jdk_crypto_jniprovider_NativeCrypto_ECEncodeGFp
     nBN = convertJavaBItoBN(nativeN, nLen);
     hBN = convertJavaBItoBN(nativeH, hLen);
 
-    if ((NULL == aBN) || (NULL == bBN) || (NULL == pBN) || (NULL == xBN) || (NULL == yBN) || (NULL == nBN) || (NULL == hBN)) {
-        goto cleanup;
-    }
-
-    key = ECEncodeGFp(aBN, bBN, pBN, xBN, yBN, nBN, hBN);
-
-cleanup:
+releaseArrays:
     if (NULL != nativeA) {
         (*env)->ReleasePrimitiveArrayCritical(env, a, nativeA, JNI_ABORT);
     }
@@ -2362,141 +2543,20 @@ cleanup:
         (*env)->ReleasePrimitiveArrayCritical(env, h, nativeH, JNI_ABORT);
     }
 
-    if (NULL != aBN) {
-        (*OSSL_BN_free)(aBN);
-    }
-    if (NULL != bBN) {
-        (*OSSL_BN_free)(bBN);
-    }
-    if (NULL != pBN) {
-        (*OSSL_BN_free)(pBN);
-    }
-    if (NULL != xBN) {
-        (*OSSL_BN_free)(xBN);
-    }
-    if (NULL != yBN) {
-        (*OSSL_BN_free)(yBN);
-    }
-    if (NULL != nBN) {
-        (*OSSL_BN_free)(nBN);
-    }
-    if (NULL != hBN) {
-        (*OSSL_BN_free)(hBN);
+    /*
+     * If we jumped to releaseArrays because of error, the BIGNUM pointers
+     * will also be NULL and we will goto cleanup and terminate.
+     */
+    if ((NULL == aBN) || (NULL == bBN) || (NULL == pBN) || (NULL == xBN) || (NULL == yBN) || (NULL == nBN) || (NULL == hBN)) {
+        goto cleanup;
     }
 
-
-    if (NULL == key) {
-        return -1;
+    if (jdk_crypto_jniprovider_NativeCrypto_ECField_Fp == fieldType) {
+        key = ECEncodeGFp(aBN, bBN, pBN, xBN, yBN, nBN, hBN);
     } else {
-        return (jlong)(intptr_t)key;
+        key = ECEncodeGF2m(aBN, bBN, pBN, xBN, yBN, nBN, hBN);
     }
-}
-
-/* Encode an EC Elliptic Curve over a Binary Field
- *
- * Class:     jdk_crypto_jniprovider_NativeCrypto
- * Method:    ECEncodeGF2m
- * Signature: ([BI[BI[BI[BI[BI[BI[BI)J
- */
-JNIEXPORT jlong JNICALL
-Java_jdk_crypto_jniprovider_NativeCrypto_ECEncodeGF2m
-  (JNIEnv *env, jclass obj, jbyteArray a, jint aLen, jbyteArray b, jint bLen, jbyteArray p, jint pLen, jbyteArray x, jint xLen, jbyteArray y, jint yLen, jbyteArray n, jint nLen, jbyteArray h, jint hLen)
-{
-    EC_KEY *key = NULL;
-    unsigned char *nativeA = NULL;
-    unsigned char *nativeB = NULL;
-    unsigned char *nativeP = NULL;
-    unsigned char *nativeX = NULL;
-    unsigned char *nativeY = NULL;
-    unsigned char *nativeN = NULL;
-    unsigned char *nativeH = NULL;
-    BIGNUM *aBN = NULL;
-    BIGNUM *bBN = NULL;
-    BIGNUM *pBN = NULL;
-    BIGNUM *xBN = NULL;
-    BIGNUM *yBN = NULL;
-    BIGNUM *nBN = NULL;
-    BIGNUM *hBN = NULL;
-    int ret = 0;
-
-    nativeA = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, a, 0));
-    if (NULL == nativeA) {
-        goto cleanup;
-    }
-
-    nativeB = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, b, 0));
-    if (NULL == nativeB) {
-        goto cleanup;
-    }
-
-    nativeP = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, p, 0));
-    if (NULL == nativeP) {
-        goto cleanup;
-    }
-
-    nativeX = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, x, 0));
-    if (NULL == nativeX) {
-        goto cleanup;
-    }
-
-    nativeY = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, y, 0));
-    if (NULL == nativeY) {
-        goto cleanup;
-    }
-
-    nativeN = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, n, 0));
-    if (NULL == nativeN) {
-        goto cleanup;
-    }
-
-    nativeH = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, h, 0));
-    if (NULL == nativeH) {
-        goto cleanup;
-    }
-
-    aBN = convertJavaBItoBN(nativeA, aLen);
-    bBN = convertJavaBItoBN(nativeB, bLen);
-    pBN = convertJavaBItoBN(nativeP, pLen);
-    xBN = convertJavaBItoBN(nativeX, xLen);
-    yBN = convertJavaBItoBN(nativeY, yLen);
-    nBN = convertJavaBItoBN(nativeN, nLen);
-    hBN = convertJavaBItoBN(nativeH, hLen);
-
-    if ((NULL == aBN) || (NULL == bBN) || (NULL == pBN) || (NULL == xBN) || (NULL == yBN) || (NULL == nBN) || (NULL == hBN)) {
-        goto cleanup;
-    }
-
-    key = ECEncodeGF2m(aBN, bBN, pBN, xBN, yBN, nBN, hBN);
-
 cleanup:
-    if (NULL != nativeA) {
-        (*env)->ReleasePrimitiveArrayCritical(env, a, nativeA, JNI_ABORT);
-    }
-
-    if (NULL != nativeB) {
-        (*env)->ReleasePrimitiveArrayCritical(env, b, nativeB, JNI_ABORT);
-    }
-
-    if (NULL != nativeP) {
-        (*env)->ReleasePrimitiveArrayCritical(env, p, nativeP, JNI_ABORT);
-    }
-
-    if (NULL != nativeX) {
-        (*env)->ReleasePrimitiveArrayCritical(env, x, nativeX, JNI_ABORT);
-    }
-
-    if (NULL != nativeY) {
-        (*env)->ReleasePrimitiveArrayCritical(env, y, nativeY, JNI_ABORT);
-    }
-
-    if (NULL != nativeN) {
-        (*env)->ReleasePrimitiveArrayCritical(env, n, nativeN, JNI_ABORT);
-    }
-
-    if (NULL != nativeH) {
-        (*env)->ReleasePrimitiveArrayCritical(env, h, nativeH, JNI_ABORT);
-    }
-
     if (NULL != aBN) {
         (*OSSL_BN_free)(aBN);
     }
@@ -2518,7 +2578,6 @@ cleanup:
     if (NULL != hBN) {
         (*OSSL_BN_free)(hBN);
     }
-
 
     if (NULL == key) {
         return -1;
@@ -2556,26 +2615,34 @@ JNIEXPORT jint JNICALL
 Java_jdk_crypto_jniprovider_NativeCrypto_ECDeriveKey
   (JNIEnv *env, jclass obj, jlong publicKey, jlong privateKey, jbyteArray secret, jint secretOffset, jint secretLen)
 {
+    jint ret = -1;
     EC_KEY *nativePublicKey = (EC_KEY*)(intptr_t) publicKey;
     EC_KEY *nativePrivateKey = (EC_KEY*)(intptr_t) privateKey;
-    unsigned char* nativeSecret = NULL;
-    int ret = 0;
+    unsigned char *nativeSecret = NULL;
+    const EC_POINT *publicKeyPoint = NULL;
 
     nativeSecret = (unsigned char*)((*env)->GetPrimitiveArrayCritical(env, secret, 0));
     if (NULL == nativeSecret) {
-        return -1;
+        goto cleanup;
     }
 
     /* Derive the shared secret */
-    ret = (*OSSL_ECDH_compute_key)((nativeSecret + secretOffset), secretLen, (*OSSL_EC_KEY_get0_public_key)(nativePublicKey), nativePrivateKey, NULL);
-
-    (*env)->ReleasePrimitiveArrayCritical(env, secret, nativeSecret, 0);
-
-    if (0 == ret) {
-        return -1;
+    publicKeyPoint = (*OSSL_EC_KEY_get0_public_key)(nativePublicKey);
+    if (NULL == publicKeyPoint) {
+        goto cleanup;
     }
 
-    return secretLen;
+    if (0 == (*OSSL_ECDH_compute_key)(nativeSecret + secretOffset, secretLen, publicKeyPoint, nativePrivateKey, NULL)) {
+        goto cleanup;
+    }
+
+    ret = 1;
+
+cleanup:
+    if (NULL != nativeSecret) {
+        (*env)->ReleasePrimitiveArrayCritical(env, secret, nativeSecret, 0);
+    }
+    return ret;
 }
 
 /** Wrapper for OSSL_EC_KEY_set_public_key_affine_coordinates
@@ -2598,7 +2665,7 @@ setECPublicKey(EC_KEY *key, BIGNUM *x, BIGNUM *y, int field)
     EC_POINT *publicKey = (*OSSL_EC_POINT_new)(group);
     int ret = 0;
 
-    if ((JNI_FALSE == OSSL_ECGF2M) && (0 != field)) {
+    if ((JNI_FALSE == OSSL_ECGF2M) && (jdk_crypto_jniprovider_NativeCrypto_ECField_Fp != field)) {
         (*OSSL_BN_CTX_free)(ctx);
         (*OSSL_EC_POINT_free)(publicKey);
         return ret;
@@ -2695,7 +2762,7 @@ cleanup:
         (*env)->ReleasePrimitiveArrayCritical(env, salt, nativeSalt, JNI_ABORT);
     }
     if (NULL != nativeKey) {
-        (*env)->ReleasePrimitiveArrayCritical(env, key, nativeKey, JNI_ABORT);
+        (*env)->ReleasePrimitiveArrayCritical(env, key, nativeKey, 0);
     }
 
     return ret;

--- a/closed/make/mapfiles/libjncrypto/mapfile-vers
+++ b/closed/make/mapfiles/libjncrypto/mapfile-vers
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -41,10 +41,10 @@ SUNWprivate_1.1 {
 		Java_jdk_crypto_jniprovider_NativeCrypto_destroyRSAKey;
 		Java_jdk_crypto_jniprovider_NativeCrypto_RSADP;
 		Java_jdk_crypto_jniprovider_NativeCrypto_RSAEP;
+		Java_jdk_crypto_jniprovider_NativeCrypto_ECGenerateKeyPair;
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECCreatePublicKey;
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECCreatePrivateKey;
-		Java_jdk_crypto_jniprovider_NativeCrypto_ECEncodeGFp;
-		Java_jdk_crypto_jniprovider_NativeCrypto_ECEncodeGF2m;
+		Java_jdk_crypto_jniprovider_NativeCrypto_ECEncodeGF;
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECDestroyKey;
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECDeriveKey;
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECNativeGF2m;

--- a/jdk/src/share/classes/sun/security/ec/ECKeyPairGenerator.java
+++ b/jdk/src/share/classes/sun/security/ec/ECKeyPairGenerator.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+ /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.ec;
 
 import java.io.IOException;
@@ -117,7 +123,7 @@ public final class ECKeyPairGenerator extends KeyPairGeneratorSpi {
         this.random = random;
     }
 
-    private static void ensureCurveIsSupported(ECParameterSpec ecSpec)
+    static void ensureCurveIsSupported(ECParameterSpec ecSpec)
         throws InvalidAlgorithmParameterException {
 
         AlgorithmParameters ecParams = ECUtil.getECParameters(null);


### PR DESCRIPTION
As part of this update, two things happen:

1. A new class is created and equivalent functionality is added that allows the use the native OpenSSL library to perform EC key generation. As part of that, `NativeECKeyPairGenerator.java` is created and several other classes are amended to support it, namely `SunEC` to load the appropriate class, and the `ECKeyPairGenerator` offered by Sun as a fallback option.
2. The code for the ECDH Key Agreement is updated. In that part, helper functions are created in the `NativeCrypto.c` file to avoid unnecessary passing of `EC_KEY` pointers. A `NativeECUtil.java` class is, also, created, so as to bundle commonly used functionality. Lastly, the handling of freeing arrays, keys and `BIGNUM` structs that were part of that functionality is updated.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/650

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)