### PR TITLE
PKCS#12 file-based Keystore support for FIPS mode

### DIFF
--- a/jdk/src/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/jdk/src/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -47,7 +47,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -143,12 +143,25 @@ public class PKCS11 {
         new HashMap<String,PKCS11>();
 
     static boolean isKey(CK_ATTRIBUTE[] attrs) {
+        boolean isPrivateKey = false;
+        boolean hasKey = false;
+
         for (CK_ATTRIBUTE attr : attrs) {
-            if ((attr.type == CKA_CLASS) && (attr.getLong() == CKO_SECRET_KEY)) {
-                return true;
+            if (attr.type == CKA_CLASS) {
+                if (attr.getLong() == CKO_SECRET_KEY) {
+                    return true;
+                } else if (attr.getLong() == CKO_PRIVATE_KEY) {
+                    isPrivateKey = true;
+                }
+            } else if (attr.type == CKA_KEY_TYPE) {
+                hasKey = true;
+                if (!((attr.getLong() == CKK_RSA) || (attr.getLong() == CKK_EC))) {
+                    isPrivateKey = false;
+                }
             }
         }
-        return false;
+
+        return isPrivateKey && hasKey;
     }
 
     // This is the SunPKCS11 provider instance


### PR DESCRIPTION
This is a backport PR from JDKNext PR https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/573 & https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/606 & https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/612 to JDK8.