### PR TITLE
Fix javadoc violations

### DIFF
--- a/langtools/src/share/classes/com/sun/tools/doclets/formats/html/markup/HtmlTree.java
+++ b/langtools/src/share/classes/com/sun/tools/doclets/formats/html/markup/HtmlTree.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package com.sun.tools.doclets.formats.html.markup;
 
 import java.io.IOException;
@@ -643,7 +649,7 @@ public class HtmlTree extends Content {
         htmltree.addAttr(HtmlAttr.BORDER, Integer.toString(border));
         htmltree.addAttr(HtmlAttr.CELLPADDING, Integer.toString(cellPadding));
         htmltree.addAttr(HtmlAttr.CELLSPACING, Integer.toString(cellSpacing));
-        htmltree.addAttr(HtmlAttr.SUMMARY, nullCheck(summary));
+        //htmltree.addAttr(HtmlAttr.SUMMARY, nullCheck(summary));
         return htmltree;
     }
 

--- a/langtools/src/share/classes/com/sun/tools/doclets/internal/toolkit/resources/stylesheet.css
+++ b/langtools/src/share/classes/com/sun/tools/doclets/internal/toolkit/resources/stylesheet.css
@@ -381,8 +381,12 @@ Table styles
     margin:0px;
     white-space:pre;
 }
+.constantsSummary caption a:link, .constantsSummary caption a:visited,
+.useSummary caption a:link, .useSummary caption a:visited {
+    color:#1f389c;
+}
 .overviewSummary caption a:link, .memberSummary caption a:link, .typeSummary caption a:link,
-.useSummary caption a:link, .constantsSummary caption a:link, .deprecatedSummary caption a:link,
+.deprecatedSummary caption a:link, .packagesSummary caption a:link,
 .overviewSummary caption a:hover, .memberSummary caption a:hover, .typeSummary caption a:hover,
 .useSummary caption a:hover, .constantsSummary caption a:hover, .deprecatedSummary caption a:hover,
 .overviewSummary caption a:active, .memberSummary caption a:active, .typeSummary caption a:active,
@@ -392,7 +396,8 @@ Table styles
     color:#FFFFFF;
 }
 .overviewSummary caption span, .memberSummary caption span, .typeSummary caption span,
-.useSummary caption span, .constantsSummary caption span, .deprecatedSummary caption span {
+.useSummary caption span, .constantsSummary caption span, .deprecatedSummary caption span,
+.packagesSummary caption span {
     white-space:nowrap;
     padding-top:5px;
     padding-left:12px;
@@ -404,7 +409,7 @@ Table styles
     border: none;
     height:16px;
 }
-.memberSummary caption span.activeTableTab span {
+.memberSummary caption span.activeTableTab span, .packagesSummary caption span.activeTableTab span {
     white-space:nowrap;
     padding-top:5px;
     padding-left:12px;
@@ -415,7 +420,7 @@ Table styles
     background-color:#F8981D;
     height:16px;
 }
-.memberSummary caption span.tableTab span {
+.memberSummary caption span.tableTab span, .packagesSummary caption span.tableTab span {
     white-space:nowrap;
     padding-top:5px;
     padding-left:12px;
@@ -426,7 +431,8 @@ Table styles
     background-color:#4D7A97;
     height:16px;
 }
-.memberSummary caption span.tableTab, .memberSummary caption span.activeTableTab {
+.memberSummary caption span.tableTab, .memberSummary caption span.activeTableTab,
+.packagesSummary caption span.tableTab, .packagesSummary caption span.activeTableTab {
     padding-top:0px;
     padding-left:0px;
     padding-right:0px;
@@ -435,14 +441,15 @@ Table styles
     display:inline;
 }
 .overviewSummary .tabEnd, .memberSummary .tabEnd, .typeSummary .tabEnd,
-.useSummary .tabEnd, .constantsSummary .tabEnd, .deprecatedSummary .tabEnd {
+.useSummary .tabEnd, .constantsSummary .tabEnd, .deprecatedSummary .tabEnd,
+.packagesSummary .tabEnd {
     display:none;
     width:5px;
     position:relative;
     float:left;
     background-color:#F8981D;
 }
-.memberSummary .activeTableTab .tabEnd {
+.memberSummary .activeTableTab .tabEnd, .packagesSummary .activeTableTab .tabEnd {
     display:none;
     width:5px;
     margin-right:3px;
@@ -450,7 +457,7 @@ Table styles
     float:left;
     background-color:#F8981D;
 }
-.memberSummary .tableTab .tabEnd {
+.memberSummary .tableTab .tabEnd, .packagesSummary .tableTab .tabEnd {
     display:none;
     width:5px;
     margin-right:3px;
@@ -460,18 +467,20 @@ Table styles
 
 }
 .overviewSummary td, .memberSummary td, .typeSummary td,
-.useSummary td, .constantsSummary td, .deprecatedSummary td {
+.useSummary td, .constantsSummary td, .deprecatedSummary td,
+.packagesSummary td {
     text-align:left;
     padding:0px 0px 12px 10px;
 }
 th.colOne, th.colFirst, th.colLast, .useSummary th, .constantsSummary th,
-td.colOne, td.colFirst, td.colLast, .useSummary td, .constantsSummary td{
+td.colOne, td.colFirst, td.colLast, .useSummary td, .constantsSummary td,
+.packagesSummary th {
     vertical-align:top;
     padding-right:0px;
     padding-top:8px;
     padding-bottom:3px;
 }
-th.colFirst, th.colLast, th.colOne, .constantsSummary th {
+th.colFirst, th.colLast, th.colOne, .constantsSummary th, .packagesSummary th {
     background:#dee3e9;
     text-align:left;
     padding:8px 3px 3px 7px;
@@ -486,14 +495,21 @@ td.colLast, th.colLast {
 td.colOne, th.colOne {
     font-size:13px;
 }
+.constantsSummary th, .packagesSummary th {
+    font-size:13px;
+}
 .overviewSummary td.colFirst, .overviewSummary th.colFirst,
 .useSummary td.colFirst, .useSummary th.colFirst,
+.packagesSummary td.colFirst, .packagesSummary td.colSecond, .packagesSummary th.colFirst, .packagesSummary th,
 .overviewSummary td.colOne, .overviewSummary th.colOne,
 .memberSummary td.colFirst, .memberSummary th.colFirst,
 .memberSummary td.colOne, .memberSummary th.colOne,
 .typeSummary td.colFirst{
     width:25%;
     vertical-align:top;
+}
+.packagesSummary th.colLast, .packagesSummary td.colLast {
+    white-space:normal;
 }
 td.colOne a:link, td.colOne a:active, td.colOne a:visited, td.colOne a:hover, td.colFirst a:link, td.colFirst a:active, td.colFirst a:visited, td.colFirst a:hover, td.colLast a:link, td.colLast a:active, td.colLast a:visited, td.colLast a:hover, .constantValuesContainer td a:link, .constantValuesContainer td a:active, .constantValuesContainer td a:visited, .constantValuesContainer td a:hover {
     font-weight:bold;


### PR DESCRIPTION
This PR fixes below violation seen in openj9 docs generated using Semeru JDK8.

    1. IBMA_Color_Contrast_WCAG2AA
    Info: Violation Text contrast of 2.21 with its background is less than the WCAG AA minimum requirements for text of size  14px and weight of 700 - 1.4.3 Contrast (Minimum)

    2. WCAG20_Table_CapSummRedundant
    Info: Violation The table summary duplicates the caption - 1.3.1 Info and Relationships 

Note: We've backport for IBMA_Color_Contrast_WCAG2AA which is in a stylesheet.css which contains 4 intermediate backports containing dependent patches being a challenge. Hence, raising the PR with required changes which fixes the violations in JDK8.