### PR TITLE
Improve speed of cipher operations for large inputs and allow unpadding at offset of output

### DIFF
--- a/jdk/src/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/jdk/src/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -892,12 +892,26 @@ final class CipherCore {
         try {
             checkReinit();
             byte[] output = new byte[getOutputSizeByOperation(inputLen, true)];
-            byte[] finalBuf = prepareInputBuffer(input, inputOffset,
-                    inputLen, output, 0);
+            int outputOffset = 0;
+            int outLen = 0;
+
+            if (inputLen > 0) {
+                /*
+                 * Call the update() method to get rid of as many bytes as
+                 * possible before potentially copying array.
+                 */
+                int updateOutLen = update(input, inputOffset, inputLen, output, outputOffset);
+                inputOffset = inputLen;
+                inputLen = 0;
+                outputOffset += updateOutLen;
+                outLen = updateOutLen;
+            }
+
+            byte[] finalBuf = prepareInputBuffer(input, inputOffset, inputLen, output, outputOffset);
             int finalOffset = (finalBuf == input) ? inputOffset : 0;
             int finalBufLen = (finalBuf == input) ? inputLen : finalBuf.length;
 
-            int outLen = fillOutputBuffer(finalBuf, finalOffset, output, 0,
+            outLen += fillOutputBuffer(finalBuf, finalOffset, output, outputOffset,
                     finalBufLen, input);
 
             endDoFinal();
@@ -962,13 +976,6 @@ final class CipherCore {
         int estOutSize = getOutputSizeByOperation(inputLen, true);
         int outputCapacity = checkOutputCapacity(output, outputOffset,
                 estOutSize);
-        int offset = decrypting ? 0 : outputOffset; // 0 for decrypting
-        byte[] finalBuf = prepareInputBuffer(input, inputOffset,
-                inputLen, output, outputOffset);
-        byte[] outWithPadding = null; // for decrypting only
-
-        int finalOffset = (finalBuf == input) ? inputOffset : 0;
-        int finalBufLen = (finalBuf == input) ? inputLen : finalBuf.length;
 
         if (decrypting) {
             // if the size of specified output buffer is less than
@@ -979,14 +986,41 @@ final class CipherCore {
             if (outputCapacity < estOutSize) {
                 cipher.save();
             }
+        }
+
+        int outLen = 0;
+        int estFinalBuffSize = estOutSize;
+        if (inputLen > 0) {
+            /*
+             * Call the update() method to get rid of as many bytes as
+             * possible before potentially copying array.
+             */
+            int updateOutLen = update(input, inputOffset, inputLen, output, outputOffset);
+            inputOffset = inputLen;
+            inputLen = 0;
+            outputOffset += updateOutLen;
+            outLen += updateOutLen;
+            estFinalBuffSize -= updateOutLen;
+        }
+
+        int offset = decrypting ? 0 : outputOffset; // 0 for decrypting
+        byte[] finalBuf = prepareInputBuffer(input, inputOffset,
+                inputLen, output, outputOffset);
+        byte[] outWithPadding = null; // for decrypting only
+
+        int finalOffset = (finalBuf == input) ? inputOffset : 0;
+        int finalBufLen = (finalBuf == input) ? inputLen : finalBuf.length;
+
+        if (decrypting) {
             // create temporary output buffer so that only "real"
             // data bytes are passed to user's output buffer.
-            outWithPadding = new byte[estOutSize];
+            outWithPadding = new byte[estFinalBuffSize];
         }
         byte[] outBuffer = decrypting ? outWithPadding : output;
 
-        int outLen = fillOutputBuffer(finalBuf, finalOffset, outBuffer,
+        int outBuffLen = fillOutputBuffer(finalBuf, finalOffset, outBuffer,
                 offset, finalBufLen, input);
+        outLen += outBuffLen;
 
         if (decrypting) {
 
@@ -999,7 +1033,7 @@ final class CipherCore {
                                                + " bytes needed");
             }
             // copy the result into user-supplied output buffer
-            System.arraycopy(outWithPadding, 0, output, outputOffset, outLen);
+            System.arraycopy(outWithPadding, 0, output, outputOffset, outBuffLen);
             // decrypt mode. Zero out output data that's not required
             Arrays.fill(outWithPadding, (byte) 0x00);
         }
@@ -1015,16 +1049,15 @@ final class CipherCore {
         }
     }
 
-    private int unpad(int outLen, byte[] outWithPadding)
+    private int unpad(int outLen, int off, byte[] outWithPadding)
             throws BadPaddingException {
-        int padStart = padding.unpad(outWithPadding, 0, outLen);
+        int padStart = padding.unpad(outWithPadding, off, outLen);
         if (padStart < 0) {
             throw new BadPaddingException("Given final block not " +
             "properly padded. Such issues can arise if a bad key " +
             "is used during decryption.");
         }
-        outLen = padStart;
-        return outLen;
+        return padStart - off;
     }
 
     private byte[] prepareInputBuffer(byte[] input, int inputOffset,
@@ -1100,7 +1133,7 @@ final class CipherCore {
             len = finalNoPadding(finalBuf, finalOffset, output,
                     outOfs, finalBufLen);
             if (decrypting && padding != null) {
-                len = unpad(len, output);
+                len = unpad(len, outOfs, output);
             }
             return len;
         } finally {


### PR DESCRIPTION
In cases were bytes remain buffered and/or padding is enabled and encryption is performed, the entirety of the input provided in the `doFinal()` methods of the `CipherCore` class would be copied in a buffer with enough space to accommodate the extra bytes requires for buffered bytes and/or padding. The buffer would subsequently be zeroed out for security reasons.

To avoid said actions and improve the performance of the process in case of very large inputs, the updated code calls the `update()` method with as much data as possible before the final steps.

Changes made as part of https://github.com/ibmruntimes/openj9-openjdk-jdk17/commit/d8fc6df82151f89566508fcb9da1e18f9a236527 had to, also, be back-ported to allow unpadding to happen at a specific offset of the output. Those involved adding an extra parameter in the `unpad()` method and using it when invoking the corresponding method of the assigned Padding.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/614

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)