### PR TITLE
macOS: Stop using sprintf in java.desktop

### DIFF
--- a/jdk/src/macosx/native/com/sun/media/sound/PLATFORM_API_MacOSX_Ports.cpp
+++ b/jdk/src/macosx/native/com/sun/media/sound/PLATFORM_API_MacOSX_Ports.cpp
@@ -619,7 +619,7 @@ void PORT_GetControls(void* id, INT32 portIndex, PortControlCreator* creator) {
                     CFRelease(cfname);
                 } else {
                     channelName = (char *)malloc(16);
-                    sprintf(channelName, "Ch %d", ch);
+                    snprintf(channelName, 16, "Ch %d", ch);
                 }
 
                 void* jControls[2];

--- a/jdk/src/macosx/native/sun/font/AWTStrike.m
+++ b/jdk/src/macosx/native/sun/font/AWTStrike.m
@@ -107,7 +107,7 @@ static CGAffineTransform sInverseTX = { 1, 0, 0, -1, 0, 0 };
 #define AWT_FONT_CLEANUP_FINISH                                         \
     if (_fontThrowJavaException == YES) {                               \
         char s[512];                                                    \
-        sprintf(s, "%s-%s:%d", THIS_FILE, __FUNCTION__, __LINE__);       \
+        snprintf(s, sizeof(s), "%s-%s:%d", THIS_FILE, __FUNCTION__, __LINE__);       \
         [JNFException raise:env as:kRuntimeException reason:s];         \
     }
 


### PR DESCRIPTION
This commit backports the changes for macOS from Java 21, replacing sprintf() by snprintf().