### PR TITLE
Set a default thread name for java.util.TimerThread

### DIFF
--- a/jdk/src/share/classes/java/util/Timer.java
+++ b/jdk/src/share/classes/java/util/Timer.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.util;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -497,6 +503,7 @@ class TimerThread extends Thread {
     private TaskQueue queue;
 
     TimerThread(TaskQueue queue) {
+        super("java.util.TimerThread");
         this.queue = queue;
     }
 


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/11930

The name isn't set in the TimerThread constructor, it calls Thread.newName() which consumes the "Thread-0" name. This causes the test to fail because it expects this name. This could have an impact on / confuse users which expect consistent thread names. Depending on the timing of the Attach API AttachHandler / FilelockTimer creation, an application can get different default thread names from run to run.

Backport of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/640