### PR TITLE
Allow loading of OpenSSL 3.x native library for Mac, Windows and AIX

### DIFF
--- a/closed/adds/jdk/src/solaris/native/jdk/crypto/jniprovider/NativeCrypto_md.c
+++ b/closed/adds/jdk/src/solaris/native/jdk/crypto/jniprovider/NativeCrypto_md.c
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2023 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,11 +43,16 @@ void * load_crypto_library(jboolean traceEnabled)
     // Library names for OpenSSL 3.x, 1.1.1, 1.1.0, 1.0.2 and symbolic links
     static const char * const libNames[] = {
 #if defined(_AIX)
+    "libcrypto.a(libcrypto64.so.3)",
+    "libcrypto64.so.3",
+    "libcrypto.a(libcrypto.so.3)",
+    "libcrypto.so.3",
     "libcrypto.a(libcrypto64.so.1.1)",
     "libcrypto.so.1.1",
     "libcrypto.so.1.0.0",
     "libcrypto.a(libcrypto64.so)",
 #elif defined(MACOSX)
+    "libcrypto.3.dylib",
     "libcrypto.1.1.dylib",
     "libcrypto.1.0.0.dylib",
     "libcrypto.dylib"

--- a/jdk/make/CopyFiles.gmk
+++ b/jdk/make/CopyFiles.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
 # ===========================================================================
 
 INCLUDEDIR = $(JDK_OUTPUTDIR)/include
@@ -234,7 +234,7 @@ ifneq ($(OPENSSL_BUNDLE_LIB_PATH), )
     # instead of 'libcrypto.so' files.
     # For reference, corresponding OpenSSL PR is
     #     https://github.com/openssl/openssl/pull/6487
-    LIBCRYPTO_NAMES := libcrypto.so.3 libcrypto.so.1.1 libcrypto.so.1.0.0 libcrypto.a
+    LIBCRYPTO_NAMES := libcrypto64.so.3 libcrypto.so.3 libcrypto.so.1.1 libcrypto.so.1.0.0
   else
     LIBCRYPTO_NAMES := libcrypto.so
   endif


### PR DESCRIPTION
Additional options for potential library files are added to accommodate for use of OpenSSL 3.x in multiple platforms, namely Mac, Windows and AIX.

The list of potential library files to be bundled with OpenJDK for AIX is, also, altered to allow bundling of OpenSSL 3.x while avoiding conflict with other applications that might be using earlier versions.

Additional logic was also added to allow windows to try loading multiple libraries instead of one hardcoded value.

Back-ported from:
https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/616 and
https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/632

Signed-off by: Jason Katonica katonica@us.ibm.com