### PR TITLE
Optimize AES/CBC cipher initialization

### DIFF
--- a/closed/adds/jdk/src/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
+++ b/closed/adds/jdk/src/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2022 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
  * ===========================================================================
  */
 
@@ -55,6 +55,7 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
     protected static ArrayDeque<Integer> avStack = new ArrayDeque<Integer>(numContexts);
 
     private static final NativeCrypto nativeCrypto;
+    private int previousKeyLength = -1;
 
     /*
      * Initialize the CBC context.
@@ -183,7 +184,12 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
 
         int ret;
         synchronized (this) {
-            ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length);
+            if (previousKeyLength == key.length) {
+                ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length, true);
+            } else {
+                ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length, false);
+                previousKeyLength = key.length;
+            }
         }
         if (ret == -1) {
             throw new ProviderException("Error in Native CipherBlockChaining");
@@ -200,7 +206,7 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
         System.arraycopy(iv, 0, r, 0, blockSize);
         int ret;
         synchronized (this) {
-            ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length);
+            ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length, true);
         }
         if (ret == -1) {
             throw new ProviderException("Error in Native CipherBlockChaining");
@@ -224,7 +230,7 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
         System.arraycopy(rSave, 0, r, 0, blockSize);
         int ret;
         synchronized (this) {
-            ret = nativeCrypto.CBCInit(nativeContext, mode, r, r.length, key, key.length);
+            ret = nativeCrypto.CBCInit(nativeContext, mode, r, r.length, key, key.length, true);
         }
         if (ret == -1) {
             throw new ProviderException("Error in Native CipherBlockChaining");

--- a/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -243,7 +243,8 @@ public class NativeCrypto {
                                     byte[] iv,
                                     int ivlen,
                                     byte[] key,
-                                    int keylen);
+                                    int keylen,
+                                    boolean doReset);
 
     public final native int CBCUpdate(long context,
                                       byte[] input,

--- a/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto.c
+++ b/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto.c
@@ -991,7 +991,7 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_CBCDestroyContex
  */
 JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_CBCInit
   (JNIEnv *env, jclass thisObj, jlong c, jint mode, jbyteArray iv, jint iv_len,
-  jbyteArray key, jint key_len) {
+  jbyteArray key, jint key_len, jboolean doReset) {
 
     EVP_CIPHER_CTX *ctx = (EVP_CIPHER_CTX*)(intptr_t) c;
     unsigned char* ivNative = NULL;
@@ -1002,18 +1002,20 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_CBCInit
         return -1;
     }
 
-    switch(key_len) {
-        case 16:
-            evp_cipher1 = (*OSSL_aes_128_cbc)();
-            break;
-        case 24:
-            evp_cipher1 = (*OSSL_aes_192_cbc)();
-            break;
-        case 32:
-            evp_cipher1 = (*OSSL_aes_256_cbc)();
-            break;
-        default:
-            break;
+    if (JNI_FALSE == doReset) {
+        switch (key_len) {
+            case 16:
+                evp_cipher1 = (*OSSL_aes_128_cbc)();
+                break;
+            case 24:
+                evp_cipher1 = (*OSSL_aes_192_cbc)();
+                break;
+            case 32:
+                evp_cipher1 = (*OSSL_aes_256_cbc)();
+                break;
+            default:
+                break;
+        }
     }
 
     ivNative = (unsigned char*)((*env)->GetByteArrayElements(env, iv, 0));
@@ -1034,7 +1036,9 @@ JNIEXPORT jint JNICALL Java_jdk_crypto_jniprovider_NativeCrypto_CBCInit
         return -1;
     }
 
-    (*OSSL_CIPHER_CTX_set_padding)(ctx, 0);
+    if (JNI_FALSE == doReset) {
+        (*OSSL_CIPHER_CTX_set_padding)(ctx, 0);
+    }
 
     (*env)->ReleaseByteArrayElements(env, iv, (jbyte*)ivNative, JNI_ABORT);
     (*env)->ReleaseByteArrayElements(env, key, (jbyte*)keyNative, JNI_ABORT);


### PR DESCRIPTION
The EVP cipher initialization cost has been found to be expensive in the `OpenSSL 3.x` API compared to the `OpenSSL 1.x` API.

This update allows for two different types of initializations to occur. The first initialization type is a full initialization which sets the key, iv, and EVP cipher context. The second type of initialization sets just the key and iv and does NOT recreate and reinitialize the EVP context. The former of these two is required once per Cipher instance, the later of these two can be used whenever we are reusing a specific Java cipher object within methods such as `Cipher.doFinal()`.

Signed-off by: Jason Katonica <katonica@us.ibm.com>