### PR TITLE
Optimize AES/GCM cipher and IV initialization and improve array cleanup code

### DIFF
--- a/closed/adds/jdk/src/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
+++ b/closed/adds/jdk/src/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
@@ -65,7 +65,7 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
         contexts = new long[numContexts];
 
         for (int i = 0; i < numContexts; i++) {
-            long context = nativeCrypto.CBCCreateContext();
+            long context = nativeCrypto.CreateContext();
             if (context == -1) {
                 throw new ProviderException("Error in Native CipherBlockChaining");
             }
@@ -90,7 +90,7 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
              */
             synchronized (NativeCipherBlockChaining.class) {
                 if (ctxIndx == -1) {
-                    long ret = nativeCrypto.CBCDestroyContext(nativeContext);
+                    long ret = nativeCrypto.DestroyContext(nativeContext);
                     if (ret == -1) {
                         throw new ProviderException("Error in Native CipherBlockChaining");
                     }
@@ -108,7 +108,7 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
 
         if (avStack.isEmpty()) {
             cipher.ctxIndx = -1;
-            long context = nativeCrypto.CBCCreateContext();
+            long context = nativeCrypto.CreateContext();
             if (context == -1) {
                 throw new ProviderException("Error in Native CipherBlockChaining");
             }

--- a/closed/adds/jdk/src/share/classes/com/sun/crypto/provider/NativeGaloisCounterMode.java
+++ b/closed/adds/jdk/src/share/classes/com/sun/crypto/provider/NativeGaloisCounterMode.java
@@ -25,19 +25,26 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2021 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
  * ===========================================================================
  */
 
 package com.sun.crypto.provider;
 
-import java.util.Arrays;
-import java.io.*;
-import java.security.*;
-import javax.crypto.*;
-import com.sun.crypto.provider.*;
+import com.sun.crypto.provider.AESCrypt;
 import static com.sun.crypto.provider.AESConstants.AES_BLOCK_SIZE;
+
+import java.io.ByteArrayOutputStream;
+import java.security.InvalidKeyException;
+import java.security.ProviderException;
+
+import javax.crypto.AEADBadTagException;
+import javax.crypto.ShortBufferException;
+import javax.crypto.IllegalBlockSizeException;
+
 import jdk.crypto.jniprovider.NativeCrypto;
+
+import sun.misc.Cleaner;
 
 /**
  * This class represents ciphers in GaloisCounter (GCM) mode.
@@ -54,9 +61,11 @@ import jdk.crypto.jniprovider.NativeCrypto;
  */
 final class NativeGaloisCounterMode extends FeedbackCipher {
 
+    private static final byte[] EMPTY_BUF = new byte[0];
+
     private byte[] key;
     private boolean decrypting;
-    private static final byte[] emptyAAD = new byte[0];
+    private final long context;
 
     static int DEFAULT_TAG_LEN = AES_BLOCK_SIZE;
     static int DEFAULT_IV_LEN = 12; // in bytes
@@ -98,10 +107,33 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
     private byte[] ibufferSave_enc = null;
     private int processedSave = 0;
 
-    private static NativeCrypto nativeCrypto;
+    private byte[] lastKey = EMPTY_BUF;
+    private byte[] lastIv = EMPTY_BUF;
 
-    static {
-        nativeCrypto = NativeCrypto.getNativeCrypto();
+    private boolean newIVLen;
+    private boolean newKeyLen;
+
+    private static final NativeCrypto nativeCrypto = NativeCrypto.getNativeCrypto();
+
+    private static final class GCMCleanerRunnable implements Runnable {
+        private final long nativeContext;
+
+        public GCMCleanerRunnable(long nativeContext) {
+            this.nativeContext = nativeContext;
+        }
+
+        @Override
+        public void run() {
+            /*
+             * Release the GCM context.
+             */
+            synchronized (NativeGaloisCounterMode.class) {
+                long ret = nativeCrypto.DestroyContext(nativeContext);
+                if (ret == -1) {
+                    throw new ProviderException("Error in destroying context in NativeGaloisCounterMode.");
+                }
+            }
+        }
     }
 
     // value must be 16-byte long; used by GCTR and GHASH as well
@@ -203,6 +235,12 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
     NativeGaloisCounterMode(SymmetricCipher embeddedCipher) {
         super(embeddedCipher);
         aadBuffer = new ByteArrayOutputStream();
+
+        context = nativeCrypto.CreateContext();
+        if (context == -1) {
+            throw new ProviderException("Error in creating context for NativeGaloisCounterMode.");
+        }
+        Cleaner.create(this, new GCMCleanerRunnable(context));
     }
 
     /**
@@ -355,6 +393,22 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
             } else {
                 ibuffer_enc = new ByteArrayOutputStream();
             }
+
+            /*
+             * Check whether cipher and IV need to be set,
+             * whether because something changed here or
+             * a call to set them in context hasn't been
+             * made yet.
+             */
+            if (lastIv.length != this.iv.length) {
+                newIVLen = true;
+            }
+            if (lastKey.length != this.key.length) {
+                newKeyLen = true;
+            }
+
+            lastKey = keyValue;
+            lastIv = iv;
         }
     }
 
@@ -465,17 +519,25 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
                 throw new ShortBufferException("Output buffer too small");
             }
 
-            byte[] aad = (((aadBuffer == null) || (aadBuffer.size() == 0)) ? emptyAAD : aadBuffer.toByteArray());
+            byte[] aad = (((aadBuffer == null) || (aadBuffer.size() == 0)) ? EMPTY_BUF : aadBuffer.toByteArray());
 
-            ret = nativeCrypto.GCMEncrypt(key, key.length,
+            ret = nativeCrypto.GCMEncrypt(context,
+                    key, key.length,
                     iv, iv.length,
                     in, inOfs, len,
                     out, outOfs,
-                    aad, aad.length, localTagLenBytes);
+                    aad, aad.length,
+                    localTagLenBytes,
+                    newIVLen,
+                    newKeyLen);
         }
         if (ret == -1) {
             throw new ProviderException("Error in Native GaloisCounterMode");
         }
+
+        /* Cipher and IV length were set, since call to GCMEncrypt succeeded. */
+        newKeyLen = false;
+        newIVLen = false;
 
         return (len + localTagLenBytes);
     }
@@ -552,7 +614,7 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
             }
 
             byte[] aad = (((aadBuffer == null) || (aadBuffer.size() == 0)) ?
-                    emptyAAD : aadBuffer.toByteArray());
+                    EMPTY_BUF : aadBuffer.toByteArray());
 
             aadBuffer = null;
 
@@ -566,11 +628,15 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
             len = in.length;
             ibuffer.reset();
 
-            ret = nativeCrypto.GCMDecrypt(key, key.length,
+            ret = nativeCrypto.GCMDecrypt(context,
+                    key, key.length,
                     iv, iv.length,
                     in, inOfs, len,
                     out, outOfs,
-                    aad, aad.length, tagLenBytes);
+                    aad, aad.length,
+                    tagLenBytes,
+                    newIVLen,
+                    newKeyLen);
         }
 
         if (ret == -2) {
@@ -579,6 +645,9 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
             throw new ProviderException("Error in Native GaloisCounterMode");
         }
 
+        /* Cipher and IV length were set, since call to GCMDecrypt succeeded. */
+        newKeyLen = false;
+        newIVLen = false;
 
         return ret;
     }

--- a/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -232,11 +232,11 @@ public class NativeCrypto {
 
     public final native int DigestReset(long context);
 
-    /* Native CBC interfaces */
+    /* Native interfaces shared by CBC and GCM. */
 
-    public final native long CBCCreateContext();
+    public final native long CreateContext();
 
-    public final native int CBCDestroyContext(long context);
+    public final native int DestroyContext(long context);
 
     public final native int CBCInit(long context,
                                     int mode,
@@ -262,7 +262,8 @@ public class NativeCrypto {
 
     /* Native GCM interfaces */
 
-    public final native int GCMEncrypt(byte[] key,
+    public final native int GCMEncrypt(long context,
+                                       byte[] key,
                                        int keylen,
                                        byte[] iv,
                                        int ivlen,
@@ -273,9 +274,12 @@ public class NativeCrypto {
                                        int outOffset,
                                        byte[] aad,
                                        int aadLen,
-                                       int tagLen);
+                                       int tagLen,
+                                       boolean newIVLen,
+                                       boolean newKeyLen);
 
-    public final native int GCMDecrypt(byte[] key,
+    public final native int GCMDecrypt(long context,
+                                       byte[] key,
                                        int keylen,
                                        byte[] iv,
                                        int ivlen,
@@ -286,7 +290,9 @@ public class NativeCrypto {
                                        int outOffset,
                                        byte[] aad,
                                        int aadLen,
-                                       int tagLen);
+                                       int tagLen,
+                                       boolean newIVLen,
+                                       boolean newKeyLen);
 
     /* Native RSA interfaces */
     public final native long createRSAPublicKey(byte[] n,

--- a/closed/make/mapfiles/libjncrypto/mapfile-vers
+++ b/closed/make/mapfiles/libjncrypto/mapfile-vers
@@ -29,8 +29,8 @@ SUNWprivate_1.1 {
 		Java_jdk_crypto_jniprovider_NativeCrypto_DigestUpdate;
 		Java_jdk_crypto_jniprovider_NativeCrypto_DigestComputeAndReset;
 		Java_jdk_crypto_jniprovider_NativeCrypto_DigestReset;
-		Java_jdk_crypto_jniprovider_NativeCrypto_CBCCreateContext;
-		Java_jdk_crypto_jniprovider_NativeCrypto_CBCDestroyContext;
+		Java_jdk_crypto_jniprovider_NativeCrypto_CreateContext;
+		Java_jdk_crypto_jniprovider_NativeCrypto_DestroyContext;
 		Java_jdk_crypto_jniprovider_NativeCrypto_CBCInit;
 		Java_jdk_crypto_jniprovider_NativeCrypto_CBCUpdate;
 		Java_jdk_crypto_jniprovider_NativeCrypto_CBCFinalEncrypt;


### PR DESCRIPTION
The cipher initialization cost has been found to be computationally expensive, especially in the OpenSSL 3.x API.

In order to optimize the cost of using OpenSSL to perform consecutive AES/GCM encryption and decryption operations, two flags are set and passed as parameters.

The first flag indicates whether a different cipher is required for the upcoming operations (i.e., the key size has changed). If that is the case, a cipher is initialized and set to the provided context. If not, those steps are omitted, thus reducing the time required for the operation.

The second flag indicates whether the IV length has changed and is used in a similar way as the first flag.

The rest of the steps required for the operation are performed regardless of the flags.

The handling of freeing arrays that were part of that functionality is, also, updated to comply with the newer approach to cleanup code.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/655

Signed-off by: Kostas Tsiounis <kostas.tsiounis@ibm.com>