### PR TITLE
Modify get_source.sh to automatically fetch release branches

### DIFF
--- a/closed/get_j9_source.sh
+++ b/closed/get_j9_source.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2023 All Rights Reserved
 # ===========================================================================
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -50,10 +50,19 @@ fi
 declare -A j9repos
 declare -A branches
 declare -A default_j9repos=( [openj9]=eclipse-openj9/openj9 [omr]=eclipse-openj9/openj9-omr )
-declare -A default_branches=( [openj9]=master [omr]=openj9 )
+declare -A default_branches
 declare -A commands
 declare -A shas
 declare -A references
+
+currentbranch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$currentbranch" =~ v[0-9]+\.[0-9]+(\.[0-9]+)?-release ]] ; then
+	default_branches[openj9]=$currentbranch
+	default_branches[omr]=$currentbranch
+else
+	default_branches[openj9]=master
+	default_branches[omr]=openj9
+fi
 
 pflag="false"
 base_git_url=https://github.com


### PR DESCRIPTION
If the current branch matches the pattern of a release branch, fetch openj9/omr branches of the same name.

This will work for a normal release, and can be overwritten for special cases. It avoids having to modify a release branch after creation in order to get the matching openj9/omr release branches. Further changes to the release branch can be pushed rather than merged, as long as the release branch matches the head stream.

Backport of https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/660