### PR TITLE
In test, increase deflate buffer size for zlinux Ubuntu 20

### DIFF
--- a/jdk/test/java/util/zip/DeInflate.java
+++ b/jdk/test/java/util/zip/DeInflate.java
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 /**
  * @test
@@ -110,7 +115,7 @@ public class DeInflate {
 
         byte[] dataIn = new byte[1024 * 512];
         new Random().nextBytes(dataIn);
-        byte[] dataOut1 = new byte[dataIn.length + 1024];
+        byte[] dataOut1 = new byte[dataIn.length + (32 * 1024)]; // See https://github.com/eclipse-openj9/openj9/issues/12740
         byte[] dataOut2 = new byte[dataIn.length];
 
         Deflater defNotWrap = new Deflater(Deflater.DEFAULT_COMPRESSION, false);


### PR DESCRIPTION
jdk/test/java/util/zip/DeInflate.java

Issue https://github.com/eclipse-openj9/openj9/issues/12740 
Fixes https://github.com/eclipse-openj9/openj9/issues/18143

Backport of https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/408

Tested in https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/2900/ which passed