### PR TITLE
Add J9JCL to sourcepath for generating beaninfo

### DIFF
--- a/jdk/make/gensrc/GensrcSwing.gmk
+++ b/jdk/make/gensrc/GensrcSwing.gmk
@@ -22,6 +22,9 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
+# ===========================================================================
+# (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+# ===========================================================================
 
 #
 # Generate java files for javax.swing.plaf package
@@ -77,7 +80,7 @@ $(JDK_OUTPUTDIR)/gensrc_no_srczip/_the.generated_beaninfo: $(BEANS_SRC) \
 	$(ECHO) Generating beaninfo
 	$(MKDIR) -p $(JDK_OUTPUTDIR)/gensrc_no_srczip/javax/swing
 	$(JAVA) -Djava.awt.headless=true $(NEW_JAVADOC) \
-	    -sourcepath "$(JDK_TOPDIR)/src/share/classes$(PATH_SEP)$(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/classes$(PATH_SEP)$(JDK_OUTPUTDIR)/gensrc" \
+	    -sourcepath "$(JDK_TOPDIR)/src/share/classes$(PATH_SEP)$(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/classes$(PATH_SEP)$(JDK_OUTPUTDIR)/gensrc$(PATH_SEP)$(J9JCL_SOURCES_DIR)/jdk/src/share/classes" \
 	    -doclet build.tools.swingbeaninfo.GenDocletBeanInfo \
 	    -x $(SWINGBEAN_DEBUG_FLAG) -d $(JDK_OUTPUTDIR)/gensrc_no_srczip/javax/swing \
 	    -t $(DOCLET_DATA_DIR)/SwingBeanInfo.template -docletpath $(JDK_OUTPUTDIR)/btclasses \


### PR DESCRIPTION
Fixes (apparently benign) errors noted in https://github.com/eclipse-openj9/openj9/issues/18500.