### PR TITLE
Match RI behaviour for MethodHandles.unrelfect with OpenJDK MHs

### DIFF
--- a/jdk/src/share/classes/java/lang/invoke/MethodHandles.java
+++ b/jdk/src/share/classes/java/lang/invoke/MethodHandles.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+ * ===========================================================================
+ */
 
 package java.lang.invoke;
 
@@ -1183,6 +1188,10 @@ return mh1;
                 MethodHandle mh = unreflectForMH(m);
                 if (mh != null)  return mh;
             }
+
+            MethodHandle mh = MethodHandleResolver.maybeCreateAbstractMethodErrorThrower(m);
+            if (mh != null) return mh;
+
             MemberName method = new MemberName(m);
             byte refKind = method.getReferenceKind();
             if (refKind == REF_invokeSpecial)


### PR DESCRIPTION
This patch addresses eclipse-openj9/openj9#14985.
For MethodHandles to private interface methods, the RI erroneously initializes the MethodHandle to have an InvokeInterface reference kind, leading to an invoke-time AbstractMethodError throw.

As per the spec, OpenJ9 initializes MethodHandles to private interface methods to have an InvokeSpecial reference kind which does not throw the error.

This distinction causes a test failure for a test reported in eclipse-openj9/openj9#14985. Though not-spec compliant, the test expects an AbstractMethodError to be thrown to conform to the RI behaviour. For OpenJ9 MHs, MethodHandles.unreflect identifies private interface methods and installs an AbstractMethodError-thrower MH. This patch sets up a similar mechanisms for OpenJDK MHs by calling a MethodHandleResolver method that installs the AbstractMethodError-thrower MH.

Issues: eclipse-openj9/openj9#14985
Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>