### PR TITLE
Update RestrictedSecurity flags, alter debug comments and profile name

### DIFF
--- a/jdk/src/share/lib/security/java.security-linux
+++ b/jdk/src/share/lib/security/java.security-linux
@@ -77,13 +77,15 @@ security.provider.9=sun.security.smartcardio.SunPCSC
 #
 # Java Restricted Security Mode
 #
-RestrictedSecurity1.desc.name = Red Hat Enterprise Linux 8 NSS Cryptographic Module FIPS 140-2
-RestrictedSecurity1.desc.number = Certificate #4413
-RestrictedSecurity1.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4413
-RestrictedSecurity1.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.NSS.140-2.desc.name = Red Hat Enterprise Linux 8 NSS Cryptographic Module FIPS 140-2
+RestrictedSecurity.NSS.140-2.desc.default = true
+RestrictedSecurity.NSS.140-2.desc.fips = true
+RestrictedSecurity.NSS.140-2.desc.number = Certificate #4413
+RestrictedSecurity.NSS.140-2.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4413
+RestrictedSecurity.NSS.140-2.desc.sunsetDate = 2026-09-21
 
-RestrictedSecurity1.tls.disabledNamedCurves =
-RestrictedSecurity1.tls.disabledAlgorithms = \
+RestrictedSecurity.NSS.140-2.tls.disabledNamedCurves =
+RestrictedSecurity.NSS.140-2.tls.disabledAlgorithms = \
     SSLv3, \
     TLS_AES_128_GCM_SHA256, \
     TLS_AES_256_GCM_SHA384, \
@@ -114,13 +116,13 @@ RestrictedSecurity1.tls.disabledAlgorithms = \
     TLSv1.1, \
     X25519, \
     X448
-RestrictedSecurity1.tls.ephemeralDHKeySize =
-RestrictedSecurity1.tls.legacyAlgorithms =
+RestrictedSecurity.NSS.140-2.tls.ephemeralDHKeySize =
+RestrictedSecurity.NSS.140-2.tls.legacyAlgorithms =
 
-RestrictedSecurity1.jce.certpath.disabledAlgorithms =
-RestrictedSecurity1.jce.legacyAlgorithms =
-RestrictedSecurity1.jce.provider.1 = sun.security.pkcs11.SunPKCS11 ${java.home}/lib/security/nss.fips.cfg
-RestrictedSecurity1.jce.provider.2 = sun.security.provider.Sun \
+RestrictedSecurity.NSS.140-2.jce.certpath.disabledAlgorithms =
+RestrictedSecurity.NSS.140-2.jce.legacyAlgorithms =
+RestrictedSecurity.NSS.140-2.jce.provider.1 = sun.security.pkcs11.SunPKCS11 ${java.home}/lib/security/nss.fips.cfg
+RestrictedSecurity.NSS.140-2.jce.provider.2 = sun.security.provider.Sun \
     [{CertificateFactory, X.509, ImplementedIn=Software}, \
     {CertPathBuilder, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}, \
     {CertPathValidator, PKIX, ValidationAlgorithm=RFC5280:ImplementedIn=Software}, \
@@ -128,15 +130,15 @@ RestrictedSecurity1.jce.provider.2 = sun.security.provider.Sun \
     {CertStore, com.sun.security.IndexedCollection, ImplementedIn=Software}, \
     {Configuration, JavaLoginConfig, *}, \
     {Policy, JavaPolicy, *}]
-RestrictedSecurity1.jce.provider.3 = sun.security.ec.SunEC \
+RestrictedSecurity.NSS.140-2.jce.provider.3 = sun.security.ec.SunEC \
     [{AlgorithmParameters, EC, *}, \
     {KeyFactory, EC, ImplementedIn=Software}]
-RestrictedSecurity1.jce.provider.4 = com.sun.net.ssl.internal.ssl.Provider
+RestrictedSecurity.NSS.140-2.jce.provider.4 = com.sun.net.ssl.internal.ssl.Provider
 
-RestrictedSecurity1.keystore.type = PKCS11
-RestrictedSecurity1.javax.net.ssl.keyStore = NONE
+RestrictedSecurity.NSS.140-2.keystore.type = PKCS11
+RestrictedSecurity.NSS.140-2.javax.net.ssl.keyStore = NONE
 
-RestrictedSecurity1.securerandom.algorithm = PKCS11
+RestrictedSecurity.NSS.140-2.securerandom.algorithm = PKCS11
 
 #
 # Sun Provider SecureRandom seed source.


### PR DESCRIPTION
The original flag to enable FIPS (i.e., `-Dsemeru.fips=true`) remains the same, but the one allowing a user to set a custom profile is changed to `-Dsemeru.customprofile=<profile.version>`.

The debug messages have been altered a bit to only be enabled using the already known and used by similar components `-Djava.security.auth.debug` flag. The information for available profiles, as well as the profile used in the particular run, is printed as part of the debug messages, instead of specifying additional properties in the custom profile flag.

Further checks are added to ensure solutions are supported in the running platform and the profile is marked as FIPS compliant.

The flag for the custom profile allows the user to either specify the full name of the profile to be used (e.g., `-Dsemeru.customprofile=NSS.FIPS140-2`), or specify the solution to be used (e.g., `-Dsemeru.customprofile=NSS`) and allow `RestrictedSecurity` to pick the default profile for that.

The naming of profiles has, also, been altered to abide by the `<solution.version>` template (e.g., `NSS.FIPS140-2`), instead of an integer.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/701

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)