### PR TITLE
Exclude subtests for FIPS openjdk8_j9

### DIFF
--- a/jdk/test/ProblemList-FIPS140_2.txt
+++ b/jdk/test/ProblemList-FIPS140_2.txt
@@ -882,3 +882,10 @@ sun/rmi/rmic/manifestClassPath/run.sh                               https://gith
 # The minimum length for an MD5 HMAC key is 16 bytes.
 # However, this test uses a 4 bytes length key for HmacMD5.
 com/sun/crypto/provider/Mac/HmacMD5.java                            https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/611   linux-x64,linux-ppc64le,linux-s390x
+
+# Temporary Exclusion
+# java.security.NoSuchAlgorithmException: MyType TerminalFactory not available
+javax/smartcardio/TerminalFactorySpiTest.java                       https://github.ibm.com/runtimes/backlog/issues/1089             linux-x64,linux-ppc64le,linux-s390x
+
+# java.lang.IllegalArgumentException: EncryptionKey: Key bytes cannot be null!
+sun/security/krb5/etype/WeakCrypto.java                             https://github.ibm.com/runtimes/backlog/issues/1089             linux-x64,linux-ppc64le,linux-s390x


### PR DESCRIPTION
-Exclude `sun/security/krb5/etype/WeakCrypto.java` 
-Exclude `javax/smartcardio/TerminalFactorySpiTest.java`
related: backlog/issues/1089
