### PR TITLE
CRIU removes libj9criu29

### DIFF
--- a/closed/CopyToBuildJdk.gmk
+++ b/closed/CopyToBuildJdk.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -163,7 +163,6 @@ $(call openj9_copy_files_and_debuginfos, \
 
 $(call openj9_copy_shlibs, \
 	cuda4j29 \
-	$(if $(filter true,$(OPENJ9_ENABLE_CRIU_SUPPORT)),j9criu29) \
 	j9dmp29 \
 	j9jextract \
 	j9gc29 \


### PR DESCRIPTION
`CRIU` removes `libj9criu29`

This library is not needed after all its functionalities are moved into `java.base`.

Required by
* https://github.com/eclipse-openj9/openj9/pull/18745


Signed-off-by: Jason Feng <fengj@ca.ibm.com>