### PR TITLE
Fixes return value type in a JNI method

### DIFF
--- a/jdk/src/share/native/com/sun/java/util/jar/pack/jni.cpp
+++ b/jdk/src/share/native/com/sun/java/util/jar/pack/jni.cpp
@@ -22,6 +22,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <sys/types.h>
 
 #include <stdio.h>
@@ -292,7 +299,7 @@ Java_com_sun_java_util_jar_pack_NativeUnpack_getUnusedInput(JNIEnv *env, jobject
 
   if (uPtr->aborting()) {
     THROW_IOE(uPtr->get_abort_message());
-    return false;
+    return null;
   }
 
   // We have fetched all the files.


### PR DESCRIPTION
When compiling with xlclang++ (16.1.0) the following error occurs:
```
openj9-openjdk-jdk8/jdk/src/share/native/com/sun/java/util/jar/pack/jni.cpp:295:12: error: cannot initialize return object of type 'jobject' (aka '_jobject *') with an rvalue of type 'bool'
    return false;
           ^~~~~
1 error generated.
```

The problem is that `Java_com_sun_java_util_jar_pack_NativeUnpack_getUnusedInput` expects a return value of type `jobject`. But, that particular line is returning `false` which is a `bool`.

This fix changes `false` to `null` so the return value type is correct.