### PR TITLE
Add isMD5Available to mapfile

### DIFF
--- a/closed/make/mapfiles/libjncrypto/mapfile-vers
+++ b/closed/make/mapfiles/libjncrypto/mapfile-vers
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -24,6 +24,7 @@
 SUNWprivate_1.1 {
 	global:
 		Java_jdk_crypto_jniprovider_NativeCrypto_loadCrypto;
+		Java_jdk_crypto_jniprovider_NativeCrypto_isMD5Available;
 		Java_jdk_crypto_jniprovider_NativeCrypto_DigestCreateContext;
 		Java_jdk_crypto_jniprovider_NativeCrypto_DigestDestroyContext;
 		Java_jdk_crypto_jniprovider_NativeCrypto_DigestUpdate;


### PR DESCRIPTION
The new method `isMD5Available()`, which was added as part of [this](https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/743) PR, needs to be added to the mapfile to allow it to be built.

Fixes: https://github.com/eclipse-openj9/openj9/issues/19289

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)