### PR TITLE
Check setting of security property when in FIPS mode

### DIFF
--- a/jdk/src/share/classes/java/security/Security.java
+++ b/jdk/src/share/classes/java/security/Security.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2024 All Rights Reserved
  * ===========================================================================
  */
 
@@ -804,6 +804,10 @@ public final class Security {
      */
     public static void setProperty(String key, String datum) {
         check("setProperty."+key);
+
+        // Check whether the change to the property is allowed.
+        RestrictedSecurity.checkSetSecurityProperty(key);
+
         props.put(key, datum);
         invalidateSMCache(key);  /* See below. */
     }


### PR DESCRIPTION
When in `FIPS` mode, calling `Security.setProperty()` should not be allowed when the security property that the user is trying to override is set in the active `RestrictedSecurity` profile. A `SecurityException` is thrown if such an attempt is made.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/773

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)