### PR TITLE
Get native EC key pointer during init through ECUtil instead of key impl

### DIFF
--- a/closed/adds/jdk/src/share/classes/sun/security/ec/NativeECDHKeyAgreement.java
+++ b/closed/adds/jdk/src/share/classes/sun/security/ec/NativeECDHKeyAgreement.java
@@ -39,6 +39,7 @@ import java.security.PrivateKey;
 import java.security.ProviderException;
 import java.security.SecureRandom;
 import java.security.interfaces.ECKey;
+import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.ECParameterSpec;
@@ -64,10 +65,16 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
     private static final Map<String, Boolean> curveSupported = new ConcurrentHashMap<>();
 
     /* private key, if initialized */
-    private ECPrivateKeyImpl privateKey;
+    private ECPrivateKey privateKey;
+
+    /* pointer to native private key, if initialized */
+    private long nativePrivateKey;
 
     /* public key, non-null between doPhase() & generateSecret() only */
-    private ECPublicKeyImpl publicKey;
+    private ECPublicKey publicKey;
+
+    /* pointer to native public key, if initialized */
+    private long nativePublicKey;
 
     /* the type of EC curve */
     private String curve;
@@ -95,8 +102,18 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
         }
         /* attempt to translate the key if it is not an ECKey */
         ECKey ecKey = ECKeyFactory.toECKey(key);
-        if (ecKey instanceof ECPrivateKeyImpl) {
-            this.privateKey = (ECPrivateKeyImpl) ecKey;
+        if (ecKey instanceof ECPrivateKey) {
+            ECPrivateKey ecPrivateKey = (ECPrivateKey) ecKey;
+            this.privateKey = ecPrivateKey;
+            this.nativePrivateKey = NativeECUtil.getPrivateKeyNativePtr(ecPrivateKey);
+            if (this.nativePrivateKey == -1) {
+                if (nativeCryptTrace) {
+                    System.err.println("Init: Could not create a pointer to a native private key."
+                            + " Using Java implementation.");
+                }
+                this.initializeJavaImplementation(key);
+                return;
+            }
 
             ECParameterSpec params = this.privateKey.getParams();
             this.curve = NativeECUtil.getCurveName(params);
@@ -109,8 +126,8 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
             boolean absent = NativeECUtil.putCurveIfAbsent("ECKeyImpl", Boolean.FALSE);
             /* only print the first time a curve is used */
             if (absent && nativeCryptTrace) {
-                System.err.println("Only ECPrivateKeyImpl and ECPublicKeyImpl" +
-                        " are supported by the native implementation, " +
+                System.err.println("Only ECPrivateKey" +
+                        " is supported by the native implementation, " +
                         "using Java crypto implementation for key agreement.");
             }
             this.initializeJavaImplementation(key);
@@ -158,24 +175,27 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
                 ("Key must be a PublicKey with algorithm EC");
         }
 
-        if (key instanceof ECPublicKeyImpl) {
-            this.publicKey = (ECPublicKeyImpl) key;
-
-            int keyLenBits = this.publicKey.getParams().getCurve().getField().getFieldSize();
-            this.secretLen = (keyLenBits + 7) >> 3;
-
-            return null;
-        } else {
-            boolean absent = NativeECUtil.putCurveIfAbsent("ECKeyImpl", Boolean.FALSE);
-            /* only print the first time a curve is used */
-            if (absent && nativeCryptTrace) {
-                System.err.println("Only ECPrivateKeyImpl and ECPublicKeyImpl" +
-                        " are supported by the native implementation, " +
-                        "using Java crypto implementation for key agreement.");
+        ECPublicKey ecKey = (ECPublicKey) key;
+        this.publicKey = ecKey;
+        this.nativePublicKey = NativeECUtil.getPublicKeyNativePtr(ecKey);
+        if (this.nativePublicKey == -1) {
+            if (nativeCryptTrace) {
+                System.err.println("DoPhase: Could not create a pointer to a native public key."
+                        + " Using Java implementation.");
             }
-            this.initializeJavaImplementation(this.privateKey);
-            return this.javaImplementation.engineDoPhase(key, lastPhase);
+            try {
+                this.initializeJavaImplementation(this.privateKey);
+                this.javaImplementation.engineDoPhase(ecKey, true);
+            } catch (InvalidKeyException e) {
+                /* should not happen */
+                throw new InternalError(e);
+            }
         }
+
+        int keyLenBits = this.publicKey.getParams().getCurve().getField().getFieldSize();
+        this.secretLen = (keyLenBits + 7) >> 3;
+
+        return null;
     }
 
     @Override
@@ -209,27 +229,7 @@ public final class NativeECDHKeyAgreement extends KeyAgreementSpi {
         if ((this.privateKey == null) || (this.publicKey == null)) {
             throw new IllegalStateException("Not initialized correctly");
         }
-        long nativePublicKey = this.publicKey.getNativePtr();
-        long nativePrivateKey = this.privateKey.getNativePtr();
-        if ((nativePublicKey == -1) || (nativePrivateKey == -1)) {
-            absent = NativeECUtil.putCurveIfAbsent(this.curve, Boolean.FALSE);
-            if (!absent) {
-                throw new ProviderException("Could not convert keys to native format");
-            }
-            /* only print the first time a curve is used */
-            if (nativeCryptTrace) {
-                System.err.println(this.curve +
-                        " is not supported by OpenSSL, using Java crypto implementation for preparing agreement.");
-            }
-            try {
-                this.initializeJavaImplementation(this.privateKey);
-                this.javaImplementation.engineDoPhase(this.publicKey, true);
-            } catch (InvalidKeyException e) {
-                /* should not happen */
-                throw new InternalError(e);
-            }
-            return this.javaImplementation.engineGenerateSecret(sharedSecret, offset);
-        }
+
         absent = NativeECUtil.putCurveIfAbsent(this.curve, Boolean.TRUE);
         if (absent && nativeCryptTrace) {
             System.err.println(this.curve +

--- a/jdk/src/share/classes/sun/security/ec/ECPrivateKeyImpl.java
+++ b/jdk/src/share/classes/sun/security/ec/ECPrivateKeyImpl.java
@@ -23,12 +23,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
- * ===========================================================================
- */
-
 package sun.security.ec;
 
 import java.io.IOException;
@@ -39,8 +33,6 @@ import java.math.BigInteger;
 import java.security.*;
 import java.security.interfaces.*;
 import java.security.spec.*;
-
-import jdk.crypto.jniprovider.NativeCrypto;
 
 import sun.security.util.ArrayUtil;
 import sun.security.util.DerInputStream;
@@ -77,12 +69,10 @@ import sun.security.pkcs.PKCS8Key;
 public final class ECPrivateKeyImpl extends PKCS8Key implements ECPrivateKey {
 
     private static final long serialVersionUID = 88695385615075129L;
-    private static NativeCrypto nativeCrypto;
 
     private BigInteger s;       // private value
     private byte[] arrayS;      // private value as a little-endian array
     private ECParameterSpec params;
-    private long nativeECKey;
 
     /**
      * Construct a key from its encoding. Called by the ECKeyFactory.
@@ -239,37 +229,5 @@ public final class ECPrivateKeyImpl extends PKCS8Key implements ECPrivateKey {
             throws IOException, ClassNotFoundException {
         throw new InvalidObjectException(
                 "ECPrivateKeyImpl keys are not directly deserializable");
-    }
-
-    /**
-     * Returns the native EC public key context pointer.
-     * @return the native EC public key context pointer or -1 on error
-     */
-    long getNativePtr() {
-        if (this.nativeECKey == 0x0) {
-            synchronized (this) {
-                if (this.nativeECKey == 0x0) {
-                    if (nativeCrypto == null) {
-                        nativeCrypto = NativeCrypto.getNativeCrypto();
-                    }
-                    long nativePointer = NativeECUtil.encodeGroup(this.params);
-                    try {
-                        if (nativePointer != -1) {
-                            byte[] value = this.getS().toByteArray();
-                            if (nativeCrypto.ECCreatePrivateKey(nativePointer, value, value.length) == -1) {
-                                nativeCrypto.ECDestroyKey(nativePointer);
-                                nativePointer = -1;
-                            }
-                        }
-                    } finally {
-                        if (nativePointer != -1) {
-                            nativeCrypto.createECKeyCleaner(this, nativePointer);
-                        }
-                    }
-                    this.nativeECKey = nativePointer;
-                }
-            }
-        }
-        return this.nativeECKey;
     }
 }


### PR DESCRIPTION
The acquisition of a native pointer for an EC key, private or public, is being moved to the ECUtil, instead of the implementation classes of said keys. This allows use of interop keys, rather than just keys coming from SunEC.

The methods to get the pointers to the native keys are called during the initialization phases, to discover the possibility of not being able to utilize the native code and revert to the Java implementation early.

The engineUpdate() methods of the RawECDSA subclass are, also, updated to use the java implementation, if one has been initialized.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/792

Signed-off by: Kostas Tsiounis <kostas.tsiounis@ibm.com>