### PR TITLE
Allow extension of RestrictedSecurity profiles

### DIFF
--- a/jdk/src/share/classes/sun/security/jca/Providers.java
+++ b/jdk/src/share/classes/sun/security/jca/Providers.java
@@ -23,9 +23,17 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.jca;
 
 import java.security.Provider;
+
+import openj9.internal.security.RestrictedSecurity;
 
 /**
  * Collection of methods to get and set provider list. Also includes
@@ -52,6 +60,7 @@ public class Providers {
         // triggers a getInstance() call (although that should not happen)
         providerList = ProviderList.EMPTY;
         providerList = ProviderList.fromSecurityProperties();
+        RestrictedSecurity.checkHashValues();
     }
 
     private Providers() {

--- a/jdk/src/share/lib/security/java.security-linux
+++ b/jdk/src/share/lib/security/java.security-linux
@@ -83,6 +83,7 @@ RestrictedSecurity.NSS.140-2.desc.fips = true
 RestrictedSecurity.NSS.140-2.desc.number = Certificate #4413
 RestrictedSecurity.NSS.140-2.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4413
 RestrictedSecurity.NSS.140-2.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.NSS.140-2.fips.mode = 140-2
 
 RestrictedSecurity.NSS.140-2.tls.disabledNamedCurves =
 RestrictedSecurity.NSS.140-2.tls.disabledAlgorithms = \


### PR DESCRIPTION
`RestrictedSecurity` profiles sometimes share a lot of duplicate settings with only minor differences. With these changes the extension, similar to object-orientation, of profiles becomes possible.

More specifically, a profile `A` can extend another a profile `B`, using `RestrictedSecurity.<profile A name>.extends = RestrictedSecurity.<profile B name>`. This allows profile `A` to inherit all of profile `B`'s properties. One can add additional properties to profile `A`, or amend some of the existing ones. That includes overriding, appending or removing from a property (wherever that's applicable).

An additional property is introduced. The `RestrictedSecurity.<profile name>.desc.hash = <hash algorithm>:<hash>` is used to ensure the profile hasn't been unintentionally altered. The profile's properties are hashed using the selected `<hash algorithm>`, and the result is compared to the `<hash>` provided through the property. This property is mandatory for base profiles (i.e., profiles that are not extending anything), and optional for the rest.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/793

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com) 