### PR TITLE
Ensure static fields set during signed jar process

### DIFF
--- a/jdk/src/share/classes/sun/security/jca/Providers.java
+++ b/jdk/src/share/classes/sun/security/jca/Providers.java
@@ -55,14 +55,6 @@ public class Providers {
     // Note volatile immutable object, so no synchronization needed.
     private static volatile ProviderList providerList;
 
-    static {
-        // set providerList to empty list first in case initialization somehow
-        // triggers a getInstance() call (although that should not happen)
-        providerList = ProviderList.EMPTY;
-        providerList = ProviderList.fromSecurityProperties();
-        RestrictedSecurity.checkHashValues();
-    }
-
     private Providers() {
         // empty
     }
@@ -98,6 +90,14 @@ public class Providers {
         "com.sun.crypto.provider.SunJCE",
         BACKUP_PROVIDER_CLASSNAME,
     };
+
+    static {
+        // set providerList to empty list first in case initialization somehow
+        // triggers a getInstance() call (although that should not happen)
+        providerList = ProviderList.EMPTY;
+        providerList = ProviderList.fromSecurityProperties();
+        RestrictedSecurity.checkHashValues();
+    }
 
     // Return to Sun provider or its backup.
     // This method should only be called by


### PR DESCRIPTION
When loading a signed jar file that is on the classpath, such as the
bouncy castle signed JCE jar file, it has been observed that the value
of `jarVerificationProviders` is set to null. This causes a
NullPointerException during the loading process.

This update moves the static declaration of `jarVerificationProviders`
to be prior to the method call `RestrictedSecurity.checkHashValues()`
since this method call needs the value of the field
`jarVerificationProviders` to be initialized in order to work correctly.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>
