### PR TITLE
Replace some sprintf with snprintf in jdk8

### DIFF
--- a/jdk/src/share/native/common/check_version.c
+++ b/jdk/src/share/native/common/check_version.c
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include "jni.h"
 #include "jvm.h"
@@ -33,7 +38,7 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     if (vm_version != JVM_INTERFACE_VERSION) {
         JNIEnv *env;
         char buf[128];
-        sprintf(buf, "JVM interface version mismatch: expecting %d, got %d.",
+        snprintf(buf, sizeof(buf), "JVM interface version mismatch: expecting %d, got %d.",
                 JVM_INTERFACE_VERSION, (int)vm_version);
         (*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_2);
         if (env) {

--- a/jdk/src/share/native/sun/misc/VM.c
+++ b/jdk/src/share/native/sun/misc/VM.c
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include <string.h>
 
@@ -48,7 +53,7 @@ static void get_thread_state_info(JNIEnv *env, jint state,
 
     values = (*GetThreadStateValues_fp)(env, state);
     if (values == NULL) {
-        sprintf(errmsg, "Mismatched VM version: Thread state (%d) "
+        snprintf(errmsg, sizeof(errmsg), "Mismatched VM version: Thread state (%d) "
                         "not supported", state);
         JNU_ThrowInternalError(env, errmsg);
         return;
@@ -58,7 +63,7 @@ static void get_thread_state_info(JNIEnv *env, jint state,
 
     names = (*GetThreadStateNames_fp)(env, state, values);
     if (names == NULL) {
-        sprintf(errmsg, "Mismatched VM version: Thread state (%d) "
+        snprintf(errmsg, sizeof(errmsg), "Mismatched VM version: Thread state (%d) "
                         "not supported", state);
         JNU_ThrowInternalError(env, errmsg);
         return;
@@ -78,7 +83,7 @@ Java_sun_misc_VM_getThreadStateValues(JNIEnv *env, jclass cls,
     jsize len1 = (*env)->GetArrayLength(env, values);
     jsize len2 = (*env)->GetArrayLength(env, names);
     if (len1 != JAVA_THREAD_STATE_COUNT || len2 != JAVA_THREAD_STATE_COUNT) {
-        sprintf(errmsg, "Mismatched VM version: JAVA_THREAD_STATE_COUNT = %d "
+        snprintf(errmsg, sizeof(errmsg), "Mismatched VM version: JAVA_THREAD_STATE_COUNT = %d "
                 " but JDK expects %d / %d",
                 JAVA_THREAD_STATE_COUNT, len1, len2);
         JNU_ThrowInternalError(env, errmsg);

--- a/jdk/src/share/native/sun/misc/Version.c
+++ b/jdk/src/share/native/sun/misc/Version.c
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include "jni.h"
 #include "jni_util.h"
@@ -40,7 +45,7 @@ static void setStaticIntField(JNIEnv* env, jclass cls, const char* name, jint va
     if (fid != 0) {
         (*env)->SetStaticIntField(env, cls, fid, value);
     } else {
-        sprintf(errmsg, "Static int field %s not found", name);
+        snprintf(errmsg, sizeof(errmsg), "Static int field %s not found", name);
         JNU_ThrowInternalError(env, errmsg);
     }
 }
@@ -53,7 +58,7 @@ static void setStaticBooleanField(JNIEnv* env, jclass cls, const char* name, jbo
     if (fid != 0) {
         (*env)->SetStaticBooleanField(env, cls, fid, value);
     } else {
-        sprintf(errmsg, "Static boolean field %s not found", name);
+        snprintf(errmsg, sizeof(errmsg), "Static boolean field %s not found", name);
         JNU_ThrowInternalError(env, errmsg);
     }
 }
@@ -66,7 +71,7 @@ static void setStaticStringField(JNIEnv* env, jclass cls, const char* name, jstr
     if (fid != 0) {
         (*env)->SetStaticObjectField(env, cls, fid, value);
     } else {
-        sprintf(errmsg, "Static String field %s not found", name);
+        snprintf(errmsg, sizeof(errmsg), "Static String field %s not found", name);
         JNU_ThrowInternalError(env, errmsg);
     }
 }

--- a/jdk/src/solaris/bin/java_md_common.c
+++ b/jdk/src/solaris/bin/java_md_common.c
@@ -22,6 +22,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "java.h"
 
 /*
@@ -249,8 +255,9 @@ static char
     if (best == NULL)
         return (NULL);
     else {
-        ret_str = JLI_MemAlloc(JLI_StrLen(dirname) + JLI_StrLen(best) + 2);
-        sprintf(ret_str, "%s/%s", dirname, best);
+        size_t ret_str_size = JLI_StrLen(dirname) + JLI_StrLen(best) + 2;
+        ret_str = JLI_MemAlloc(ret_str_size);
+        snprintf(ret_str, ret_str_size, "%s/%s", dirname, best);
         JLI_MemFree(best);
         return (ret_str);
     }
@@ -283,9 +290,10 @@ LocateJRE(manifest_info* info)
         path = JLI_StringDup(path);
     } else {
         if ((home = getenv("HOME")) != NULL) {
-            path = (char *)JLI_MemAlloc(JLI_StrLen(home) + \
-                        JLI_StrLen(system_dir) + JLI_StrLen(user_dir) + 2);
-            sprintf(path, "%s%s:%s", home, user_dir, system_dir);
+            size_t path_size = JLI_StrLen(home) + \
+                        JLI_StrLen(system_dir) + JLI_StrLen(user_dir) + 2;
+            path = (char *)JLI_MemAlloc(path_size);
+            snprintf(path, path_size, "%s%s:%s", home, user_dir, system_dir);
         } else {
             path = JLI_StringDup(system_dir);
         }

--- a/jdk/src/solaris/native/java/lang/UNIXProcess_md.c
+++ b/jdk/src/solaris/native/java/lang/UNIXProcess_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -293,6 +293,7 @@ throwIOException(JNIEnv *env, int errnum, const char *defaultDetail)
     static const char * const format = "error=%d, %s";
     const char *detail = defaultDetail;
     char *errmsg;
+    size_t fmtsize;
     char tmpbuf[1024];
     jstring s;
 
@@ -302,11 +303,12 @@ throwIOException(JNIEnv *env, int errnum, const char *defaultDetail)
             detail = tmpbuf;
     }
     /* ASCII Decimal representation uses 2.4 times as many bits as binary. */
-    errmsg = NEW(char, strlen(format) + strlen(detail) + 3 * sizeof(errnum));
+    fmtsize = strlen(format) + strlen(detail) + 3 * sizeof(errnum);
+    errmsg = NEW(char, fmtsize);
     if (errmsg == NULL)
         return;
 
-    sprintf(errmsg, format, errnum, detail);
+    snprintf(errmsg, fmtsize, format, errnum, detail);
     s = JNU_NewStringPlatform(env, errmsg);
     if (s != NULL) {
         jobject x = JNU_NewObjectByName(env, "java/io/IOException",

--- a/jdk/src/solaris/native/sun/tools/attach/LinuxVirtualMachine.c
+++ b/jdk/src/solaris/native/sun/tools/attach/LinuxVirtualMachine.c
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include "jni.h"
 #include "jni_util.h"
@@ -104,7 +109,7 @@ static pid_t getParent(pid_t pid) {
     /*
      * try to open /proc/%d/stat
      */
-    sprintf(fn, "/proc/%d/stat", pid);
+    snprintf(fn, sizeof(fn), "/proc/%d/stat", pid);
     fp = fopen(fn, "r");
     if (fp == NULL) {
         return -1;

--- a/jdk/src/windows/native/sun/net/dns/ResolverConfigurationImpl.c
+++ b/jdk/src/windows/native/sun/net/dns/ResolverConfigurationImpl.c
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include <stdlib.h>
 #include <windows.h>
@@ -147,7 +152,7 @@ static int loadConfig(char *sl, char *ns) {
         while (curr != NULL) {
             char key[MAX_STR_LEN];
 
-            sprintf(key,
+            snprintf(key, sizeof(key),
                 "SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces\\%s",
                 curr->AdapterName);
 

--- a/jdk/src/windows/native/sun/net/spi/DefaultProxySelector.c
+++ b/jdk/src/windows/native/sun/net/spi/DefaultProxySelector.c
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
 
 #include <windows.h>
 #include "jni.h"
@@ -214,7 +219,7 @@ Java_sun_net_spi_DefaultProxySelector_getSystemProxy(JNIEnv *env,
           type_proxy = (*env)->GetStaticObjectField(env, ptype_class, ptype_httpID);
         }
 
-        sprintf(pproto,"%s=", cproto);
+        snprintf(pproto, sizeof(pproto), "%s=", cproto);
         if (isCopy == JNI_TRUE)
           (*env)->ReleaseStringUTFChars(env, proto, cproto);
         /**

--- a/jdk/src/windows/native/sun/tools/attach/WindowsVirtualMachine.c
+++ b/jdk/src/windows/native/sun/tools/attach/WindowsVirtualMachine.c
@@ -22,6 +22,12 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <Sddl.h>
 #include <string.h>
@@ -202,7 +208,7 @@ JNIEXPORT jlong JNICALL Java_sun_tools_attach_WindowsVirtualMachine_openProcess
             } else {
                 char err_mesg[255];
                 /* include the last error in the default detail message */
-                sprintf(err_mesg, "OpenProcess(pid=%d) failed; LastError=0x%x",
+                snprintf(err_mesg, sizeof(err_mesg), "OpenProcess(pid=%d) failed; LastError=0x%x",
                     (int)pid, (int)GetLastError());
                 JNU_ThrowIOExceptionWithLastError(env, err_mesg);
             }


### PR DESCRIPTION
Backport snprintf change from 8074818
8074818: Resolve disabled warnings for libjava
https://github.com/ibmruntimes/openj9-openjdk-jdk8/commit/ed0be89

Replace sprintf with snprintf in base type files that don't appear to be backports from later versions.