### PR TITLE
Fix names of algorithms printed in debug trace

### DIFF
--- a/jdk/src/share/classes/sun/security/ec/SunECEntries.java
+++ b/jdk/src/share/classes/sun/security/ec/SunECEntries.java
@@ -55,18 +55,18 @@ final class SunECEntries {
     /* The property 'jdk.nativeEC' is used to control enablement of the native
      * ECDH implementation.
      */
-    private static final boolean useNativeECDH = NativeCrypto.isAlgorithmEnabled("jdk.nativeEC", "SunEC");
+    private static final boolean useNativeECDH = NativeCrypto.isAlgorithmEnabled("jdk.nativeEC", "ECDH");
 
     /* The property 'jdk.nativeECKeyGen' is used to control enablement of the native
      * ECKeyGeneration implementation.
      * OpenSSL 1.1.0 or above is required for EC key generation support.
      */
-    private static final boolean useNativeECKeyGen = NativeCrypto.isAlgorithmEnabled("jdk.nativeECKeyGen", "SunEC");
+    private static final boolean useNativeECKeyGen = NativeCrypto.isAlgorithmEnabled("jdk.nativeECKeyGen", "ECKeyGen");
 
     /* The property 'jdk.nativeECDSA' is used to control enablement of the native
      * ECDSA signature implementation.
      */
-    private static final boolean useNativeECDSA = NativeCrypto.isAlgorithmEnabled("jdk.nativeECDSA", "SunEC");
+    private static final boolean useNativeECDSA = NativeCrypto.isAlgorithmEnabled("jdk.nativeECDSA", "ECDSA");
 
     private SunECEntries() {
         // empty


### PR DESCRIPTION
The parameter used to indicate the name of the algorithm, whose native implementation's availability is being checked, was incorrectly set to the provider name, leading to incorrect debug trace messages.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/874

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>