### PR TITLE
Check if OpenSSL is in FIPS mode and use Java for some algorithms

### DIFF
--- a/jdk/src/share/classes/sun/security/provider/SunEntries.java
+++ b/jdk/src/share/classes/sun/security/provider/SunEntries.java
@@ -288,7 +288,7 @@ final class SunEntries {
          */
         /* Don't use native MD5 on AIX due to an observed performance regression. */
         if (useNativeMD5
-            && NativeCrypto.isMD5Available()
+            && NativeCrypto.isAlgorithmAvailable("MD5")
             && !isAIX
         ) {
             providerMD5 = "sun.security.provider.NativeMD5";


### PR DESCRIPTION
If the `OpenSSL` library used is in `FIPS` mode, avoid using it for algorithms that are not `FIPS` compliant and revert to the original Java implementation.

Back-ported by: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/867

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>