### PR TITLE
Add NativeCrypto.isOpenSSLFIPS to mapfile-vers

### DIFF
--- a/closed/make/mapfiles/libjncrypto/mapfile-vers
+++ b/closed/make/mapfiles/libjncrypto/mapfile-vers
@@ -52,6 +52,7 @@ SUNWprivate_1.1 {
 		Java_jdk_crypto_jniprovider_NativeCrypto_PBEDerive;
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECDSASign;
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECDSAVerify;
+		Java_jdk_crypto_jniprovider_NativeCrypto_isOpenSSLFIPS;
 	local:
 		*;
 };


### PR DESCRIPTION
This should fix linkage issues.

Related: https://github.com/eclipse-openj9/openj9/pull/20387#issuecomment-2462123661