### PR TITLE
Fix profiles with same name beginnings being treated as one

### DIFF
--- a/closed/adds/jdk/src/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/adds/jdk/src/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -331,10 +331,11 @@ public final class RestrictedSecurity {
             }
             String defaultMatch = null;
             boolean profileExists = false;
+            String profilePrefix = potentialProfileID + '.';
             for (Object keyObject : props.keySet()) {
                 if (keyObject instanceof String) {
                     String key = (String) keyObject;
-                    if (key.startsWith(potentialProfileID)) {
+                    if (key.startsWith(profilePrefix)) {
                         profileExists = true;
                         if (key.endsWith(".desc.default")) {
                             // Check if property is set to true.

--- a/closed/test/jdk/openj9/internal/security/TestProperties.java
+++ b/closed/test/jdk/openj9/internal/security/TestProperties.java
@@ -60,6 +60,11 @@ public class TestProperties {
     @Parameters
     public static List<Object[]> data() {
         return Arrays.asList(new Object[][] {
+            // 1 - Test property - Same beginnings of the profile name without version.
+            {"Test-Profile-SameStartWithoutVersion",
+                System.getProperty("test.src") + "/property-java.security",
+                "(?s)(?=.*Sun)(?=.*\\bSunJCE\\b)(?=.*SunJSSE)", 0},
+
             // 1 - Test profile - base profile misspell properties.
             {"Test-Profile.Base",
                 System.getProperty("test.src") + "/property-java.security",

--- a/closed/test/jdk/openj9/internal/security/property-java.security
+++ b/closed/test/jdk/openj9/internal/security/property-java.security
@@ -514,7 +514,7 @@ RestrictedSecurity.Test-Profile-ConstraintChanged_3.Base.securerandom.algorithm 
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.name = Test-Profile-SameStartWithoutVersion
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.default = true
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.fips = true
-RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.hash = SHA-256:2c893d75043da09c3dba8d8b24cb71dc1c7ceac5fb8bf362a35847418a933a06
+RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.hash = SHA-256:6c5546ec32c83192cf7d8bebfdf9c56049db1c957b5a69a71cb51ba8c1b23a38
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.number = Certificate #XXX
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
 RestrictedSecurity.Test-Profile-SameStartWithoutVersion.desc.sunsetDate = 2026-09-21


### PR DESCRIPTION
Fix the issue where profiles with the same beginnings of profile name are treated as a single profile.

This is a back-port PR from JDKNext PR: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/887