### PR TITLE
Add selected tracepoints for OpenJ9 -Xtrace

### DIFF
--- a/closed/adds/jdk/src/share/native/sun/nio/ch/nio_util.c
+++ b/closed/adds/jdk/src/share/native/sun/nio/ch/nio_util.c
@@ -1,0 +1,38 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+
+#include "jni.h"
+
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_nio.c"
+
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+    UT_JCL_NIO_MODULE_LOADED(J9_UTINTERFACE_FROM_VM((J9JavaVM *)vm));
+
+    return JNI_VERSION_1_2;
+}

--- a/jdk/make/lib/CoreLibraries.gmk
+++ b/jdk/make/lib/CoreLibraries.gmk
@@ -24,7 +24,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2023, 2025 All Rights Reserved
 # ===========================================================================
 
 # Include custom extensions if available.
@@ -151,6 +151,21 @@ LIBJAVA_SRC_DIRS += $(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/native/java/l
     $(JDK_TOPDIR)/src/share/native/java/util/concurrent/atomic \
     $(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/native/common \
     $(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/native/java/util
+
+BUILD_LIBJAVA_check_version.c_CFLAGS := \
+    -I$(OPENJ9_TOPDIR)/runtime/include \
+    -I$(OPENJ9_TOPDIR)/runtime/oti \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR) \
+    -I$(OPENJ9_TOPDIR)/runtime/jcl \
+    -I$(OPENJ9_TOPDIR)/runtime/util \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
+BUILD_LIBJAVA_io_util_md.c_CFLAGS := \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
+BUILD_LIBJAVA_UnixFileSystem_md.c_CFLAGS := \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
 
 ifeq ($(OPENJDK_TARGET_OS), windows)
   LIBJAVA_SRC_DIRS += $(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/native/sun/util/locale/provider

--- a/jdk/make/lib/NetworkingLibraries.gmk
+++ b/jdk/make/lib/NetworkingLibraries.gmk
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
+
 LIBNET_SRC_DIRS := $(JDK_TOPDIR)/src/share/native/java/net \
     $(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/native/java/net \
     $(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/native/sun/net/ \
@@ -36,6 +40,33 @@ else
 endif
 
 LIBNET_CFLAGS := $(foreach dir, $(LIBNET_SRC_DIRS), -I$(dir))
+
+BUILD_LIBNET_aix_close.c_CFLAGS := \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
+BUILD_LIBNET_bsd_close.c_CFLAGS := \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
+BUILD_LIBNET_DualStackPlainSocketImpl.c_CFLAGS := \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
+BUILD_LIBNET_linux_close.c_CFLAGS := \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
+BUILD_LIBNET_net_util.c_CFLAGS := \
+    -I$(OPENJ9_TOPDIR)/runtime/include \
+    -I$(OPENJ9_TOPDIR)/runtime/oti \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR) \
+    -I$(OPENJ9_TOPDIR)/runtime/jcl \
+    -I$(OPENJ9_TOPDIR)/runtime/util \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
+BUILD_LIBNET_PlainSocketImpl.c_CFLAGS := \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
+BUILD_LIBNET_TwoStacksPlainSocketImpl.c_CFLAGS := \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
 
 LIBNET_EXCLUDE_FILES :=
 ifneq ($(OPENJDK_TARGET_OS), linux)

--- a/jdk/make/lib/NioLibraries.gmk
+++ b/jdk/make/lib/NioLibraries.gmk
@@ -23,8 +23,13 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
+
 BUILD_LIBNIO_SRC := \
     $(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/native/java/nio \
+    $(SRC_ROOT)/closed/adds/jdk/src/share/native/sun/nio/ch \
     $(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/native/sun/nio/ch \
     $(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/native/sun/nio/fs
 
@@ -33,6 +38,24 @@ BUILD_LIBNIO_CFLAGS := \
     -I$(JDK_TOPDIR)/src/share/native/java/io \
     -I$(JDK_TOPDIR)/src/share/native/java/net \
     -I$(JDK_TOPDIR)/src/$(OPENJDK_TARGET_OS_API_DIR)/native/java/net
+
+BUILD_LIBNIO_FileDispatcherImpl.c_CFLAGS := \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
+BUILD_LIBNIO_Net.c_CFLAGS := \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
+BUILD_LIBNIO_nio_util.c_CFLAGS := \
+    -I$(OPENJ9_TOPDIR)/runtime/include \
+    -I$(OPENJ9_TOPDIR)/runtime/oti \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR) \
+    -I$(OPENJ9_TOPDIR)/runtime/jcl \
+    -I$(OPENJ9_TOPDIR)/runtime/util \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
+BUILD_LIBNIO_SocketDispatcher.c_CFLAGS := \
+    -I$(OPENJ9OMR_TOPDIR)/include_core \
+    -I$(OPENJ9_VM_BUILD_DIR)/jcl
 
 BUILD_LIBNIO_FILES := \
     DatagramChannelImpl.c \
@@ -43,6 +66,7 @@ BUILD_LIBNIO_FILES := \
     IOUtil.c \
     MappedByteBuffer.c \
     Net.c \
+    nio_util.c \
     ServerSocketChannelImpl.c \
     SocketChannelImpl.c \
     SocketDispatcher.c

--- a/jdk/make/mapfiles/libnio/mapfile-linux
+++ b/jdk/make/mapfiles/libnio/mapfile-linux
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
+
 SUNWprivate_1.1 {
 	global:
                 Java_java_nio_MappedByteBuffer_force0;
@@ -203,6 +207,7 @@ SUNWprivate_1.1 {
 		Java_sun_nio_fs_UnixNativeDispatcher_getpwnam0;
 		Java_sun_nio_fs_UnixNativeDispatcher_getgrnam0;
 		Java_sun_nio_fs_UnixCopyFile_transfer;
+		JNI_OnLoad;
 		handleSocketError;
 
 	local:

--- a/jdk/make/mapfiles/libnio/mapfile-macosx
+++ b/jdk/make/mapfiles/libnio/mapfile-macosx
@@ -23,6 +23,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
+
 SUNWprivate_1.1 {
 	global:
                 Java_java_nio_MappedByteBuffer_force0;
@@ -175,6 +179,7 @@ SUNWprivate_1.1 {
 		Java_sun_nio_fs_UnixNativeDispatcher_getpwnam0;
 		Java_sun_nio_fs_UnixNativeDispatcher_getgrnam0;
 		Java_sun_nio_fs_UnixCopyFile_transfer;
+		JNI_OnLoad;
 		handleSocketError;
 
 	local:

--- a/jdk/src/share/native/common/check_version.c
+++ b/jdk/src/share/native/common/check_version.c
@@ -24,12 +24,17 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2024, 2025 All Rights Reserved
  * ===========================================================================
  */
 
 #include "jni.h"
 #include "jvm.h"
+
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_java.c"
 
 JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved)
@@ -45,5 +50,8 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
             (*env)->FatalError(env, buf);
         }
     }
+
+    UT_JCL_JAVA_MODULE_LOADED(J9_UTINTERFACE_FROM_VM((J9JavaVM *)vm));
+
     return JNI_VERSION_1_2;
 }

--- a/jdk/src/share/native/java/net/net_util.c
+++ b/jdk/src/share/native/java/net/net_util.c
@@ -23,10 +23,21 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include "jni.h"
 #include "jvm.h"
 #include "jni_util.h"
 #include "net_util.h"
+
+#include "j9access.h"
+/* tracehelp.c defines getTraceInterfaceFromVM(), used by J9_UTINTERFACE_FROM_VM(). */
+#include "tracehelp.c"
+#include "ut_jcl_net.c"
 
 int IPv6_supported() ;
 
@@ -53,6 +64,9 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
             return JNI_VERSION_1_2;
         }
     }
+
+    UT_JCL_NET_MODULE_LOADED(J9_UTINTERFACE_FROM_VM((J9JavaVM *)vm));
+
     iCls = (*env)->FindClass(env, "java/lang/Boolean");
     CHECK_NULL_RETURN(iCls, JNI_VERSION_1_2);
     mid = (*env)->GetStaticMethodID(env, iCls, "getBoolean", "(Ljava/lang/String;)Z");

--- a/jdk/src/solaris/native/java/io/UnixFileSystem_md.c
+++ b/jdk/src/solaris/native/java/io/UnixFileSystem_md.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <assert.h>
 #include <sys/types.h>
 #include <sys/time.h>
@@ -41,6 +47,8 @@
 #include "io_util_md.h"
 #include "java_io_FileSystem.h"
 #include "java_io_UnixFileSystem.h"
+
+#include "ut_jcl_java.h"
 
 #if defined(_ALLBSD_SOURCE)
 #define dirent64 dirent
@@ -255,6 +263,7 @@ Java_java_io_UnixFileSystem_createFileExclusively(JNIEnv *env, jclass cls,
                 if (errno != EEXIST)
                     JNU_ThrowIOExceptionWithLastError(env, path);
             } else {
+                Trc_io_UnixFileSystem_createFileExclusively_close(fd);
                 if (close(fd) == -1)
                     JNU_ThrowIOExceptionWithLastError(env, path);
                 rv = JNI_TRUE;

--- a/jdk/src/solaris/native/java/io/io_util_md.c
+++ b/jdk/src/solaris/native/java/io/io_util_md.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #if defined(__linux__)
 #define _FILE_OFFSET_BITS 64
 #endif
@@ -42,6 +48,8 @@
 #if defined(__linux__) || defined(_ALLBSD_SOURCE) || defined(_AIX)
 #include <sys/ioctl.h>
 #endif
+
+#include "ut_jcl_java.h"
 
 #ifdef MACOSX
 
@@ -93,6 +101,11 @@ handleOpen(const char *path, int oflag, int mode) {
             close(fd);
             fd = -1;
         }
+    }
+    if (-1 == fd) {
+        Trc_io_handleOpen_err(path, oflag, mode, 0, 0, errno);
+    } else {
+        Trc_io_handleOpen(path, oflag, mode, 0, 0, (jlong)fd);
     }
     return fd;
 }
@@ -148,8 +161,12 @@ fileClose(JNIEnv *env, jobject this, jfieldID fid)
             dup2(devnull, fd);
             close(devnull);
         }
+        Trc_io_fileDescriptorClose((jlong)fd);
     } else if (close(fd) == -1) {
+        Trc_io_fileDescriptorClose_err((jlong)fd, errno);
         JNU_ThrowIOExceptionWithLastError(env, "close failed");
+    } else {
+        Trc_io_fileDescriptorClose((jlong)fd);
     }
 }
 

--- a/jdk/src/solaris/native/java/net/PlainSocketImpl.c
+++ b/jdk/src/solaris/native/java/net/PlainSocketImpl.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <errno.h>
 #include <string.h>
 #include <sys/types.h>
@@ -36,6 +42,7 @@
 #include <netinet/ip.h>
 #endif
 #include <netdb.h>
+#include <arpa/inet.h>
 #include <stdlib.h>
 
 #ifdef __solaris__
@@ -51,6 +58,8 @@
 
 #include "java_net_SocketOptions.h"
 #include "java_net_PlainSocketImpl.h"
+
+#include "ut_jcl_net.h"
 
 /************************************************************************
  * PlainSocketImpl
@@ -362,6 +371,14 @@ Java_java_net_PlainSocketImpl_socketConnect(JNIEnv *env, jobject this,
          * established, fail, or timeout.
          */
         SET_NONBLOCKING(fd);
+
+        if (AF_INET == him.him4.sin_family) {
+            char buf[INET_ADDRSTRLEN];
+            Trc_PlainSocketImpl_socketConnect4("", fd, inet_ntop(AF_INET, &him.him4.sin_addr, buf, sizeof(buf)), port, len);
+        } else if (AF_INET6 == him.him6.sin6_family) {
+            char buf[INET6_ADDRSTRLEN];
+            Trc_PlainSocketImpl_socketConnect6("", fd, inet_ntop(AF_INET6, &him.him6.sin6_addr, buf, sizeof(buf)), port, ntohl(him.him6.sin6_scope_id), len);
+        }
 
         /* no need to use NET_Connect as non-blocking */
         connect_rv = connect(fd, (struct sockaddr *)&him, len);

--- a/jdk/src/solaris/native/java/net/bsd_close.c
+++ b/jdk/src/solaris/native/java/net/bsd_close.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <assert.h>
 #include <limits.h>
 #include <stdio.h>
@@ -39,6 +45,9 @@
 #include <unistd.h>
 #include <errno.h>
 #include <sys/poll.h>
+#include <arpa/inet.h>
+
+#include "ut_jcl_net.h"
 
 /*
  * Stack allocated by thread when doing blocking operation
@@ -341,6 +350,7 @@ int NET_Dup2(int fd, int fd2) {
  * preempted and the I/O system call will return -1/EBADF.
  */
 int NET_SocketClose(int fd) {
+    Trc_NET_SocketClose(fd);
     return closefd(-1, fd);
 }
 
@@ -407,6 +417,15 @@ int NET_Accept(int s, struct sockaddr *addr, int *addrlen) {
 }
 
 int NET_Connect(int s, struct sockaddr *addr, int addrlen) {
+    if (AF_INET == addr->sa_family) {
+        char buf[INET_ADDRSTRLEN];
+        struct sockaddr_in *sa = (struct sockaddr_in *)addr;
+        Trc_NET_Connect4(s, inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf)), ntohs(sa->sin_port), addrlen);
+    } else if (AF_INET6 == addr->sa_family) {
+        char buf[INET6_ADDRSTRLEN];
+        struct sockaddr_in6 *sa = (struct sockaddr_in6 *)addr;
+        Trc_NET_Connect6(s, inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)), ntohs(sa->sin6_port), ntohl(sa->sin6_scope_id), addrlen);
+    }
     BLOCKING_IO_RETURN_INT( s, connect(s, addr, addrlen) );
 }
 

--- a/jdk/src/solaris/native/java/net/linux_close.c
+++ b/jdk/src/solaris/native/java/net/linux_close.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <assert.h>
 #include <limits.h>
 #include <stdio.h>
@@ -37,6 +43,9 @@
 #include <unistd.h>
 #include <errno.h>
 #include <sys/poll.h>
+#include <arpa/inet.h>
+
+#include "ut_jcl_net.h"
 
 /*
  * Stack allocated by thread when doing blocking operation
@@ -337,6 +346,7 @@ int NET_Dup2(int fd, int fd2) {
  * preempted and the I/O system call will return -1/EBADF.
  */
 int NET_SocketClose(int fd) {
+    Trc_NET_SocketClose(fd);
     return closefd(-1, fd);
 }
 
@@ -402,6 +412,15 @@ int NET_Accept(int s, struct sockaddr *addr, int *addrlen) {
 }
 
 int NET_Connect(int s, struct sockaddr *addr, int addrlen) {
+    if (AF_INET == addr->sa_family) {
+        char buf[INET_ADDRSTRLEN];
+        struct sockaddr_in *sa = (struct sockaddr_in *)addr;
+        Trc_NET_Connect4(s, inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf)), ntohs(sa->sin_port), addrlen);
+    } else if (AF_INET6 == addr->sa_family) {
+        char buf[INET6_ADDRSTRLEN];
+        struct sockaddr_in6 *sa = (struct sockaddr_in6 *)addr;
+        Trc_NET_Connect6(s, inet_ntop(AF_INET6, &sa->sin6_addr, buf, sizeof(buf)), ntohs(sa->sin6_port), ntohl(sa->sin6_scope_id), addrlen);
+    }
     BLOCKING_IO_RETURN_INT( s, connect(s, addr, addrlen) );
 }
 

--- a/jdk/src/solaris/native/sun/nio/ch/FileDispatcherImpl.c
+++ b/jdk/src/solaris/native/sun/nio/ch/FileDispatcherImpl.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #if defined(__linux__)
 #define _FILE_OFFSET_BITS 64
 #endif
@@ -62,6 +68,8 @@
 #include "nio_util.h"
 #include "sun_nio_ch_FileDispatcherImpl.h"
 #include "java_lang_Long.h"
+
+#include "ut_jcl_nio.h"
 
 static int preCloseFD = -1;     /* File descriptor to which we dup other fd's
                                    before closing them for real */
@@ -284,6 +292,7 @@ Java_sun_nio_ch_FileDispatcherImpl_release0(JNIEnv *env, jobject this,
 
 static void closeFileDescriptor(JNIEnv *env, int fd) {
     if (fd != -1) {
+        Trc_nio_ch_FileDispatcherImpl_close(fd);
         int result = close(fd);
         if (result < 0)
             JNU_ThrowIOExceptionWithLastError(env, "Close failed");

--- a/jdk/src/windows/native/java/net/DualStackPlainSocketImpl.c
+++ b/jdk/src/windows/native/java/net/DualStackPlainSocketImpl.c
@@ -22,11 +22,20 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <winsock2.h>
 #include "jni.h"
 #include "net_util.h"
 #include "java_net_DualStackPlainSocketImpl.h"
+
+#include "ut_jcl_net.h"
 
 #define SET_BLOCKING 0
 #define SET_NONBLOCKING 1
@@ -117,6 +126,14 @@ JNIEXPORT jint JNICALL Java_java_net_DualStackPlainSocketImpl_connect0
     if (NET_InetAddressToSockaddr(env, iaObj, port, (struct sockaddr *)&sa,
                                  &sa_len, JNI_TRUE) != 0) {
       return -1;
+    }
+
+    if (AF_INET == sa.him4.sin_family) {
+        char buf[INET_ADDRSTRLEN];
+        Trc_PlainSocketImpl_socketConnect4("DualStack ", fd, inet_ntop(AF_INET, &sa.him4.sin_addr, buf, sizeof(buf)), port, sa_len);
+    } else if (AF_INET6 == sa.him6.sin6_family) {
+        char buf[INET6_ADDRSTRLEN];
+        Trc_PlainSocketImpl_socketConnect6("DualStack ", fd, inet_ntop(AF_INET6, &sa.him6.sin6_addr, buf, sizeof(buf)), port, ntohl(sa.him6.sin6_scope_id), sa_len);
     }
 
     rv = connect(fd, (struct sockaddr *)&sa, sa_len);
@@ -349,6 +366,7 @@ JNIEXPORT jint JNICALL Java_java_net_DualStackPlainSocketImpl_available0
  */
 JNIEXPORT void JNICALL Java_java_net_DualStackPlainSocketImpl_close0
   (JNIEnv *env, jclass clazz, jint fd) {
+     Trc_PlainSocketImpl_socketClose("DualStack ", fd);
      NET_SocketClose(fd);
 }
 

--- a/jdk/src/windows/native/java/net/TwoStacksPlainSocketImpl.c
+++ b/jdk/src/windows/native/java/net/TwoStacksPlainSocketImpl.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <winsock2.h>
 #include <ctype.h>
@@ -40,6 +46,8 @@
 #include "jvm.h"
 #include "net_util.h"
 #include "jni_util.h"
+
+#include "ut_jcl_net.h"
 
 /************************************************************************
  * TwoStacksPlainSocketImpl
@@ -257,6 +265,14 @@ Java_java_net_TwoStacksPlainSocketImpl_socketConnect(JNIEnv *env, jobject this,
         }
     }
     (*env)->SetObjectField(env, this, psi_fd1ID, NULL);
+
+    if (AF_INET == family) {
+        char buf[INET_ADDRSTRLEN];
+        Trc_PlainSocketImpl_socketConnect4("TwoStacks ", fd, inet_ntop(AF_INET, &him.him4.sin_addr, buf, sizeof(buf)), port, len);
+    } else if (AF_INET6 == family) {
+        char buf[INET6_ADDRSTRLEN];
+        Trc_PlainSocketImpl_socketConnect6("TwoStacks ", fd, inet_ntop(AF_INET6, &him.him6.sin6_addr, buf, sizeof(buf)), port, ntohl(him.him6.sin6_scope_id), len);
+    }
 
     if (timeout <= 0) {
         connect_res = connect(fd, (struct sockaddr *) &him, SOCKETADDRESS_LEN(&him));
@@ -826,10 +842,12 @@ Java_java_net_TwoStacksPlainSocketImpl_socketClose0(JNIEnv *env, jobject this,
         fd1 = (*env)->GetIntField(env, fd1Obj, IO_fd_fdID);
     }
     if (fd != -1) {
+        Trc_PlainSocketImpl_socketClose("", fd);
         (*env)->SetIntField(env, fdObj, IO_fd_fdID, -1);
         NET_SocketClose(fd);
     }
     if (fd1 != -1) {
+        Trc_PlainSocketImpl_socketClose("fd1 ", fd1);
         (*env)->SetIntField(env, fd1Obj, IO_fd_fdID, -1);
         NET_SocketClose(fd1);
     }

--- a/jdk/src/windows/native/sun/nio/ch/FileDispatcherImpl.c
+++ b/jdk/src/windows/native/sun/nio/ch/FileDispatcherImpl.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include "jni.h"
 #include "jni_util.h"
@@ -33,6 +39,8 @@
 #include "nio.h"
 #include "nio_util.h"
 #include "jlong.h"
+
+#include "ut_jcl_nio.h"
 
 
 /**************************************************************
@@ -469,6 +477,7 @@ Java_sun_nio_ch_FileDispatcherImpl_release0(JNIEnv *env, jobject this,
 static void closeFile(JNIEnv *env, jlong fd) {
     HANDLE h = (HANDLE)fd;
     if (h != INVALID_HANDLE_VALUE) {
+        Trc_nio_ch_FileDispatcherImpl_close(fd);
         int result = CloseHandle(h);
         if (result < 0)
             JNU_ThrowIOExceptionWithLastError(env, "Close failed");

--- a/jdk/src/windows/native/sun/nio/ch/Net.c
+++ b/jdk/src/windows/native/sun/nio/ch/Net.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <winsock2.h>
 #include "jni.h"
@@ -36,6 +42,8 @@
 
 #include "sun_nio_ch_Net.h"
 #include "sun_nio_ch_PollArrayWrapper.h"
+
+#include "ut_jcl_nio.h"
 
 /**
  * Definitions to allow for building with older SDK include files.
@@ -206,6 +214,14 @@ Java_sun_nio_ch_Net_connect0(JNIEnv *env, jclass clazz, jboolean preferIPv6, job
 
     if (NET_InetAddressToSockaddr(env, iao, port, (struct sockaddr *)&sa, &sa_len, preferIPv6) != 0) {
         return IOS_THROWN;
+    }
+
+    if (AF_INET == sa.him4.sin_family) {
+        char buf[INET_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect4((jlong)s, inet_ntop(AF_INET, &sa.him4.sin_addr, buf, sizeof(buf)), port, sa_len);
+    } else if (AF_INET6 == sa.him6.sin6_family) {
+        char buf[INET6_ADDRSTRLEN];
+        Trc_nio_ch_Net_connect6((jlong)s, inet_ntop(AF_INET6, &sa.him6.sin6_addr, buf, sizeof(buf)), port, ntohl(sa.him6.sin6_scope_id), sa_len);
     }
 
     rv = connect(s, (struct sockaddr *)&sa, sa_len);

--- a/jdk/src/windows/native/sun/nio/ch/SocketDispatcher.c
+++ b/jdk/src/windows/native/sun/nio/ch/SocketDispatcher.c
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
 #include <windows.h>
 #include <winsock2.h>
 #include <ctype.h>
@@ -33,6 +39,8 @@
 #include "sun_nio_ch_SocketDispatcher.h"
 #include "nio.h"
 #include "nio_util.h"
+
+#include "ut_jcl_nio.h"
 
 
 /**************************************************************
@@ -282,6 +290,7 @@ Java_sun_nio_ch_SocketDispatcher_close0(JNIEnv *env, jclass clazz,
                                          jobject fdo)
 {
     jint fd = fdval(env, fdo);
+    Trc_nio_ch_SocketDispatcher_close(fd);
     if (closesocket(fd) == SOCKET_ERROR) {
         JNU_ThrowIOExceptionWithLastError(env, "Socket close failed");
     }


### PR DESCRIPTION
Depends on https://github.com/eclipse-openj9/openj9/pull/20936

Issue https://github.ibm.com/runtimes/semeru-requests/issues/46

Backport of https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/243

Linux java(io) tracepoints
```
20:44:47.651 0x25a00        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0xc2, sharing=0x1b6, creation=0x0, attributes=0x0, handle=22)
20:44:47.651 0x25a00        jcl_java.4         - io_createFileExclusively_close(handle=22)
20:44:47.651 0x25a00        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x241, sharing=0x1b6, creation=0x0, attributes=0x0, handle=22)
20:44:47.651 0x25a00        jcl_java.0         - io_fileDescriptorClose(handle=22)
```
Linux net tracepoints
```
20:33:44.238*0x25a00         jcl_net.1         - NET_Connect(descriptor=15, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=39451 scope_id=0), length=28)
20:33:44.239 0x25a00         jcl_net.2         - NET_SocketClose(descriptor=15)

20:36:49.028*0x25a00         jcl_net.0         - NET_Connect(descriptor=15, connect_to(AF_INET: addr=127.0.0.1 port=37669), length=16)
20:36:49.028 0x25a00         jcl_net.2         - NET_SocketClose(descriptor=15)
```
Linux nio tracepoints
```
20:34:33.088*0x25a00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=22, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=45177 scope_id=0), length=28)
20:34:33.089 0x25a00         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=22)

20:36:14.730*0x25a00         jcl_nio.0         - nio_ch_Net_Connect(descriptor=21, connect_to(AF_INET: addr=127.0.0.1 port=34381), length=16)
20:36:14.731 0x25a00         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=21)
```

Windows java(io) tracepoints
```
21:17:55.513 0x25a00        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x40000000, sharing=0x3, creation=0x2, attributes=0x80, handle=2100)
21:17:55.513 0x25a00        jcl_java.0         - io_fileDescriptorClose(handle=2100)
```
Windows net tracepoints
```
20:42:18.973*0x25a00         jcl_net.4         - PlainSocketImpl_socketConnect(DualStack descriptor=2084, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=58376 scope_id=0), length=28)
20:42:18.974 0x25a00         jcl_net.5         - PlainSocketImpl_socketClose(DualStack descriptor=2084)

20:44:04.898*0x25a00         jcl_net.3         - PlainSocketImpl_socketConnect(TwoStacks descriptor=2036, connect_to(AF_INET: addr=127.0.0.1 port=58395), length=16)
20:44:04.898 0x25a00         jcl_net.5         - PlainSocketImpl_socketClose(descriptor=2036)
```
Windows nio tracepoints
```
20:43:05.217*0x25a00         jcl_nio.1         - nio_ch_Net_Connect(descriptor=2100, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=58382 scope_id=0), length=28)
20:43:05.217 0x25a00         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2100)

20:43:43.442*0x25a00         jcl_nio.0         - nio_ch_Net_Connect(descriptor=2060, connect_to(AF_INET: addr=127.0.0.1 port=58391), length=16)
20:43:43.442 0x25a00         jcl_nio.4         - nio_ch_SocketDispatcher_close(descriptor=2060)
```

xmac java(io) tracepoints
```
19:10:58.046 0x7f21000        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0xa02, sharing=0x1b6, creation=0x0, attributes=0x0, handle=20)
19:10:58.046 0x7f21000        jcl_java.4         - io_createFileExclusively_close(handle=20)
19:10:58.046 0x7f21000        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x601, sharing=0x1b6, creation=0x0, attributes=0x0, handle=20)
19:10:58.046 0x7f21000        jcl_java.0         - io_fileDescriptorClose(handle=20)
```

xmac net tracpoints
```
21:37:10.164*0x13588500         jcl_net.1         - NET_Connect(descriptor=14, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=61764 scope_id=0), length=28)
21:37:10.164 0x13588500         jcl_net.2         - NET_SocketClose(descriptor=14)

21:39:59.927*0xa022500         jcl_net.0         - NET_Connect(descriptor=14, connect_to(AF_INET: addr=127.0.0.1 port=61767), length=16)
21:39:59.928 0xa022500         jcl_net.2         - NET_SocketClose(descriptor=14)
```

xmac nio tracepoints
```
19:11:52.798*0x1b303000         jcl_nio.1         - nio_ch_Net_Connect(descriptor=20, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=55700 scope_id=0), length=28)
19:11:52.801 0x1b303000         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=20)

19:14:41.534*0xda73000         jcl_nio.0         - nio_ch_Net_Connect(descriptor=20, connect_to(AF_INET: addr=127.0.0.1 port=55709), length=16)
19:14:41.538 0xda73000         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=20)
```

AIX java(io) tracepoints
```
19:08:14.186 0x30010700        jcl_java.2         - io_handleOpen(filename=myfile.txt, access=0x502, sharing=0x1b6, creation=0x0, attributes=0x0, handle=17)
19:08:14.186 0x30010700        jcl_java.4         - io_createFileExclusively_close(handle=17)
19:08:14.186 0x30010700        jcl_java.2         - io_handleOpen(filename=myfile2.txt, access=0x301, sharing=0x1b6, creation=0x0, attributes=0x0, handle=17)
19:08:14.187 0x30010700        jcl_java.0         - io_fileDescriptorClose(handle=17)
```

AIX net tracepoints
```
02:11:41.304*0x30010700         jcl_net.1         - NET_Connect(descriptor=11, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=43613 scope_id=0), length=28)
02:11:41.305 0x30010700         jcl_net.2         - NET_SocketClose(descriptor=11)

02:12:21.644*0x30010700         jcl_net.0         - NET_Connect(descriptor=12, connect_to(AF_INET: addr=127.0.0.1 port=43616), length=16)
02:12:21.645 0x30010700         jcl_net.2         - NET_SocketClose(descriptor=12)
```

AIX nio tracepoints
```
19:09:22.459*0x30010700         jcl_nio.1         - nio_ch_Net_Connect(descriptor=9, connect_to(AF_INET6: addr=::ffff:127.0.0.1 port=40894 scope_id=0), length=28)
19:09:22.460 0x30010700         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=9)

19:09:52.063*0x30010700         jcl_nio.0         - nio_ch_Net_Connect(descriptor=17, connect_to(AF_INET: addr=127.0.0.1 port=40897), length=16)
19:09:52.064 0x30010700         jcl_nio.5         - nio_ch_FileDispatcherImpl_close(descriptor=17)
```