### PR TITLE
Backport 8347740: java/io/File/createTempFile/SpecialTempFile.java failing

### DIFF
--- a/jdk/test/java/io/File/createTempFile/SpecialTempFile.java
+++ b/jdk/test/java/io/File/createTempFile/SpecialTempFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @bug 8013827 8011950 8017212 8025128
  * @summary Check whether File.createTempFile can handle special parameters
@@ -32,9 +38,12 @@ import java.io.File;
 import java.io.IOException;
 
 public class SpecialTempFile {
-
+    //
+    // If exceptionExpected == null, then any IOException thrown by
+    // File.createTempFile is ignored.
+    //
     private static void test(String name, String[] prefix, String[] suffix,
-                             boolean exceptionExpected) throws IOException
+                             Boolean exceptionExpected) throws IOException
     {
         if (prefix == null || suffix == null
             || prefix.length != suffix.length)
@@ -61,19 +70,21 @@ public class SpecialTempFile {
                     else
                         f = File.createTempFile(prefix[i], suffix[i], new File(dir));
                 } catch (IOException e) {
-                    if (exceptionExpected) {
-                        if (e.getMessage().startsWith(exceptionMsg))
-                            exceptionThrown = true;
-                        else
-                            System.out.println("Wrong error message:" +
-                                               e.getMessage());
-                    } else {
-                        throw e;
+                    if (exceptionExpected != null) {
+                        if (exceptionExpected) {
+                            if (e.getMessage().startsWith(exceptionMsg))
+                                exceptionThrown = true;
+                            else
+                                System.out.println("Wrong error message:" +
+                                                   e.getMessage());
+                        } else {
+                            throw e;
+                        }
+
+                        if (exceptionExpected && (!exceptionThrown || f != null))
+                            throw new RuntimeException("IOException expected");
                     }
                 }
-
-                if (exceptionExpected && (!exceptionThrown || f != null))
-                    throw new RuntimeException("IOException is expected");
             }
         }
     }
@@ -106,6 +117,12 @@ public class SpecialTempFile {
         // Test JDK-8013827
         String[] resvPre = { "LPT1.package.zip", "com7.4.package.zip" };
         String[] resvSuf = { ".temp", ".temp" };
-        test("ReservedName", resvPre, resvSuf, true);
+
+        System.out.println("OS name:    " + System.getProperty("os.name") + "\n" +
+                           "OS version: " + System.getProperty("os.version"));
+
+        // Here the test is for whether File.createTempFile hangs, so whether
+        // an exception is thrown is ignored: expectedException == null
+        test("ReservedName", resvPre, resvSuf, null);
     }
 }


### PR DESCRIPTION
Fix the test so it doesn't fail on Windows 11 or Server 2025 machines.

https://bugs.openjdk.org/browse/JDK-8345368
https://bugs.openjdk.org/browse/JDK-8347740

https://github.com/ibmruntimes/openj9-openjdk-jdk17/commit/0ff2c3742e