### PR TITLE
Remove --with-mixedrefs configuration option

### DIFF
--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -411,31 +411,21 @@ AC_DEFUN([OPENJ9_PLATFORM_SETUP],
   AC_ARG_WITH(noncompressedrefs, [AS_HELP_STRING([--with-noncompressedrefs],
     [build non-compressedrefs vm (large heap)])])
 
-  AC_ARG_WITH(mixedrefs, [AS_HELP_STRING([--with-mixedrefs],
-    [build mixedrefs vm (--with-mixedrefs=static or --with-mixedrefs=dynamic)])])
-
   OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU($build_cpu)
 
   # Default OPENJ9_BUILD_OS=OPENJDK_BUILD_OS, but override with OpenJ9 equivalent as appropriate
   OPENJ9_BUILD_OS="${OPENJDK_BUILD_OS}"
 
-  if test "x$with_noncompressedrefs" = xyes -o "x$OPENJDK_TARGET_CPU_BITS" = x32 -o "x$with_mixedrefs" = xno -o "x$COMPILE_TYPE" = xcross ; then
+  if test "x$with_noncompressedrefs" = xyes ; then
     OMR_MIXED_REFERENCES_MODE=off
-    if test "x$with_noncompressedrefs" = xyes -o "x$OPENJDK_TARGET_CPU_BITS" = x32 ; then
-      OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}"
-      OPENJ9_LIBS_SUBDIR=default
-    else
-      OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_cmprssptrs"
-      OPENJ9_LIBS_SUBDIR=compressedrefs
-    fi
+    OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}"
+    OPENJ9_LIBS_SUBDIR=default
+  elif test "x$with_noncompressedrefs" = xno -o "x$COMPILE_TYPE" = xcross ; then
+    OMR_MIXED_REFERENCES_MODE=off
+    OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_cmprssptrs"
+    OPENJ9_LIBS_SUBDIR=compressedrefs
   else
-    if test "x$with_mixedrefs" = x -o "x$with_mixedrefs" = xyes -o "x$with_mixedrefs" = xstatic ; then
-      OMR_MIXED_REFERENCES_MODE=static
-    elif test "x$with_mixedrefs" = xdynamic ; then
-      OMR_MIXED_REFERENCES_MODE=dynamic
-    else
-      AC_MSG_ERROR([OpenJ9 supports --with-mixedrefs=static and --with-mixedrefs=dynamic])
-    fi
+    OMR_MIXED_REFERENCES_MODE=static
     OPENJ9_BUILD_MODE_ARCH="${OPENJ9_CPU}_mxdptrs"
     OPENJ9_LIBS_SUBDIR=default
   fi


### PR DESCRIPTION
The default behavior will remain unchanged: to produce a VM which supports both compressed and non-compressed references.

Support for non-compressed references only is available, as before, by using the `--with-noncompressedrefs` configuration option.

Support for compressed references only is now available by using the configuration option `--with-noncompressedrefs=no` (instead of `--with-mixedrefs=no`).

See eclipse-openj9/openj9#18124.