### PR TITLE
Extend RestrictedSecurity constraints

### DIFF
--- a/closed/test/jdk/openj9/internal/security/TestConstraintsFailure.java
+++ b/closed/test/jdk/openj9/internal/security/TestConstraintsFailure.java
@@ -1,0 +1,174 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+
+/*
+ * @test
+ * @summary Test Restricted Security Mode Constraints
+ * @library /test/lib
+ * @run junit TestConstraintsFailure
+ */
+import org.junit.jupiter.api.Test;
+
+import java.security.AlgorithmParameterGenerator;
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Signature;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.CertPathValidator;
+import java.security.cert.CertStore;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyAgreement;
+import javax.crypto.KeyGenerator;
+import javax.crypto.Mac;
+import javax.crypto.SecretKeyFactory;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestConstraintsFailure {
+
+    private static void getInstances() throws Exception {
+        try {
+            CertificateFactory.getInstance("X.509");
+            throw new RuntimeException("A CertificateException should have been thrown");
+        } catch (CertificateException ce) {
+            // Do nothing. This is expected.
+        }
+        try {
+            CertPathValidator.getInstance("PKIX");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+        try {
+            MessageDigest.getInstance("SHA-512");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+        try {
+            KeyStore.getInstance("JKS");
+            throw new RuntimeException("A KeyStoreException should have been thrown");
+        } catch (KeyStoreException ke) {
+            // Do nothing. This is expected.
+        }
+        try {
+            Signature.getInstance("SHA256withECDSA");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+        try {
+            KeyPairGenerator.getInstance("EC");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+        try {
+            KeyAgreement.getInstance("ECDH");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+        try {
+            KeyFactory.getInstance("EC");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+        try {
+            Cipher.getInstance("RSA");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+        try {
+            KeyGenerator.getInstance("AES");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+        try {
+            AlgorithmParameterGenerator.getInstance("DiffieHellman");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+        try {
+            SecretKeyFactory.getInstance("PBEWithMD5AndDES");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+        try {
+            Mac.getInstance("HmacSHA256");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+
+        try {
+            KeyManagerFactory.getInstance("SunX509");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+        try {
+            TrustManagerFactory.getInstance("SunX509");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+        try {
+            SSLContext.getInstance("TLSv1.3");
+            throw new RuntimeException("A NoSuchAlgorithmException should have been thrown");
+        } catch (NoSuchAlgorithmException nsae) {
+            // Do nothing. This is expected.
+        }
+    }
+
+    @Test
+    public void runWithConstraints() throws Exception {
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
+                "-Dsemeru.customprofile=TestConstraints.Version",
+                "-Djava.security.properties=" + System.getProperty("test.src") + "/constraints-java.security",
+                "TestConstraintsFailure"
+        );
+        outputAnalyzer.reportDiagnosticSummary();
+        outputAnalyzer.shouldHaveExitValue(0);
+    }
+
+    public static void main(String[] args) throws Exception {
+        getInstances();
+    }
+}

--- a/closed/test/jdk/openj9/internal/security/TestConstraintsSuccess.java
+++ b/closed/test/jdk/openj9/internal/security/TestConstraintsSuccess.java
@@ -1,0 +1,91 @@
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * IBM designates this particular file as subject to the "Classpath" exception
+ * as provided by IBM in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * ===========================================================================
+ */
+
+/*
+ * @test
+ * @summary Test Restricted Security Mode Constraints
+ * @library /test/lib
+ * @run junit TestConstraintsSuccess
+ */
+import org.junit.jupiter.api.Test;
+
+import java.security.AlgorithmParameterGenerator;
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Signature;
+import java.security.cert.CertificateFactory;
+import java.security.cert.CertPathValidator;
+import java.security.cert.CertStore;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyAgreement;
+import javax.crypto.KeyGenerator;
+import javax.crypto.Mac;
+import javax.crypto.SecretKeyFactory;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestConstraintsSuccess {
+
+    private static void getInstances() throws Exception {
+        CertificateFactory.getInstance("X.509");
+        CertPathValidator.getInstance("PKIX");
+        MessageDigest.getInstance("SHA-512");
+        KeyStore.getInstance("JKS");
+        Signature.getInstance("SHA256withECDSA");
+        KeyPairGenerator.getInstance("EC");
+        KeyAgreement.getInstance("ECDH");
+        KeyFactory.getInstance("EC");
+        Cipher.getInstance("RSA");
+        KeyGenerator.getInstance("AES");
+        AlgorithmParameterGenerator.getInstance("DiffieHellman");
+        SecretKeyFactory.getInstance("PBEWithMD5AndDES");
+        Mac.getInstance("HmacSHA256");
+        KeyManagerFactory.getInstance("SunX509");
+        TrustManagerFactory.getInstance("SunX509");
+        SSLContext.getInstance("TLSv1.3");
+    }
+
+    @Test
+    public void runWithConstraints() throws Exception {
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
+                "-Dsemeru.customprofile=TestConstraints.Version",
+                "-Djava.security.properties=" + System.getProperty("test.src") + "/constraints-java.security",
+                "TestConstraintsSuccess"
+        );
+        outputAnalyzer.reportDiagnosticSummary();
+        outputAnalyzer.shouldHaveExitValue(0);
+    }
+
+    public static void main(String[] args) throws Exception {
+        getInstances();
+    }
+}

--- a/closed/test/jdk/openj9/internal/security/constraints-java.security
+++ b/closed/test/jdk/openj9/internal/security/constraints-java.security
@@ -1,0 +1,62 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# IBM designates this particular file as subject to the "Classpath" exception
+# as provided by IBM in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+RestrictedSecurity.TestConstraints.Version.desc.name = Test Base Profile
+RestrictedSecurity.TestConstraints.Version.desc.default = false
+RestrictedSecurity.TestConstraints.Version.desc.fips = false
+RestrictedSecurity.TestConstraints.Version.desc.hash = SHA-256:c961153e33a2b77a051f15ebfb6ea605395a4be82937fa7e8971b79afa4527a5
+RestrictedSecurity.TestConstraints.Version.desc.number = Certificate #XXX
+RestrictedSecurity.TestConstraints.Version.desc.policy =
+RestrictedSecurity.TestConstraints.Version.fips.mode = test
+
+RestrictedSecurity.TestConstraints.Version.jce.provider.1 = sun.security.provider.Sun [ \
+    {CertificateFactory, X.509, *, FullClassName:TestConstraintsSuccess}, \
+    {CertStore, Collection, *, FullClassName:TestConstraintsSuccess}, \
+    {Configuration, JavaLoginConfig, *, FullClassName:TestConstraintsSuccess}, \
+    {CertPathBuilder, PKIX, *, FullClassName:TestConstraintsSuccess}, \
+    {CertPathValidator, PKIX, *, FullClassName:TestConstraintsSuccess}, \
+    {SecureRandom, SHA1PRNG, *, FullClassName:TestConstraintsSuccess}, \
+    {MessageDigest, SHA, *}, \
+    {MessageDigest, SHA-256, *}, \
+    {MessageDigest, SHA-512, *, FullClassName:TestConstraintsSuccess}, \
+    {KeyStore, JKS, *, FullClassName:TestConstraintsSuccess}]
+RestrictedSecurity.TestConstraints.Version.jce.provider.2 = sun.security.ec.SunEC [ \
+    {AlgorithmParameters, EC, *, FullClassName:TestConstraintsSuccess}, \
+    {Signature, SHA256withECDSA, *, FullClassName:TestConstraintsSuccess}, \
+    {KeyPairGenerator, EC, *, FullClassName:TestConstraintsSuccess}, \
+    {KeyAgreement, ECDH, *, FullClassName:TestConstraintsSuccess}, \
+    {KeyFactory, EC, *, FullClassName:TestConstraintsSuccess}]
+RestrictedSecurity.TestConstraints.Version.jce.provider.3 = com.sun.crypto.provider.SunJCE [ \
+    {Cipher, RSA, *, FullClassName:TestConstraintsSuccess}, \
+    {KeyGenerator, AES, *, FullClassName:TestConstraintsSuccess}, \
+    {AlgorithmParameterGenerator, DiffieHellman, *, FullClassName:TestConstraintsSuccess}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, FullClassName:TestConstraintsSuccess}, \
+    {Mac, HmacSHA256, *, FullClassName:TestConstraintsSuccess}, \
+    {AlgorithmParameters, PBES2, *, FullClassName:sun.security.pkcs12.PKCS12KeyStore}, \
+    {AlgorithmParameters, PBEWithHmacSHA256AndAES_256, *, FullClassName:sun.security.pkcs12.PKCS12KeyStore}, \
+    {SecretKeyFactory, PBEWithMD5AndDES, *, FullClassName:sun.security.pkcs12.PKCS12KeyStore}, \
+    {Cipher, PBEWithHmacSHA256AndAES_256, *, FullClassName:sun.security.pkcs12.PKCS12KeyStore}, \
+    {Mac, HmacPBESHA256, *, FullClassName:sun.security.pkcs12.PKCS12KeyStore}]
+RestrictedSecurity.TestConstraints.Version.jce.provider.4 = com.sun.net.ssl.internal.ssl.Provider [ \
+    {KeyManagerFactory, SunX509, *, FullClassName:TestConstraintsSuccess}, \
+    {TrustManagerFactory, SunX509, *, FullClassName:TestConstraintsSuccess}, \
+    {SSLContext, TLSv1.3, *, FullClassName:TestConstraintsSuccess}]
+
+RestrictedSecurity.TestConstraints.Version.securerandom.algorithm = SHA1PRNG

--- a/jdk/src/share/classes/java/security/Provider.java
+++ b/jdk/src/share/classes/java/security/Provider.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2022, 2023 All Rights Reserved
+ * (c) Copyright IBM Corp. 2022, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -1136,7 +1136,7 @@ public abstract class Provider extends Properties {
             throw new IllegalArgumentException
                     ("service.getProvider() must match this Provider object");
         }
-        if (!RestrictedSecurity.isServiceAllowed(s)) {
+        if (!RestrictedSecurity.canServiceBeRegistered(s)) {
             // We're in restricted security mode which does not allow this service,
             // return without registering.
             return;


### PR DESCRIPTION
The functionality of the provider constraints in `RestrictedSecurity` profiles is extended. Instead of allowing them to be universally used, one can optionally indicate the specific module and/or class from where a particular cryptographic algorithm can be called.

Tests are, also, added to test the new functionality offered through `RestrictedSecurity` profiles.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/935

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>