### PR TITLE
Set property com.ibm.fips.mode based on active FIPS profile

### DIFF
--- a/closed/adds/jdk/src/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/adds/jdk/src/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -557,6 +557,18 @@ public final class RestrictedSecurity {
         propsMapping.put("jdk.certpath.disabledAlgorithms", restricts.jdkCertpathDisabledAlgorithms);
         propsMapping.put("jdk.security.legacyAlgorithms", restricts.jdkSecurityLegacyAlgorithms);
 
+        if (restricts.descIsFIPS) {
+            if (restricts.jdkFipsMode == null) {
+                printStackTraceAndExit(profileID + ".fips.mode property is not set in FIPS profile");
+            }
+            String fipsMode = System.getProperty("com.ibm.fips.mode");
+            if (fipsMode == null) {
+                System.setProperty("com.ibm.fips.mode", restricts.jdkFipsMode);
+            } else if (!fipsMode.equals(restricts.jdkFipsMode)) {
+                printStackTraceAndExit("Property com.ibm.fips.mode is incompatible with semeru.customprofile and semeru.fips properties");
+            }
+        }
+
         if (userEnabledFIPS && !allowSetProperties) {
             // Add all properties that cannot be modified.
             unmodifiableProperties.addAll(propsMapping.keySet());


### PR DESCRIPTION
When loading a `RestrictedSecurity` `FIPS` profile, we need to set the system property value `com.ibm.fips.mode` to the value contained within the active profile.

A `RestrictedSecurity` profile, however, doesn't have to be a `FIPS` profile, in which case a `FIPS mode` property is not required and the corresponding system property should not be set.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/957 and https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/756


Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>