### PR TITLE
Support native PBKDF2

### DIFF
--- a/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
+++ b/closed/adds/jdk/src/share/classes/jdk/crypto/jniprovider/NativeCrypto.java
@@ -37,12 +37,14 @@ import sun.security.action.GetPropertyAction;
 public class NativeCrypto {
 
     /* Define constants for the native digest algorithm indices. */
-    public static final int SHA1_160 = 0;
-    public static final int SHA2_224 = 1;
-    public static final int SHA2_256 = 2;
-    public static final int SHA5_384 = 3;
-    public static final int SHA5_512 = 4;
-    public static final int MD5 = 5;
+    public static final int MD5 = 0;
+    public static final int SHA1_160 = 1;
+    public static final int SHA2_224 = 2;
+    public static final int SHA2_256 = 3;
+    public static final int SHA5_384 = 4;
+    public static final int SHA5_512 = 5;
+    public static final int SHA5_512_224 = 6;
+    public static final int SHA5_512_256 = 7;
 
     /* Define constants for the EC field types. */
     public static final int ECField_Fp = 0;
@@ -489,4 +491,11 @@ public class NativeCrypto {
                                         int digestLen,
                                         byte[] signature,
                                         int sigLen);
+
+    /* Password based key derivation functions (PBKDF). */
+    public final native byte[] PBKDF2Derive(byte[] password,
+                                            byte[] salt,
+                                            int iterations,
+                                            int keyLength,
+                                            int hashAlgorithm);
 }

--- a/closed/make/mapfiles/libjncrypto/mapfile-vers
+++ b/closed/make/mapfiles/libjncrypto/mapfile-vers
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2018, 2024 All Rights Reserved
+# (c) Copyright IBM Corp. 2018, 2025 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -50,6 +50,7 @@ SUNWprivate_1.1 {
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECDeriveKey;
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECNativeGF2m;
 		Java_jdk_crypto_jniprovider_NativeCrypto_PBEDerive;
+		Java_jdk_crypto_jniprovider_NativeCrypto_PBKDF2Derive;
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECDSASign;
 		Java_jdk_crypto_jniprovider_NativeCrypto_ECDSAVerify;
 		Java_jdk_crypto_jniprovider_NativeCrypto_isOpenSSLFIPS;


### PR DESCRIPTION
A native implementation of the following PBKDF2
related crypto services are supported to optimize
the PBKDF2 key derivations performance.

- PBKDF2WithHmacSHA1
- PBKDF2WithHmacSHA224
- PBKDF2WithHmacSHA256
- PBKDF2WithHmacSHA384
- PBKDF2WithHmacSHA512
- PBKDF2WithHmacSHA512/224
- PBKDF2WithHmacSHA512/256

A new JVM option (jdk.nativePBKDF2) is provided to enable the use of the native PBKDF2 implementation, which is disabled by default.