### PR TITLE
Use proper library path based on architecture

### DIFF
--- a/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto.c
+++ b/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider/NativeCrypto.c
@@ -646,7 +646,7 @@ find_crypto_library(jboolean traceEnabled, const char *chomepath)
 #if defined(_WIN32)
         static const char pathSuffix[] = "\\bin\\";
 #else /* defined(_WIN32) */
-        static const char pathSuffix[] = "/lib/";
+        static const char pathSuffix[] = "/lib" OPENJDK_TARGET_CPU_LIBDIR "/";
 #endif /* defined(_WIN32) */
 
         size_t path_len = strlen(chomepath) + sizeof(pathSuffix) - 1;

--- a/jdk/make/lib/SecurityLibraries.gmk
+++ b/jdk/make/lib/SecurityLibraries.gmk
@@ -319,6 +319,7 @@ ifeq ($(WITH_OPENSSL), yes)
         LANG := C, \
         OPTIMIZATION := LOW, \
         CFLAGS := $(CFLAGS_JDKLIB) \
+            -DOPENJDK_TARGET_CPU_LIBDIR='"$(OPENJDK_TARGET_CPU_LIBDIR)"' \
             -I$(SRC_ROOT)/closed/adds/jdk/src/share/native/jdk/crypto/jniprovider \
             -c $(OPENSSL_CFLAGS), \
         MAPFILE := $(SRC_ROOT)/closed/make/mapfiles/libjncrypto/mapfile-vers, \


### PR DESCRIPTION
In Java8 there is another level of directories under the `lib` directory pertaining to the specific architecture for which the JDK is built.

To address that difference, separate specification of path per architecture is required.

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>