### PR TITLE
Update the RestrictedSecurity constraints tests

### DIFF
--- a/closed/test/jdk/openj9/internal/security/TestConstraintsFailure.java
+++ b/closed/test/jdk/openj9/internal/security/TestConstraintsFailure.java
@@ -25,10 +25,10 @@
 /*
  * @test
  * @summary Test Restricted Security Mode Constraints
- * @library /test/lib
+ * @library /jdk/test/lib/testlibrary
  * @run junit TestConstraintsFailure
  */
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.security.AlgorithmParameterGenerator;
 import java.security.KeyFactory;
@@ -52,8 +52,8 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
+import jdk.testlibrary.OutputAnalyzer;
+import jdk.testlibrary.ProcessTools;
 
 public class TestConstraintsFailure {
 
@@ -158,8 +158,9 @@ public class TestConstraintsFailure {
     }
 
     @Test
-    public void runWithConstraints() throws Exception {
-        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
+    public void runWithConstraints() throws Throwable {
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(
+                "-cp", System.getProperty("test.classes"),
                 "-Dsemeru.customprofile=TestConstraints.Version",
                 "-Djava.security.properties=" + System.getProperty("test.src") + "/constraints-java.security",
                 "TestConstraintsFailure"

--- a/closed/test/jdk/openj9/internal/security/TestConstraintsSuccess.java
+++ b/closed/test/jdk/openj9/internal/security/TestConstraintsSuccess.java
@@ -25,10 +25,10 @@
 /*
  * @test
  * @summary Test Restricted Security Mode Constraints
- * @library /test/lib
+ * @library /jdk/test/lib/testlibrary
  * @run junit TestConstraintsSuccess
  */
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import java.security.AlgorithmParameterGenerator;
 import java.security.KeyFactory;
@@ -50,8 +50,8 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
+import jdk.testlibrary.OutputAnalyzer;
+import jdk.testlibrary.ProcessTools;
 
 public class TestConstraintsSuccess {
 
@@ -85,8 +85,9 @@ public class TestConstraintsSuccess {
     }
 
     @Test
-    public void runWithConstraints() throws Exception {
-        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJava(
+    public void runWithConstraints() throws Throwable {
+        OutputAnalyzer outputAnalyzer = ProcessTools.executeTestJvm(
+                "-cp", System.getProperty("test.classes"),
                 "-Dsemeru.customprofile=TestConstraints.Version",
                 "-Djava.security.properties=" + System.getProperty("test.src") + "/constraints-java.security",
                 "TestConstraintsSuccess"


### PR DESCRIPTION
This commit downgrades the test framework from JUnit 5 to JUnit 4, as OpenJDK 8 does not support JUnit 5 for RestrictedSecurity constraint tests.

Issue https://github.com/eclipse-openj9/openj9/issues/21374