### PR TITLE
Avoid checking RestrictedSecurity profile hash during jar verification

### DIFF
--- a/jdk/src/share/classes/sun/security/jca/Providers.java
+++ b/jdk/src/share/classes/sun/security/jca/Providers.java
@@ -25,7 +25,7 @@
 
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2024, 2025 All Rights Reserved
  * ===========================================================================
  */
 
@@ -96,7 +96,6 @@ public class Providers {
         // triggers a getInstance() call (although that should not happen)
         providerList = ProviderList.EMPTY;
         providerList = ProviderList.fromSecurityProperties();
-        RestrictedSecurity.checkHashValues();
     }
 
     // Return to Sun provider or its backup.


### PR DESCRIPTION
If the process of verifying a jar is started before the `RestrictedSecurity` profile is loaded, the hash calculation is triggered as part of it leading to a nested jar verification and a subsequent error.

To avoid that, the hash calulation of a profile is skipped if triggered by a jar verification process and is performed later in the loading process.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/969

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>