### PR TITLE
Enable native PBKDF2 as default

### DIFF
--- a/jdk/src/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
+++ b/jdk/src/share/classes/com/sun/crypto/provider/PBKDF2KeyImpl.java
@@ -64,8 +64,7 @@ final class PBKDF2KeyImpl implements javax.crypto.interfaces.PBEKey {
 
     private static final long serialVersionUID = -2234868909660948157L;
 
-    private static final boolean useNativePBKDF2 = Boolean.parseBoolean(
-            GetPropertyAction.privilegedGetProperty("jdk.nativePBKDF2"));
+    private static final boolean useNativePBKDF2 = NativeCrypto.isAlgorithmEnabled("jdk.nativePBKDF2", "PBKDF2");
     private static NativeCrypto nativeCrypto;
     private static final boolean nativeCryptTrace = NativeCrypto.isTraceEnabled();
 


### PR DESCRIPTION
Switch the default implementation of PBKDF2 related crypto services from java to native.

Backport from: Backport from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1015