### PR TITLE
Remove obsolete GetSourceTips definition

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -32,15 +32,6 @@ clean-j9vm :
 	test-image-openj9 \
 	#
 
-# Override definition from MakeBase.gmk for OpenJ9.
-define GetSourceTips
-	$(PRINTF) "%s:%s\n" \
-		OpenJDK "$(shell $(GIT) -C $(TOPDIR) rev-parse --short HEAD)" \
-		OpenJ9  "$(shell $(GIT) -C $(OPENJ9_TOPDIR) rev-parse --short HEAD)" \
-		OMR     "$(shell $(GIT) -C $(OPENJ9OMR_TOPDIR) rev-parse --short HEAD)" \
-		> $@
-endef
-
 jdk : build-j9vm
 
 build-j9vm : start-make


### PR DESCRIPTION
SourceRevision.gmk finds all the git SHAs.