### PR TITLE
Backport fixes to compile with gcc 14

### DIFF
--- a/jdk/src/share/bin/splashscreen_stubs.c
+++ b/jdk/src/share/bin/splashscreen_stubs.c
@@ -61,11 +61,11 @@ typedef char* (*SplashGetScaledImageName_t)(const char* fileName,
 #define INVOKEV(name) _INVOKE(name, ,;)
 
 int     DoSplashLoadMemory(void* pdata, int size) {
-    INVOKE(SplashLoadMemory, NULL)(pdata, size);
+    INVOKE(SplashLoadMemory, 0)(pdata, size);
 }
 
 int     DoSplashLoadFile(const char* filename) {
-    INVOKE(SplashLoadFile, NULL)(filename);
+    INVOKE(SplashLoadFile, 0)(filename);
 }
 
 void    DoSplashInit(void) {

--- a/jdk/src/share/native/sun/awt/image/jpeg/imageioJPEG.c
+++ b/jdk/src/share/native/sun/awt/image/jpeg/imageioJPEG.c
@@ -2690,7 +2690,7 @@ Java_com_sun_imageio_plugins_jpeg_JPEGImageWriter_writeTables
     RELEASE_ARRAYS(env, data, NULL);
 }
 
-static void freeArray(void** arr, jint size) {
+static void freeArray(UINT8** arr, jint size) {
     int i;
     if (arr != NULL) {
         for (i = 0; i < size; i++) {


### PR DESCRIPTION
From jdk11:
* [8074840: Resolve disabled warnings for libjli and libjli_static](https://github.com/ibmruntimes/openj9-openjdk-jdk11/commit/8198fd44c5a8f3d94a8125f2a9af093250805cbd)
* [8162545: Mac build failure](https://github.com/ibmruntimes/openj9-openjdk-jdk11/commit/3e543105126d1b468afa4d285a2bf72bc33fc556)