### PR TITLE
Update the RestrictedSecurity property test case

### DIFF
--- a/closed/test/jdk/openj9/internal/security/TestProperties.java
+++ b/closed/test/jdk/openj9/internal/security/TestProperties.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * (c) Copyright IBM Corp. 2024, 2025 All Rights Reserved
  * ===========================================================================
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,7 +171,7 @@ public class TestProperties {
             // 25 - Test constraint - constraint changed 3.
             {"Test-Profile-ConstraintChanged_3.Base",
                 System.getProperty("test.src") + "/property-java.security",
-                "You cannot add or remove to provider (.*?). This is the base profile.", 1}
+                "Constraints of provider not previously specified cannot be modified", 1}
         });
     }
 


### PR DESCRIPTION
This is a back port PR from https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1075

Update the RestrictedSecurity property test case to match the new expected error message.

Before:

```
printStackTraceAndExit("You cannot add or remove to provider "
        + m.group(1) + ". This is the base profile.");

```
After:

```
printStackTraceAndExit("Constraints of provider not previously specified "
        + "cannot be modified: " + providerName);
```