### PR TITLE
Check if service is allowed in RestrictedSecurity mode

### DIFF
--- a/jdk/src/share/classes/sun/security/jca/ProviderList.java
+++ b/jdk/src/share/classes/sun/security/jca/ProviderList.java
@@ -357,8 +357,7 @@ public final class ProviderList {
         for (int i = 0; i < configs.length; i++) {
             Provider p = getProvider(i);
             Service s = p.getService(type, name);
-            if ((s != null) && RestrictedSecurity.isServiceAllowed(s)) {
-                // We found a service that is allowed in restricted security mode.
+            if (s != null) {
                 return s;
             }
         }
@@ -463,14 +462,14 @@ public final class ProviderList {
                 if (type != null) {
                     // simple lookup
                     Service s = p.getService(type, algorithm);
-                    if ((s != null) && RestrictedSecurity.isServiceAllowed(s)) {
+                    if (s != null) {
                         addService(s);
                     }
                 } else {
                     // parallel lookup
                     for (ServiceId id : ids) {
                         Service s = p.getService(id.type, id.algorithm);
-                        if ((s != null) && RestrictedSecurity.isServiceAllowed(s)) {
+                        if (s != null) {
                             addService(s);
                         }
                     }


### PR DESCRIPTION
Checks are relocated to verify that a service is allowed, when said service is directly requested from a provider.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1078

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>