### PR TITLE
Fix for LockedMonitors

### DIFF
--- a/jdk/test/java/lang/management/ThreadMXBean/LockingThread.java
+++ b/jdk/test/java/lang/management/ThreadMXBean/LockingThread.java
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2025, 2025 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * @bug     5086470  6358247
@@ -182,7 +187,7 @@ public class LockingThread extends Thread {
             throw new RuntimeException("LockName: " + lockName +
                 " class name not matched. Expected: " + waitingLockName);
         }
-        int i = Integer.parseInt(s[1], 16);
+        int i = Integer.parseUnsignedInt(s[1], 16);
         if (hcode != i) {
             throw new RuntimeException("LockName: " + lockName +
                 " IdentityHashCode not matched. Expected: " + hcode);


### PR DESCRIPTION
The problem is that OpenJ9 supports negative identity hash codes by default. The negative integer is convert via `Integer.toHexString(identityHashCode)` to an unsigned hex value, however `Integer.parseInt(s[1], 16);` doesn't handle converting that back to a negative integer value. Technically it's bug in the test case. Hotspot doesn't use negative values for the identity hash so the test works. OpenJ9 supports a compatibility option https://www.eclipse.org/openj9/docs/xxpositiveidentityhash/ in order to only use positive values.

A fix for the test can be made to the OpenJDK project, or the test excluded. The fix is to use `parseUnsignedInt()`.

Backport of : https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1080

Signed-off-by: Darshan N [Darshan.N3@ibm.com](mailto:Darshan.N3@ibm.com)