### PR TITLE
Add OPENJDK_VERSION_STRING to openj9_version_info.h

### DIFF
--- a/closed/openj9_version_info.h.in
+++ b/closed/openj9_version_info.h.in
@@ -39,6 +39,7 @@
 #define OPENJ9_TAG                "@OPENJ9_TAG@"
 #define OPENJDK_SHA               "@OPENJDK_SHA@"
 #define OPENJDK_TAG               "@OPENJDK_TAG@"
+#define OPENJDK_VERSION_STRING    "@JRE_RELEASE_VERSION@"
 #define VENDOR_SHA                "@VENDOR_SHA@"
 
 #endif /* OPENJ9_VERSION_INFO_H */


### PR DESCRIPTION
Backport https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1095

OPENJDK_VERSION_STRING is (for example) 1.8.0_472-b08