### PR TITLE
Run java/rmi/reliability/benchmark/bench/serial/Main with -Xmso512k

### DIFF
--- a/jdk/test/java/rmi/reliability/benchmark/bench/serial/Main.java
+++ b/jdk/test/java/rmi/reliability/benchmark/bench/serial/Main.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2026, 2026 All Rights Reserved
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @summary The Serialization benchmark test. This java class is used to run the
  *          test under JTREG.
@@ -43,7 +49,7 @@
  * @build bench.serial.ReplaceTrees bench.serial.ShortArrays
  * @build bench.serial.Shorts bench.serial.SmallObjTrees
  * @build bench.serial.StreamBuffer bench.serial.Strings
- * @run main/othervm/timeout=1800 bench.serial.Main -c jtreg-config
+ * @run main/othervm/timeout=1800 -Xmso512k bench.serial.Main -c jtreg-config
  * @author Mike Warres, Nigel Daley
  */
 


### PR DESCRIPTION
Increase the native stack size for x86 mac, and some other platforms. Some platforms already use 512k as the default. No platform has a default which is bigger than 512k atm.

Related to https://github.com/eclipse-openj9/openj9/issues/23666#issuecomment-4409738921

Closes https://github.com/eclipse-openj9/openj9/issues/23666

Passing grinder
https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/59944/