### PR TITLE
Disable OpenJDK MethodHandles on 32-bit platforms

### DIFF
--- a/jdk/make/closed/autoconf/custom-hook.m4
+++ b/jdk/make/closed/autoconf/custom-hook.m4
@@ -344,7 +344,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_OPENJDK_METHODHANDLES],
 [
   AC_MSG_CHECKING([for openjdk-methodhandles])
   AC_ARG_ENABLE([openjdk-methodhandles], [AS_HELP_STRING([--enable-openjdk-methodhandles],
-      [enable support for OpenJDK MethodHandles @<:@enabled@:>@])])
+      [enable support for OpenJDK MethodHandles @<:@enabled, except on 32-bit platforms@:>@])])
   OPENJ9_ENABLE_OPENJDK_METHODHANDLES=true
 
   if test "x$enable_openjdk_methodhandles" = xyes ; then
@@ -353,7 +353,12 @@ AC_DEFUN([OPENJ9_CONFIGURE_OPENJDK_METHODHANDLES],
     AC_MSG_RESULT([no (explicitly disabled)])
     OPENJ9_ENABLE_OPENJDK_METHODHANDLES=false
   elif test "x$enable_openjdk_methodhandles" = x ; then
-    AC_MSG_RESULT([yes (default)])
+    if test "x$OPENJDK_TARGET_CPU_BITS" = x32 ; then
+      AC_MSG_RESULT([no (default for $OPENJ9_PLATFORM_CODE)])
+      OPENJ9_ENABLE_OPENJDK_METHODHANDLES=false
+    else
+      AC_MSG_RESULT([yes (default)])
+    fi
   else
     AC_MSG_ERROR([--enable-openjdk-methodhandles accepts no argument])
   fi


### PR DESCRIPTION
OpenJDK MethodHandles are enabled for JDK8 builds, but 32-bit platforms
has a blocker: https://github.com/eclipse-openj9/openj9/issues/23934.

Set `OPENJ9_ENABLE_OPENJDK_METHODHANDLES` to `false` for 32-bit platforms
while keeping it enabled for other platforms until the blocker is
resolved.




---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).
